### PR TITLE
feat: add new `same-origin` option

### DIFF
--- a/apps/nuxt/pages/preview.vue
+++ b/apps/nuxt/pages/preview.vue
@@ -39,5 +39,13 @@
 </template>
 
 <script setup lang="ts">
+import { type DisableOverlays, enableOverlays } from '@sanity/overlays'
+
+let disable: DisableOverlays
+onMounted(() => {
+  disable = enableOverlays({ allowStudioOrigin: 'same-origin' })
+})
+onUnmounted(() => disable())
+
 const route = useRoute()
 </script>

--- a/packages/channels/package.json
+++ b/packages/channels/package.json
@@ -15,7 +15,8 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "test": "vitest --pass-with-no-tests"
+    "test": "vitest --pass-with-no-tests",
+    "typecheck": "vitest typecheck --pass-with-no-tests --run"
   },
   "prettier": {
     "plugins": [
@@ -83,7 +84,8 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "vitest": "^0.34.6"
   },
   "engines": {
     "node": ">=18"

--- a/packages/channels/tsconfig.json
+++ b/packages/channels/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "declarationDir": "./dist/dts",
     "outDir": "./dist/dts",
     "incremental": true,

--- a/packages/core-loader/package.json
+++ b/packages/core-loader/package.json
@@ -59,7 +59,8 @@
     "build": "pkg build --strict && pkg --strict",
     "lint": "eslint .",
     "prepublishOnly": "pnpm build",
-    "test": "tsc --noEmit",
+    "test": "vitest --pass-with-no-tests",
+    "typecheck": "vitest typecheck --pass-with-no-tests --run",
     "watch": "pkg watch --strict"
   },
   "browserslist": [
@@ -135,8 +136,10 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
+    "happy-dom": "^12.10.3",
     "nanostores": "0.9.5",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "vitest": "^0.34.6"
   },
   "peerDependencies": {
     "@sanity/client": "^6.9.1"

--- a/packages/core-loader/src/live-mode/enableLiveMode.ts
+++ b/packages/core-loader/src/live-mode/enableLiveMode.ts
@@ -15,6 +15,7 @@ import { atom, MapStore } from 'nanostores'
 
 import { isStegaClient } from '../isStegaClient'
 import { EnableLiveModeOptions, QueryStoreState, SetFetcher } from '../types'
+import { parseAllowStudioOrigin } from './parseAllowStudioOrigin'
 
 /** @internal */
 export interface LazyEnableLiveModeOptions extends EnableLiveModeOptions {
@@ -25,7 +26,7 @@ export interface LazyEnableLiveModeOptions extends EnableLiveModeOptions {
 export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
   const {
     client,
-    allowStudioOrigin = '/',
+    allowStudioOrigin = 'same-origin',
     setFetcher,
     onConnect,
     onDisconnect,
@@ -55,7 +56,7 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
     }
   >()
 
-  const targetOrigin = new URL(allowStudioOrigin, location.origin).origin
+  const targetOrigin = parseAllowStudioOrigin(allowStudioOrigin)
   const channel = createChannel<VisualEditingMsg>({
     id: 'loaders' satisfies VisualEditingConnectionIds,
     onStatusUpdate(status) {

--- a/packages/core-loader/src/live-mode/parseAllowStudioOrigin.ts
+++ b/packages/core-loader/src/live-mode/parseAllowStudioOrigin.ts
@@ -1,0 +1,9 @@
+import { EnableLiveModeOptions } from '../types'
+
+export function parseAllowStudioOrigin(
+  unsafeAllowStudioOrigin: EnableLiveModeOptions['allowStudioOrigin'],
+): string {
+  return unsafeAllowStudioOrigin === 'same-origin'
+    ? location.origin
+    : new URL(unsafeAllowStudioOrigin, location.origin).origin
+}

--- a/packages/core-loader/src/types.ts
+++ b/packages/core-loader/src/types.ts
@@ -35,10 +35,16 @@ export interface EnableLiveModeOptions {
   /**
    * The origin that are allowed to connect to the loader.
    * If left unspecified it will default to the current origin, and the Studio will have to be hosted by the same origin.
-   * @example `https://my.sanity.studio`
-   * @defaultValue `location.origin`
+   * @example 'https://my.sanity.studio'
+   * @example location.origin
+   * @example 'same-origin'
+   * @defaultValue 'same-origin'
    */
-  allowStudioOrigin: string
+  allowStudioOrigin:
+    | 'same-origin'
+    | `https://${string}`
+    | `http://${string}`
+    | string
   /**
    * You may use any client that is an `instanceof SanityClient` or `instanceof SanityStegaClient`.
    * Required when `ssr: true`, optional otherwise.

--- a/packages/core-loader/test/parseAllowStudioOrigin.test.ts
+++ b/packages/core-loader/test/parseAllowStudioOrigin.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest'
+
+import { parseAllowStudioOrigin } from '../src/live-mode/parseAllowStudioOrigin'
+
+describe('allowStudioOrigin handling', () => {
+  test('same-origin', () => {
+    expect(parseAllowStudioOrigin('same-origin')).toBe('http://localhost:3000')
+  })
+
+  test('Absolute URL', () => {
+    expect(parseAllowStudioOrigin('https://my.sanity.studio/')).toBe(
+      'https://my.sanity.studio',
+    )
+  })
+
+  test('Relative URL', () => {
+    expect(parseAllowStudioOrigin('/studio')).toBe('http://localhost:3000')
+  })
+
+  test('Invalid URL', () => {
+    expect(() =>
+      parseAllowStudioOrigin('//'),
+    ).toThrowErrorMatchingInlineSnapshot('"Invalid URL"')
+  })
+})

--- a/packages/core-loader/vitest.config.ts
+++ b/packages/core-loader/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+  },
+})

--- a/packages/groq-store/package.json
+++ b/packages/groq-store/package.json
@@ -34,6 +34,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
+    "src",
     "CHANGELOG.md"
   ],
   "scripts": {
@@ -41,7 +42,8 @@
     "build": "pkg build --strict && pkg --strict",
     "lint": "eslint .",
     "prepublishOnly": "pnpm build",
-    "test": "tsc --noEmit",
+    "test": "vitest --pass-with-no-tests",
+    "typecheck": "vitest typecheck --pass-with-no-tests --run",
     "watch": "pkg watch --strict"
   },
   "browserslist": [
@@ -117,7 +119,8 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "vitest": "^0.34.6"
   },
   "peerDependencies": {
     "@sanity/client": "^6.9.1"

--- a/packages/nuxt-loader/package.json
+++ b/packages/nuxt-loader/package.json
@@ -41,6 +41,7 @@
   },
   "files": [
     "dist",
+    "src",
     "CHANGELOG.md"
   ],
   "scripts": {
@@ -48,7 +49,8 @@
     "build": "pkg build --strict && pkg --strict",
     "lint": "eslint .",
     "prepublishOnly": "pnpm build",
-    "test": "tsc --noEmit",
+    "test": "vitest --pass-with-no-tests",
+    "typecheck": "vitest typecheck --pass-with-no-tests --run",
     "watch": "pkg watch --strict"
   },
   "browserslist": [
@@ -127,6 +129,7 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "nuxt": "^3.8.2",
     "typescript": "^5.3.2",
+    "vitest": "^0.34.6",
     "vue": "^3.3.9"
   },
   "peerDependencies": {

--- a/packages/overlays/package.json
+++ b/packages/overlays/package.json
@@ -34,6 +34,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
+    "src",
     "CHANGELOG.md"
   ],
   "scripts": {
@@ -42,6 +43,7 @@
     "lint": "eslint .",
     "prepublishOnly": "pnpm build",
     "test": "vitest --pass-with-no-tests",
+    "typecheck": "vitest typecheck --pass-with-no-tests --run",
     "watch": "pkg watch --strict"
   },
   "browserslist": [
@@ -134,6 +136,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",
+    "happy-dom": "^12.10.3",
     "ls-engines": "^0.9.1",
     "rimraf": "^5.0.5",
     "typescript": "^5.3.2",

--- a/packages/overlays/src/ui/Overlays.tsx
+++ b/packages/overlays/src/ui/Overlays.tsx
@@ -24,6 +24,7 @@ import styled from 'styled-components'
 import { HistoryAdapter, OverlayEventHandler } from '../types'
 import { ElementOverlay } from './ElementOverlay'
 import { overlayStateReducer } from './overlayStateReducer'
+import { useAllowStudioOrigin } from './useAllowStudioOrigin'
 import { useChannel } from './useChannel'
 import { useController } from './useController'
 
@@ -94,16 +95,11 @@ export const Overlays: FunctionComponent<{
     [history],
   )
 
-  const allowOrigin = useMemo(() => {
-    // previewUrl might be relative, if it is we set `targetOrigin` to the same origin as the Studio
-    // if it's an absolute URL we extract the origin from it
-    const url = new URL(allowStudioOrigin, location.href)
-    return url.origin
-  }, [allowStudioOrigin])
+  const targetOrigin = useAllowStudioOrigin(allowStudioOrigin)
 
   const { channel, status } = useChannel<VisualEditingMsg>(
     channelEventHandler,
-    allowOrigin,
+    targetOrigin,
   )
 
   const overlayEventHandler: OverlayEventHandler = useCallback(

--- a/packages/overlays/src/ui/enableOverlays.tsx
+++ b/packages/overlays/src/ui/enableOverlays.tsx
@@ -2,6 +2,7 @@ import type { Root } from 'react-dom/client'
 
 import { OVERLAY_ID } from '../constants'
 import { HistoryAdapter } from '../types'
+import type { AllowStudioOrigin } from './useAllowStudioOrigin'
 
 /**
  * Cleanup function used when e.g. unmounting
@@ -23,10 +24,12 @@ export function enableOverlays(
   options: {
     /**
      * The origin that are allowed to connect to the overlay.
-     * @example `https://my.sanity.studio`
-     * @example `location.origin`
+     * @example 'https://my.sanity.studio'
+     * @example location.origin
+     * @example 'same-origin'
+     * @defaultValue 'same-origin'
      */
-    allowStudioOrigin: string
+    allowStudioOrigin?: AllowStudioOrigin
     history?: HistoryAdapter
     zIndex?: string | number
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,8 +43,7 @@ export function enableOverlays(
     ([reactClient, { Overlays }]) => {
       if (controller.signal.aborted) return
 
-      const { history, zIndex } = options
-      const allowStudioOrigin = options.allowStudioOrigin || location.origin
+      const { allowStudioOrigin = 'same-origin', history, zIndex } = options
 
       if (!node) {
         node = document.createElement('div')

--- a/packages/overlays/src/ui/useAllowStudioOrigin.ts
+++ b/packages/overlays/src/ui/useAllowStudioOrigin.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react'
+
+/**
+ * The origin that are allowed to connect to the overlay.
+ * @example 'https://my.sanity.studio'
+ * @example location.origin
+ * @example 'same-origin'
+ * @public
+ */
+export type AllowStudioOrigin =
+  | 'same-origin'
+  | `https://${string}`
+  | `http://${string}`
+  | string
+
+export function useAllowStudioOrigin(
+  unsafeAllowStudioOrigin: AllowStudioOrigin,
+): string {
+  return useMemo(() => {
+    // previewUrl might be relative, if it is we set `targetOrigin` to the same origin as the Studio
+    // if it's an absolute URL we extract the origin from it
+    return unsafeAllowStudioOrigin === 'same-origin'
+      ? location.origin
+      : new URL(unsafeAllowStudioOrigin, location.origin).origin
+  }, [unsafeAllowStudioOrigin])
+}

--- a/packages/overlays/src/ui/useChannel.tsx
+++ b/packages/overlays/src/ui/useChannel.tsx
@@ -5,6 +5,7 @@ import {
   ConnectionStatus,
   createChannel,
 } from '@sanity/channels'
+import type { VisualEditingConnectionIds } from '@sanity/visual-editing-helpers'
 import { useEffect, useRef, useState } from 'react'
 
 /**
@@ -23,12 +24,12 @@ export function useChannel<T extends ChannelMsg>(
 
   useEffect(() => {
     const channel = createChannel<T>({
-      id: 'overlays',
+      id: 'overlays' satisfies VisualEditingConnectionIds,
       connections: [
         {
           target: parent,
           targetOrigin,
-          id: 'presentation',
+          id: 'presentation' satisfies VisualEditingConnectionIds,
         },
       ],
       handler,

--- a/packages/overlays/test/useAllowStudioOrigin.test.tsx
+++ b/packages/overlays/test/useAllowStudioOrigin.test.tsx
@@ -1,0 +1,39 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, test } from 'vitest'
+
+import { useAllowStudioOrigin } from '../src/ui/useAllowStudioOrigin'
+
+function TestPrinter(props: { allowStudioOrigin: string }) {
+  return useAllowStudioOrigin(props.allowStudioOrigin)
+}
+
+describe('allowStudioOrigin handling', () => {
+  test('same-origin', () => {
+    const output = renderToStaticMarkup(
+      <TestPrinter allowStudioOrigin="same-origin" />,
+    )
+    expect(output).toBe('http://localhost:3000')
+  })
+
+  test('Absolute URL', () => {
+    const output = renderToStaticMarkup(
+      <TestPrinter allowStudioOrigin="https://my.sanity.studio/" />,
+    )
+    expect(output).toBe('https://my.sanity.studio')
+  })
+
+  test('Relative URL', () => {
+    const output = renderToStaticMarkup(
+      <TestPrinter allowStudioOrigin="/studio" />,
+    )
+    expect(output).toBe('http://localhost:3000')
+  })
+
+  test('Invalid URL', () => {
+    expect(() =>
+      renderToStaticMarkup(<TestPrinter allowStudioOrigin="//" />),
+    ).toThrowErrorMatchingInlineSnapshot('"Invalid URL"')
+  })
+})

--- a/packages/overlays/vitest.config.ts
+++ b/packages/overlays/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+  },
+})

--- a/packages/presentation/package.json
+++ b/packages/presentation/package.json
@@ -43,6 +43,7 @@
     "lint": "eslint .",
     "prepublishOnly": "pnpm build",
     "test": "vitest --pass-with-no-tests",
+    "typecheck": "vitest typecheck --pass-with-no-tests --run",
     "watch": "pkg watch --strict"
   },
   "browserslist": [
@@ -129,6 +130,7 @@
     "@sanity/client": "^6.9.1",
     "@sanity/pkg-utils": "^3.3.2",
     "@sanity/visual-editing-helpers": "workspace:*",
+    "happy-dom": "^12.10.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sanity": "^3.20.2",

--- a/packages/presentation/vitest.config.ts
+++ b/packages/presentation/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+  },
+})

--- a/packages/preview-kit-compat/package.json
+++ b/packages/preview-kit-compat/package.json
@@ -34,6 +34,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
+    "src",
     "CHANGELOG.md"
   ],
   "scripts": {
@@ -41,6 +42,8 @@
     "build": "pkg build --strict && pkg --strict",
     "lint": "eslint .",
     "prepublishOnly": "pnpm build",
+    "test": "vitest --pass-with-no-tests",
+    "typecheck": "vitest typecheck --pass-with-no-tests --run",
     "watch": "pkg watch --strict"
   },
   "browserslist": [
@@ -121,7 +124,8 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "react": "^18.2.0",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "vitest": "^0.34.6"
   },
   "peerDependencies": {
     "@sanity/client": "^6.9.1",

--- a/packages/preview-url-secret/globals.d.ts
+++ b/packages/preview-url-secret/globals.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@edge-runtime/types" />

--- a/packages/preview-url-secret/package.json
+++ b/packages/preview-url-secret/package.json
@@ -108,6 +108,7 @@
   },
   "files": [
     "dist",
+    "src",
     "CHANGELOG.md"
   ],
   "scripts": {
@@ -115,6 +116,8 @@
     "build": "pkg build --strict && pkg --strict",
     "lint": "eslint .",
     "prepublishOnly": "pnpm build",
+    "test": "vitest --pass-with-no-tests",
+    "typecheck": "vitest typecheck --pass-with-no-tests --run",
     "watch": "pkg watch --strict"
   },
   "browserslist": [
@@ -175,7 +178,6 @@
     "@sanity/uuid": "3.0.2"
   },
   "devDependencies": {
-    "@edge-runtime/types": "^2.2.7",
     "@sanity/channels": "workspace:*",
     "@sanity/client": "^6.9.1",
     "@sanity/icons": "^2.7.0",
@@ -187,7 +189,8 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "sanity": "^3.20.2",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "vitest": "^0.34.6"
   },
   "peerDependencies": {
     "@sanity/client": "^6.9.1",

--- a/packages/preview-url-secret/src/validateSecret.ts
+++ b/packages/preview-url-secret/src/validateSecret.ts
@@ -11,7 +11,7 @@ export async function validateSecret(
   secret: string,
 ): Promise<boolean> {
   // If we're in the Edge Runtime it's usually too quick and we need to delay fetching the secret a little bit
-  // eslint-disable-next-line no-warning-comments
+  // @ts-expect-error -- this global exists if we're in the Edge Runtime
   if (typeof EdgeRuntime !== 'undefined') {
     await new Promise((resolve) => setTimeout(resolve, 300))
   }

--- a/packages/react-loader/package.json
+++ b/packages/react-loader/package.json
@@ -67,6 +67,7 @@
   },
   "files": [
     "dist",
+    "src",
     "CHANGELOG.md"
   ],
   "scripts": {
@@ -75,7 +76,8 @@
     "dev": "pkg watch --strict",
     "lint": "eslint .",
     "prepublishOnly": "pnpm build",
-    "typecheck": "vitest typecheck --run"
+    "test": "vitest --pass-with-no-tests",
+    "typecheck": "vitest typecheck --pass-with-no-tests --run"
   },
   "browserslist": [
     "> 0.2% and last 2 versions and supports es6-module and supports es6-module-dynamic-import and not dead and not IE 11",

--- a/packages/react-loader/test/createQueryStore.test-d.ts
+++ b/packages/react-loader/test/createQueryStore.test-d.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@sanity/client'
 import { describe, expectTypeOf, test } from 'vitest'
 
-import { createQueryStore } from './createQueryStore'
+import { createQueryStore } from '../src/createQueryStore'
 
 describe('useQuery', () => {
   const { useQuery } = createQueryStore({ client: createClient({}) })
@@ -16,7 +16,11 @@ describe('useQuery', () => {
         '',
         {},
         {
-          initial: { data: true, sourceMap: undefined, perspective: undefined },
+          initial: {
+            data: true,
+            sourceMap: undefined,
+            perspective: undefined,
+          },
         },
       ).data,
     ).toMatchTypeOf<boolean>()

--- a/packages/svelte-loader/package.json
+++ b/packages/svelte-loader/package.json
@@ -34,6 +34,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
+    "src",
     "CHANGELOG.md"
   ],
   "scripts": {
@@ -41,7 +42,8 @@
     "build": "pkg build --strict && pkg --strict",
     "lint": "eslint .",
     "prepublishOnly": "pnpm build",
-    "test": "tsc --noEmit",
+    "test": "vitest --pass-with-no-tests",
+    "typecheck": "vitest typecheck --pass-with-no-tests --run",
     "watch": "pkg watch --strict"
   },
   "browserslist": [
@@ -117,7 +119,8 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "vitest": "^0.34.6"
   },
   "peerDependencies": {
     "@sanity/client": "^6.9.1"

--- a/packages/visual-editing-helpers/package.json
+++ b/packages/visual-editing-helpers/package.json
@@ -36,6 +36,7 @@
   },
   "files": [
     "dist",
+    "src",
     "CHANGELOG.md"
   ],
   "scripts": {
@@ -43,8 +44,8 @@
     "build": "pkg build --strict && pkg --strict",
     "lint": "eslint .",
     "prepublishOnly": "pnpm build",
-    "test": "vitest",
-    "typecheck": "tsc --noEmit",
+    "test": "vitest --pass-with-no-tests",
+    "typecheck": "vitest typecheck --pass-with-no-tests --run",
     "watch": "pkg watch --strict"
   },
   "browserslist": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,6 +545,9 @@ importers:
       typescript:
         specifier: ^5.3.2
         version: 5.3.2
+      vitest:
+        specifier: ^0.34.6
+        version: 0.34.6(happy-dom@12.10.3)(jsdom@20.0.3)
 
   packages/core-loader:
     dependencies:
@@ -582,12 +585,18 @@ importers:
       eslint-plugin-simple-import-sort:
         specifier: ^10.0.0
         version: 10.0.0(eslint@8.55.0)
+      happy-dom:
+        specifier: ^12.10.3
+        version: 12.10.3
       nanostores:
         specifier: 0.9.5
         version: 0.9.5
       typescript:
         specifier: ^5.3.2
         version: 5.3.2
+      vitest:
+        specifier: ^0.34.6
+        version: 0.34.6(happy-dom@12.10.3)(jsdom@20.0.3)
 
   packages/groq-store:
     dependencies:
@@ -628,6 +637,9 @@ importers:
       typescript:
         specifier: ^5.3.2
         version: 5.3.2
+      vitest:
+        specifier: ^0.34.6
+        version: 0.34.6(happy-dom@12.10.3)(jsdom@20.0.3)
 
   packages/nuxt-loader:
     dependencies:
@@ -674,6 +686,9 @@ importers:
       typescript:
         specifier: ^5.3.2
         version: 5.3.2
+      vitest:
+        specifier: ^0.34.6
+        version: 0.34.6(happy-dom@12.10.3)(jsdom@20.0.3)
       vue:
         specifier: ^3.3.9
         version: 3.3.9(typescript@5.3.2)
@@ -744,6 +759,9 @@ importers:
       eslint-plugin-simple-import-sort:
         specifier: ^10.0.0
         version: 10.0.0(eslint@8.55.0)
+      happy-dom:
+        specifier: ^12.10.3
+        version: 12.10.3
       ls-engines:
         specifier: ^0.9.1
         version: 0.9.1
@@ -755,7 +773,7 @@ importers:
         version: 5.3.2
       vitest:
         specifier: ^0.34.6
-        version: 0.34.6(jsdom@20.0.3)
+        version: 0.34.6(happy-dom@12.10.3)(jsdom@20.0.3)
 
   packages/presentation:
     dependencies:
@@ -802,6 +820,9 @@ importers:
       '@sanity/visual-editing-helpers':
         specifier: workspace:*
         version: link:../visual-editing-helpers
+      happy-dom:
+        specifier: ^12.10.3
+        version: 12.10.3
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -819,7 +840,7 @@ importers:
         version: 5.3.2
       vitest:
         specifier: ^0.34.6
-        version: 0.34.6(jsdom@20.0.3)
+        version: 0.34.6(happy-dom@12.10.3)(jsdom@20.0.3)
 
   packages/preview-kit-compat:
     devDependencies:
@@ -862,6 +883,9 @@ importers:
       typescript:
         specifier: ^5.3.2
         version: 5.3.2
+      vitest:
+        specifier: ^0.34.6
+        version: 0.34.6(happy-dom@12.10.3)(jsdom@20.0.3)
 
   packages/preview-url-secret:
     dependencies:
@@ -869,9 +893,6 @@ importers:
         specifier: 3.0.2
         version: 3.0.2
     devDependencies:
-      '@edge-runtime/types':
-        specifier: ^2.2.7
-        version: 2.2.7
       '@sanity/channels':
         specifier: workspace:*
         version: link:../channels
@@ -908,6 +929,9 @@ importers:
       typescript:
         specifier: ^5.3.2
         version: 5.3.2
+      vitest:
+        specifier: ^0.34.6
+        version: 0.34.6(happy-dom@12.10.3)(jsdom@20.0.3)
 
   packages/react-loader:
     dependencies:
@@ -956,7 +980,7 @@ importers:
         version: 5.3.2
       vitest:
         specifier: ^0.34.6
-        version: 0.34.6(jsdom@20.0.3)
+        version: 0.34.6(happy-dom@12.10.3)(jsdom@20.0.3)
 
   packages/svelte-loader:
     dependencies:
@@ -997,6 +1021,9 @@ importers:
       typescript:
         specifier: ^5.3.2
         version: 5.3.2
+      vitest:
+        specifier: ^0.34.6
+        version: 0.34.6(happy-dom@12.10.3)(jsdom@20.0.3)
 
   packages/visual-editing-helpers:
     devDependencies:
@@ -1035,7 +1062,7 @@ importers:
         version: 0.22.0
       vitest:
         specifier: ^0.34.6
-        version: 0.34.6(jsdom@20.0.3)
+        version: 0.34.6(happy-dom@12.10.3)(jsdom@20.0.3)
 
 packages:
 
@@ -2572,13 +2599,7 @@ packages:
   /@edge-runtime/primitives@4.0.5:
     resolution: {integrity: sha512-t7QiN5d/KpXgCvIfSt6Nm9Hj3WVdNgc5CpOD73jasY+9EvTI7Ngdj5cXvjcHrPcmYWJZMySPgeEeoL/1N/Llag==}
     engines: {node: '>=16'}
-
-  /@edge-runtime/types@2.2.7:
-    resolution: {integrity: sha512-9MTwGooICP7+ZsX9BTy6YCRzOr4tP6RFRymsc8CaKORfvuAHgLZUQaLwILfQ94tddufVXcBwq637VfEd3ZXbWA==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@edge-runtime/primitives': 4.0.5
-    dev: true
+    dev: false
 
   /@edge-runtime/vm@3.1.7:
     resolution: {integrity: sha512-hUMFbDQ/nZN+1TLMi6iMO1QFz9RSV8yGG8S42WFPFma1d7VSNE0eMdJUmwjmtav22/iQkzHMmu6oTSfAvRGS8g==}
@@ -8078,6 +8099,10 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
+  /css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+    dev: true
+
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -10724,6 +10749,17 @@ packages:
       ufo: 1.3.2
       uncrypto: 0.1.3
       unenv: 1.7.4
+
+  /happy-dom@12.10.3:
+    resolution: {integrity: sha512-JzUXOh0wdNGY54oKng5hliuBkq/+aT1V3YpTM+lrN/GoLQTANZsMaIvmHiHe612rauHvPJnDZkZ+5GZR++1Abg==}
+    dependencies:
+      css.escape: 1.5.1
+      entities: 4.5.0
+      iconv-lite: 0.6.3
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+    dev: true
 
   /hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
@@ -18272,7 +18308,7 @@ packages:
       vite: 5.0.5(@types/node@20.8.7)
     dev: true
 
-  /vitest@0.34.6(jsdom@20.0.3):
+  /vitest@0.34.6(happy-dom@12.10.3)(jsdom@20.0.3):
     resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -18316,6 +18352,7 @@ packages:
       cac: 6.7.14
       chai: 4.3.10
       debug: 4.3.4
+      happy-dom: 12.10.3
       jsdom: 20.0.3
       local-pkg: 0.4.3
       magic-string: 0.30.5


### PR DESCRIPTION
# Before
```ts
enableOverlay({
  allowStudioOrigin: typeof location === 'undefined' ? 'http://localhost:3000' : location.origin,
}
useLiveMode({
  allowStudioOrigin: typeof location === 'undefined' ? 'http://localhost:3000' : location.origin,
})
```
# After
```ts
enableOverlay({
  allowStudioOrigin: 'same-origin'
})
useLiveMode({
  allowStudioOrigin: 'same-origin'
})
```