### PR TITLE
feat: expose resolvers

### DIFF
--- a/packages/csm/src/index.ts
+++ b/packages/csm/src/index.ts
@@ -1,2 +1,4 @@
 export * from './legacy'
+export * from './resolveKeyedSourcePath'
+export * from './resolveSanityNode'
 export * from './wrap'

--- a/packages/csm/src/legacy/index.ts
+++ b/packages/csm/src/legacy/index.ts
@@ -1,5 +1,5 @@
 export { encodeJsonPathToUriComponent } from './editIntent'
-export { parseJsonPath } from './jsonpath'
+export { compileJsonPath, parseJsonPath } from './jsonpath'
 export * from './mapToEditLinks'
 export { resolveMapping } from './resolveMapping'
 export * from './transcode'

--- a/packages/csm/src/resolveKeyedSourcePath.ts
+++ b/packages/csm/src/resolveKeyedSourcePath.ts
@@ -1,0 +1,22 @@
+import { compileJsonPath, parseJsonPath, PathSegment } from './legacy'
+
+export function resolvedKeyedSourcePath(options: {
+  keyedResultPath: PathSegment[]
+  pathSuffix?: string
+  sourceBasePath: string
+}): PathSegment[] {
+  const { keyedResultPath, pathSuffix, sourceBasePath } = options
+
+  const inferredResultPath =
+    pathSuffix === undefined ? [] : parseJsonPath(pathSuffix)
+
+  const inferredPath = keyedResultPath.slice(
+    keyedResultPath.length - inferredResultPath.length,
+  )
+
+  const inferredPathSuffix = inferredPath.length
+    ? compileJsonPath(inferredPath, { keyArraySelectors: true }).slice(1)
+    : ''
+
+  return parseJsonPath(sourceBasePath + inferredPathSuffix)
+}

--- a/packages/csm/src/resolveSanityNode.ts
+++ b/packages/csm/src/resolveSanityNode.ts
@@ -1,14 +1,14 @@
 import { ContentSourceMap } from '@sanity/client'
 import { SanityNode } from 'visual-editing-helpers'
 
-import { Logger, PathSegment } from '../legacy'
-import { compileJsonPath, parseJsonPath } from '../legacy/jsonpath'
-import { resolveMapping } from '../legacy/resolveMapping'
-import { simplifyPath } from '../legacy/simplifyPath'
-import { getPublishedId } from './getPublishedId'
-import { SanityNodeContext } from './types'
+import { Logger, PathSegment } from './legacy'
+import { resolveMapping } from './legacy/resolveMapping'
+import { simplifyPath } from './legacy/simplifyPath'
+import { resolvedKeyedSourcePath } from './resolveKeyedSourcePath'
+import { getPublishedId } from './wrap/getPublishedId'
+import { SanityNodeContext } from './wrap/types'
 
-export function getValueSource(
+export function resolveSanityNode(
   context: SanityNodeContext,
   csm: ContentSourceMap,
   resultPath: PathSegment[],
@@ -34,20 +34,17 @@ export function getValueSource(
   const sourceBasePath = csm.paths[mapping.source.path]
 
   if (sourceDoc && sourceBasePath) {
-    const inferredResultPath = pathSuffix ? parseJsonPath(pathSuffix) : []
-    const inferredPath = keyedResultPath.slice(
-      keyedResultPath.length - inferredResultPath.length,
-    )
-    const inferredPathSuffix = inferredPath.length
-      ? compileJsonPath(inferredPath, { keyArraySelectors: true }).slice(1)
-      : ''
-    const sourcePath = parseJsonPath(sourceBasePath + inferredPathSuffix)
-
     return {
       baseUrl: context.baseUrl,
       dataset: context.dataset,
       id: getPublishedId(sourceDoc._id),
-      path: simplifyPath(sourcePath),
+      path: simplifyPath(
+        resolvedKeyedSourcePath({
+          keyedResultPath,
+          pathSuffix,
+          sourceBasePath,
+        }),
+      ),
       projectId: context.projectId,
       tool: context.tool,
       type: sourceDoc._type,

--- a/packages/csm/src/wrap/wrapData.ts
+++ b/packages/csm/src/wrap/wrapData.ts
@@ -5,8 +5,8 @@ import { ContentSourceMap } from '@sanity/client'
 import { Logger, PathSegment } from '../legacy'
 import { isArray, isRecord } from '../legacy/helpers'
 import { simplifyPath } from '../legacy/simplifyPath'
+import { resolveSanityNode } from '../resolveSanityNode'
 import { SANITY_KEYS } from './constants'
-import { getValueSource } from './getValueSource'
 import { SanityKey, SanityNodeContext, WrappedValue } from './types'
 
 /** @public */
@@ -67,7 +67,13 @@ export function wrapData<T>(
     $$type$$: 'sanity',
     path: simplifyPath(resultPath) || undefined,
     source: sourceMap
-      ? getValueSource(context, sourceMap, resultPath, keyedResultPath, logger)
+      ? resolveSanityNode(
+          context,
+          sourceMap,
+          resultPath,
+          keyedResultPath,
+          logger,
+        )
       : undefined,
     value,
   } as unknown as WrappedValue<T>


### PR DESCRIPTION
- exposes `resolveSanityNode` which is used by `wrapData`
- exposes `resolveKeyedSourcePath` which is used by `resolveSanityNode`