### PR TITLE
fix(overlays): use getComputedStyle over computedStyleMap

### DIFF
--- a/packages/overlays/src/util/findNonInlineElement.ts
+++ b/packages/overlays/src/util/findNonInlineElement.ts
@@ -1,5 +1,5 @@
 export function findNonInlineElement(element: HTMLElement): HTMLElement | null {
-  const display = element.computedStyleMap().get('display')?.toString()
+  const { display } = window.getComputedStyle(element)
 
   if (display !== 'inline') return element
 


### PR DESCRIPTION
Replaces the use of the experimental `computedStyleMap` with `window.getComputedStyle` to get an element's `display` property. The former method is not supported by Firefox.