### PR TITLE
Fix QueryOptions typing for Next.js

### DIFF
--- a/packages/react-loader/src/index.ts
+++ b/packages/react-loader/src/index.ts
@@ -53,7 +53,7 @@ export interface QueryStore {
   loadQuery: <QueryResponseResult>(
     query: string,
     params?: QueryParams,
-    options?: { perspective?: ClientPerspective },
+    options?: QueryOptions,
   ) => Promise<{
     data: QueryResponseResult
     sourceMap?: ContentSourceMap


### PR DESCRIPTION
The `QueryOptions` type isn't being used for the `options` field of the `loadQuery` type in `src/index.ts`, despite it being used for that in `rsc/types.ts`. This is preventing type-safety when providing `Next.js` tags for revalidating requests in the framework. This PR simply updates the type to match (though I'm not sure if the return type should be updated too).

```typescript
// src/rsc/index.react-server.ts

export interface QueryStore {
  loadQuery: <QueryResponseResult>(
    query: string,
    params?: QueryParams,
    options?: QueryOptions,
  ) => Promise<QueryResponseInitial<QueryResponseResult>>
  setServerClient: ReturnType<typeof createCoreQueryStore>['setServerClient']
  useQuery: UseQueryHook
  useLiveMode: UseLiveModeHook
}
```

```typescript
// src/index.ts

export interface QueryStore {
  loadQuery: <QueryResponseResult>(
    query: string,
    params?: QueryParams,
    options?: { perspective?: ClientPerspective },
  ) => Promise<{
    data: QueryResponseResult
    sourceMap?: ContentSourceMap
    perspective?: ClientPerspective
  }>
  setServerClient: ReturnType<typeof createCoreQueryStore>['setServerClient']
  useQuery: UseQueryHook
  useLiveMode: UseLiveModeHook
}
```

Not sure if this is the right way to go about this, but just trying to bring it to attention.
