### PR TITLE
fix: allow opting out of `cache: no-store` fetch option in `@sanity/preview-url-secret`

### DIFF
--- a/packages/preview-url-secret/src/validatePreviewUrl.ts
+++ b/packages/preview-url-secret/src/validatePreviewUrl.ts
@@ -14,6 +14,7 @@ import { validateSecret } from './validateSecret'
 export async function validatePreviewUrl(
   _client: SanityClientLike,
   previewUrl: string,
+  disableCacheNoStore?: boolean
 ): Promise<PreviewUrlValidateUrlResult> {
   const client = createClientWithConfig(_client)
   let parsedPreviewUrl: ParsedPreviewUrl
@@ -30,7 +31,7 @@ export async function validatePreviewUrl(
     return { isValid: false }
   }
 
-  const isValid = await validateSecret(client, parsedPreviewUrl.secret)
+  const isValid = await validateSecret(client, parsedPreviewUrl.secret, disableCacheNoStore)
   const redirectTo = isValid ? parsedPreviewUrl.redirectTo : undefined
 
   return { isValid, redirectTo }

--- a/packages/preview-url-secret/src/validateSecret.ts
+++ b/packages/preview-url-secret/src/validateSecret.ts
@@ -25,7 +25,7 @@ export async function validateSecret(
     {
       tag,
       // @ts-expect-error -- the `cache` option is valid, but not in the types when NextJS typings aren't installed
-      ...(!disableCacheStore ? { cache: 'no-store'} : undefined)
+      ...(!disableCacheNoStore ? { cache: 'no-store'} : undefined)
     },
   )
   if (!result?._id || !result?._updatedAt || !result?.secret) {

--- a/packages/preview-url-secret/src/validateSecret.ts
+++ b/packages/preview-url-secret/src/validateSecret.ts
@@ -9,6 +9,7 @@ import type {
 export async function validateSecret(
   client: SanityClientLike,
   secret: string,
+  disableCacheNoStore?: boolean
 ): Promise<boolean> {
   // If we're in the Edge Runtime it's usually too quick and we need to delay fetching the secret a little bit
   // @ts-expect-error -- this global exists if we're in the Edge Runtime
@@ -24,7 +25,7 @@ export async function validateSecret(
     {
       tag,
       // @ts-expect-error -- the `cache` option is valid, but not in the types when NextJS typings aren't installed
-      cache: 'no-store',
+      ...(!disableCacheStore ? { cache: 'no-store'} : undefined)
     },
   )
   if (!result?._id || !result?._updatedAt || !result?.secret) {


### PR DESCRIPTION
It is currently not possible to use the `validatePreviewUrl` function from `@sanity/preview-url-secret` in a CloudFlare Worker, as the Worker runtime's `fetch` implementation (annoyingly) throws in the presence of the `cache` request init keyword instead of failing silently or simply providing an implementation stub.

Ideally, CloudFlare updates the Worker runtime to not throw in this case, as the `cache` option is part of the fetch standard. Until that happens, this PR allows users to opt out of setting the `cache: "no-store"` option in `validateSecret`'s request init object, allowing `@sanity/preview-url-secret` to be used in CloudFlare Workers.

Related issues:
-  https://github.com/cloudflare/workerd/issues/698