### PR TITLE
fix(overlays): only render overlays in iframe if channel is connected

### DIFF
--- a/apps/nuxt/components/ElementOverlay.vue
+++ b/apps/nuxt/components/ElementOverlay.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script lang="ts" setup>
-import { OverlayRect } from '@sanity/overlays'
+import type { OverlayRect } from '@sanity/overlays'
 
 const emit = defineEmits<{
   (e: 'open'): void

--- a/packages/overlays/src/ui/Overlays.tsx
+++ b/packages/overlays/src/ui/Overlays.tsx
@@ -74,11 +74,6 @@ export const Overlays: FunctionComponent<{
   const [rootElement, setRootElement] = useState<HTMLElement | null>(null)
   const [overlayEnabled, setOverlayEnabled] = useState(true)
 
-  const elementsToRender = useMemo(
-    () => elements.filter((e) => e.activated || e.focused),
-    [elements],
-  )
-
   const channelEventHandler = useCallback<
     ChannelEventHandler<VisualEditingMsg>
   >(
@@ -106,7 +101,10 @@ export const Overlays: FunctionComponent<{
     return url.origin
   }, [allowStudioOrigin])
 
-  const channel = useChannel<VisualEditingMsg>(channelEventHandler, allowOrigin)
+  const { channel, status } = useChannel<VisualEditingMsg>(
+    channelEventHandler,
+    allowOrigin,
+  )
 
   const overlayEventHandler: OverlayEventHandler = useCallback(
     (message) => {
@@ -220,6 +218,13 @@ export const Overlays: FunctionComponent<{
 
     return
   }, [overlayEnabled])
+
+  const elementsToRender = useMemo(() => {
+    if (!channel || (channel.inFrame && status !== 'connected')) {
+      return []
+    }
+    return elements.filter((e) => e.activated || e.focused)
+  }, [channel, elements, status])
 
   return (
     <ThemeProvider theme={studioTheme} tone="transparent">

--- a/packages/overlays/src/ui/useChannel.tsx
+++ b/packages/overlays/src/ui/useChannel.tsx
@@ -2,9 +2,10 @@ import {
   ChannelEventHandler,
   ChannelMsg,
   ChannelReturns,
+  ConnectionStatus,
   createChannel,
 } from 'channels'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 /**
  * Hook for maintaining a channel between overlays and the presentation tool
@@ -13,8 +14,12 @@ import { useEffect, useRef } from 'react'
 export function useChannel<T extends ChannelMsg>(
   handler: ChannelEventHandler<T>,
   targetOrigin: string,
-): ChannelReturns<T> | undefined {
+): {
+  channel: ChannelReturns<T> | undefined
+  status: ConnectionStatus | undefined
+} {
   const channelRef = useRef<ChannelReturns<T>>()
+  const [status, setStatus] = useState<ConnectionStatus>()
 
   useEffect(() => {
     const channel = createChannel<T>({
@@ -27,6 +32,9 @@ export function useChannel<T extends ChannelMsg>(
         },
       ],
       handler,
+      onStatusUpdate(status) {
+        setStatus(status)
+      },
     })
     channelRef.current = channel
     return () => {
@@ -35,5 +43,8 @@ export function useChannel<T extends ChannelMsg>(
     }
   }, [handler, targetOrigin])
 
-  return channelRef.current
+  return {
+    channel: channelRef.current,
+    status,
+  }
 }


### PR DESCRIPTION
This solution means that overlay elements will only render if either:

- The app is not in an iframe.
- The app is in an iframe the overlays channel connection status is `connected`.

Fixes ECO-289.