### PR TITLE
fix(presentation): preserve current document on initial navigation

### DIFF
--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -238,10 +238,11 @@ export default function PresentationTool(props: {
           })
         } else if (type === 'overlay/navigate') {
           if (previewRef.current !== data.url) {
+            const isInitialNavigation = previewRef.current === undefined;
             previewRef.current = data.url
             setParams({
-              id: undefined,
-              type: undefined,
+              id: isInitialNavigation ? params.id : undefined,
+              type: isInitialNavigation ? params.type : undefined,
               preview: data.url,
             })
           }

--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -238,13 +238,14 @@ export default function PresentationTool(props: {
           })
         } else if (type === 'overlay/navigate') {
           if (previewRef.current !== data.url) {
-            const isInitialNavigation = previewRef.current === undefined;
+            const isInitialNavigation = previewRef.current === undefined
+
             previewRef.current = data.url
-            setParams({
-              id: isInitialNavigation ? params.id : undefined,
-              type: isInitialNavigation ? params.type : undefined,
-              preview: data.url,
-            })
+            setParams(
+              isInitialNavigation
+                ? { preview: data.url }
+                : { id: undefined, type: undefined, preview: data.url },
+            )
           }
         } else if (type === 'overlay/toggle') {
           setOverlayEnabled(data.enabled)


### PR DESCRIPTION
The `overlay/navigate` event triggered after initial load was causing a reset of the open document state. Added a check so that `id` and `type` params are preserved on the first navigation.

Fixes ECO-290.