### PR TITLE
feat: add share URL button and improve popup window mode

### DIFF
--- a/apps/next/src/app/shoes/VisualEditing.tsx
+++ b/apps/next/src/app/shoes/VisualEditing.tsx
@@ -55,7 +55,11 @@ export default function VisualEditing() {
 
   useLiveMode({ client: stegaClient })
   useEffect(() => {
-    if (process.env.NEXT_PUBLIC_VERCEL_ENV !== 'preview' && window === parent) {
+    if (
+      process.env.NEXT_PUBLIC_VERCEL_ENV !== 'preview' &&
+      window === parent &&
+      !opener
+    ) {
       // If not an iframe, turn off Draft Mode
       location.href = '/api/disable-draft'
     }

--- a/apps/next/src/components/VisualEditing.tsx
+++ b/apps/next/src/components/VisualEditing.tsx
@@ -48,7 +48,11 @@ export default function VisualEditing() {
 
   useLiveMode({ client: stegaClient })
   useEffect(() => {
-    if (process.env.NEXT_PUBLIC_VERCEL_ENV !== 'preview' && window === parent) {
+    if (
+      process.env.NEXT_PUBLIC_VERCEL_ENV !== 'preview' &&
+      window === parent &&
+      !opener
+    ) {
       // If not an iframe, turn off Draft Mode
       location.href = '/api/disable-pages-draft'
     }

--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -22,15 +22,6 @@ const sharedSettings = definePlugin({
   schema,
 })
 
-const devMode = (() => {
-  const vercelEnv = process.env.SANITY_STUDIO_VERCEL_ENV
-  if (vercelEnv === 'development' || vercelEnv === 'preview') return true
-
-  return typeof document === 'undefined'
-    ? false
-    : location.hostname === 'localhost'
-}) satisfies PresentationPluginOptions['devMode']
-
 // If we're on a preview deployment we'll want the iframe URLs to point to the same preview deployment
 function maybeGitBranchUrl(url: string) {
   if (
@@ -78,9 +69,10 @@ function definePreviewUrl(
 }
 
 const presentationWorkspaces = Object.entries({
-  remix:
-    process.env.SANITY_STUDIO_REMIX_PREVIEW_URL ||
-    'http://localhost:3000/shoes',
+  // @TODO make the remix build functional again
+  // remix:
+  // process.env.SANITY_STUDIO_REMIX_PREVIEW_URL ||
+  // 'http://localhost:3000/shoes',
   next: {
     'app-router':
       process.env.SANITY_STUDIO_NEXT_APP_ROUTER_PREVIEW_URL ||
@@ -119,7 +111,6 @@ const presentationWorkspaces = Object.entries({
           name: toolName,
           previewUrl: definePreviewUrl(previewUrl, workspaceName, toolName),
           locate,
-          devMode,
           components:
             name === 'page-builder-demo'
               ? {
@@ -156,7 +147,7 @@ const presentationWorkspaces = Object.entries({
           previewUrl: definePreviewUrl(previewUrl, workspaceName, toolName),
           // @TODO fix the locator for the pages-router
           locate: toolName === 'pages-router' ? undefined : locate,
-          devMode,
+          unstable_showUnsafeShareUrl: toolName === 'app-router',
         })
       }),
       visionTool(),

--- a/packages/channels/src/types.ts
+++ b/packages/channels/src/types.ts
@@ -80,8 +80,8 @@ export type ChannelsEventHandler<T extends ChannelMsg = ChannelMsg> = (
 export interface ChannelsControllerOptions<T extends ChannelMsg = ChannelMsg> {
   id: string
   connectTo: ChannelsControllerChannelOptions<T>[]
-  frame: HTMLIFrameElement
-  frameOrigin: string
+  target: Window
+  targetOrigin: string
   onEvent?: ChannelsEventHandler<T>
   onStatusUpdate?: (status: ChannelStatus, connectionId: string) => void
 }
@@ -115,6 +115,7 @@ export interface ChannelsControllerChannel<T extends ChannelMsg = ChannelMsg> {
  * @public
  */
 export interface ChannelsController<T extends ChannelMsg = ChannelMsg> {
+  addSource: (source: MessageEventSource) => void
   destroy: () => void
   send: (id: string | string[] | undefined, ...args: ToArgs<T>) => void
 }
@@ -136,6 +137,7 @@ export interface ChannelsNodeChannel {
   id: string | null
   buffer: ChannelMsg[]
   origin: string | null
+  source: MessageEventSource | null
   status: ChannelStatus
 }
 

--- a/packages/presentation/src/preview/PreviewFrame.tsx
+++ b/packages/presentation/src/preview/PreviewFrame.tsx
@@ -3,15 +3,23 @@ import { ClientPerspective } from '@sanity/client'
 import {
   CheckmarkIcon,
   ChevronDownIcon,
+  CopyIcon,
   DatabaseIcon,
   DesktopIcon,
   EditIcon,
+  LaunchIcon,
   MobileDeviceIcon,
   PanelLeftIcon,
   PublishIcon,
   RefreshIcon,
+  ShareIcon,
 } from '@sanity/icons'
-import { withoutSecretSearchParams } from '@sanity/preview-url-secret/without-secret-search-params'
+import { createPreviewSecret } from '@sanity/preview-url-secret/create-secret'
+import {
+  hasSecretSearchParams,
+  setSecretSearchParams,
+  withoutSecretSearchParams,
+} from '@sanity/preview-url-secret/without-secret-search-params'
 import {
   Box,
   Button,
@@ -30,6 +38,7 @@ import {
   Tooltip,
   TooltipDelayGroupProvider,
   usePrefersReducedMotion,
+  useToast,
 } from '@sanity/ui'
 import { AnimatePresence, motion, MotionConfig } from 'framer-motion'
 import {
@@ -43,12 +52,12 @@ import {
   useMemo,
   useState,
 } from 'react'
-import { Hotkeys } from 'sanity'
+import { Hotkeys, useClient, useCurrentUser } from 'sanity'
 import styled from 'styled-components'
 
 import { ErrorCard } from '../components/ErrorCard'
-import { MAX_TIME_TO_OVERLAYS_CONNECTION } from '../constants'
-import { PresentationParams } from '../types'
+import { API_VERSION, MAX_TIME_TO_OVERLAYS_CONNECTION } from '../constants'
+import { PresentationParams, PresentationPluginOptions } from '../types'
 import { usePresentationTool } from '../usePresentationTool'
 import { IFrame } from './IFrame'
 import { PreviewLocationInput } from './PreviewLocationInput'
@@ -99,607 +108,655 @@ const PERSPECTIVE_ICONS: Record<ClientPerspective, ComponentType> = {
   raw: DatabaseIcon,
 }
 
-export const PreviewFrame = forwardRef<
-  HTMLIFrameElement,
-  {
-    initialUrl: URL
-    targetOrigin: string
-    navigatorEnabled: boolean
-    onPathChange: (nextPath: string) => void
-    overlayEnabled: boolean
-    params: PresentationParams
-    perspective: ClientPerspective
-    setPerspective: Dispatch<SetStateAction<ClientPerspective>>
-    toggleNavigator?: () => void
-    toggleOverlay: () => void
-    loadersConnection: ChannelStatus
-    overlaysConnection: ChannelStatus
-    previewKitConnection: ChannelStatus
-  }
->(function PreviewFrame(props, ref) {
-  const {
-    initialUrl,
-    targetOrigin,
-    navigatorEnabled,
-    onPathChange,
-    overlayEnabled,
-    params,
-    perspective,
-    setPerspective,
-    toggleNavigator,
-    toggleOverlay,
-    loadersConnection,
-    overlaysConnection,
-    previewKitConnection,
-  } = props
+interface PreviewFrameProps {
+  initialUrl: URL
+  targetOrigin: string
+  navigatorEnabled: boolean
+  onPathChange: (nextPath: string) => void
+  openPopup: (url: string) => void
+  overlayEnabled: boolean
+  params: PresentationParams
+  perspective: ClientPerspective
+  setPerspective: Dispatch<SetStateAction<ClientPerspective>>
+  toggleNavigator?: () => void
+  toggleOverlay: () => void
+  loadersConnection: ChannelStatus
+  overlaysConnection: ChannelStatus
+  previewKitConnection: ChannelStatus
+  unstable_showUnsafeShareUrl: PresentationPluginOptions['unstable_showUnsafeShareUrl']
+}
 
-  const { devMode } = usePresentationTool()
+export const PreviewFrame = forwardRef<HTMLIFrameElement, PreviewFrameProps>(
+  function PreviewFrame(props, ref) {
+    const {
+      initialUrl,
+      targetOrigin,
+      navigatorEnabled,
+      onPathChange,
+      openPopup,
+      overlayEnabled,
+      params,
+      perspective,
+      setPerspective,
+      toggleNavigator,
+      toggleOverlay,
+      loadersConnection,
+      overlaysConnection,
+      previewKitConnection,
+      unstable_showUnsafeShareUrl,
+    } = props
 
-  const [mode, setMode] = useState<'desktop' | 'mobile'>('desktop')
-  const prefersReducedMotion = usePrefersReducedMotion()
+    const { devMode } = usePresentationTool()
 
-  const setDesktopMode = useCallback(() => setMode('desktop'), [setMode])
-  const setMobileMode = useCallback(() => setMode('mobile'), [setMode])
-  const [loading, setLoading] = useState(true)
-  const [timedOut, setTimedOut] = useState(false)
-  const [refreshing, setRefreshing] = useState(false)
-  const [somethingIsWrong, setSomethingIsWrong] = useState(false)
-  const iframeIsBusy =
-    loading || refreshing || overlaysConnection === 'connecting'
+    const [mode, setMode] = useState<'desktop' | 'mobile'>('desktop')
+    const prefersReducedMotion = usePrefersReducedMotion()
 
-  const previewLocationOrigin = useMemo(() => {
-    return targetOrigin === location.origin ? '' : targetOrigin
-  }, [targetOrigin])
+    const setDesktopMode = useCallback(() => setMode('desktop'), [setMode])
+    const setMobileMode = useCallback(() => setMode('mobile'), [setMode])
+    const [loading, setLoading] = useState(true)
+    const [timedOut, setTimedOut] = useState(false)
+    const [refreshing, setRefreshing] = useState(false)
+    const [somethingIsWrong, setSomethingIsWrong] = useState(false)
+    const iframeIsBusy =
+      loading || refreshing || overlaysConnection === 'connecting'
 
-  const handleRefresh = useCallback(() => {
-    if (typeof ref === 'function' || !ref?.current) {
+    const previewLocationOrigin = useMemo(() => {
+      return targetOrigin === location.origin ? '' : targetOrigin
+    }, [targetOrigin])
+
+    const handleRefresh = useCallback(() => {
+      if (typeof ref === 'function' || !ref?.current) {
+        return
+      }
+
+      // Funky way to reload an iframe without CORS issues
+      // eslint-disable-next-line no-self-assign
+      // ref.current.src = ref.current.src
+      ref.current.src = `${targetOrigin}${params.preview || '/'}`
+
+      setRefreshing(true)
+    }, [params.preview, targetOrigin, ref])
+    const handleRetry = useCallback(() => {
+      if (typeof ref === 'function' || !ref?.current) {
+        return
+      }
+
+      ref.current.src = initialUrl.toString()
+
+      setRefreshing(true)
+    }, [ref, initialUrl])
+    const handleContinueAnyway = useCallback(() => {
+      setContinueAnyway(true)
+    }, [])
+
+    const [continueAnyway, setContinueAnyway] = useState(false)
+    const [showOverlaysConnectionStatus, setShowOverlaysConnectionState] =
+      useState(false)
+    useEffect(() => {
+      if (loading || refreshing) {
+        return
+      }
+
+      if (
+        overlaysConnection === 'connecting' ||
+        overlaysConnection === 'reconnecting'
+      ) {
+        const timeout = setTimeout(() => {
+          setShowOverlaysConnectionState(true)
+        }, 1000)
+        return () => clearTimeout(timeout)
+      }
       return
-    }
+    }, [
+      overlaysConnection,
+      loading,
+      refreshing,
+      setShowOverlaysConnectionState,
+    ])
 
-    // Funky way to reload an iframe without CORS issues
-    // eslint-disable-next-line no-self-assign
-    // ref.current.src = ref.current.src
-    ref.current.src = `${targetOrigin}${params.preview || '/'}`
-
-    setRefreshing(true)
-  }, [params.preview, targetOrigin, ref])
-  const handleRetry = useCallback(() => {
-    if (typeof ref === 'function' || !ref?.current) {
-      return
-    }
-
-    ref.current.src = initialUrl.toString()
-
-    setRefreshing(true)
-  }, [ref, initialUrl])
-  const handleContinueAnyway = useCallback(() => {
-    setContinueAnyway(true)
-  }, [])
-
-  const [continueAnyway, setContinueAnyway] = useState(false)
-  const [showOverlaysConnectionStatus, setShowOverlaysConnectionState] =
-    useState(false)
-  useEffect(() => {
-    if (loading || refreshing) {
-      return
-    }
-
-    if (
-      overlaysConnection === 'connecting' ||
-      overlaysConnection === 'reconnecting'
-    ) {
-      const timeout = setTimeout(() => {
-        setShowOverlaysConnectionState(true)
-      }, 1000)
-      return () => clearTimeout(timeout)
-    }
-    return
-  }, [overlaysConnection, loading, refreshing, setShowOverlaysConnectionState])
-
-  useEffect(() => {
-    if (loading || refreshing || !showOverlaysConnectionStatus) {
-      return
-    }
-    if (overlaysConnection === 'connected') {
-      setSomethingIsWrong(false)
-      setShowOverlaysConnectionState(false)
-      setTimedOut(false)
-      setContinueAnyway(false)
-    }
-    if (overlaysConnection === 'connecting') {
-      const timeout = setTimeout(() => {
-        setTimedOut(true)
-        // eslint-disable-next-line no-console
-        console.error(
-          `Unable to connect to overlays. Make sure you're calling the 'enableOverlays' function in '@sanity/overlays' correctly`,
-        )
-      }, MAX_TIME_TO_OVERLAYS_CONNECTION)
-      return () => clearTimeout(timeout)
-    }
-    if (overlaysConnection === 'reconnecting') {
-      const timeout = setTimeout(() => {
-        setTimedOut(true)
+    useEffect(() => {
+      if (loading || refreshing || !showOverlaysConnectionStatus) {
+        return
+      }
+      if (overlaysConnection === 'connected') {
+        setSomethingIsWrong(false)
+        setShowOverlaysConnectionState(false)
+        setTimedOut(false)
+        setContinueAnyway(false)
+      }
+      if (overlaysConnection === 'connecting') {
+        const timeout = setTimeout(() => {
+          setTimedOut(true)
+          // eslint-disable-next-line no-console
+          console.error(
+            `Unable to connect to overlays. Make sure you're calling the 'enableOverlays' function in '@sanity/overlays' correctly`,
+          )
+        }, MAX_TIME_TO_OVERLAYS_CONNECTION)
+        return () => clearTimeout(timeout)
+      }
+      if (overlaysConnection === 'reconnecting') {
+        const timeout = setTimeout(() => {
+          setTimedOut(true)
+          setSomethingIsWrong(true)
+        }, MAX_TIME_TO_OVERLAYS_CONNECTION)
+        return () => clearTimeout(timeout)
+      }
+      if (overlaysConnection === 'disconnected') {
         setSomethingIsWrong(true)
-      }, MAX_TIME_TO_OVERLAYS_CONNECTION)
-      return () => clearTimeout(timeout)
-    }
-    if (overlaysConnection === 'disconnected') {
-      setSomethingIsWrong(true)
-    }
-    return
-  }, [loading, overlaysConnection, refreshing, showOverlaysConnectionStatus])
+      }
+      return
+    }, [loading, overlaysConnection, refreshing, showOverlaysConnectionStatus])
 
-  const previewLocationRoute = useMemo(() => {
-    const previewUrl = new URL(params.preview || '/', targetOrigin)
-    const { pathname, search } = withoutSecretSearchParams(previewUrl)
+    const previewLocationRoute = useMemo(() => {
+      const previewUrl = new URL(params.preview || '/', targetOrigin)
+      const { pathname, search } = withoutSecretSearchParams(previewUrl)
 
-    return `${pathname}${search}`
-  }, [params.preview, targetOrigin])
+      return `${pathname}${search}`
+    }, [params.preview, targetOrigin])
 
-  const onIFrameLoad = useCallback(() => {
-    setLoading(false)
-    setRefreshing(false)
-  }, [])
+    const onIFrameLoad = useCallback(() => {
+      setLoading(false)
+      setRefreshing(false)
+    }, [])
 
-  return (
-    <MotionConfig
-      transition={prefersReducedMotion ? { duration: 0 } : undefined}
-    >
-      <TooltipDelayGroupProvider delay={1000}>
-        <Card
-          flex="none"
-          padding={2}
-          shadow={1}
-          style={{ position: 'relative' }}
-        >
-          <Flex align="center" gap={2} style={{ minHeight: 0 }}>
-            {toggleNavigator && (
-              <Tooltip
-                animate
-                content={<Text size={1}>Toggle navigator</Text>}
-                fallbackPlacements={['bottom-start']}
-                padding={2}
-                placement="bottom"
-                portal
-              >
-                <Button
-                  aria-label="Toggle navigator"
-                  fontSize={1}
-                  icon={PanelLeftIcon}
-                  mode="bleed"
-                  onClick={toggleNavigator}
-                  padding={3}
-                  selected={navigatorEnabled}
-                />
-              </Tooltip>
-            )}
+    return (
+      <MotionConfig
+        transition={prefersReducedMotion ? { duration: 0 } : undefined}
+      >
+        <TooltipDelayGroupProvider delay={1000}>
+          <Card
+            flex="none"
+            padding={2}
+            shadow={1}
+            style={{ position: 'relative' }}
+          >
+            <Flex align="center" gap={2} style={{ minHeight: 0 }}>
+              {toggleNavigator && (
+                <Tooltip
+                  animate
+                  content={<Text size={1}>Toggle navigator</Text>}
+                  fallbackPlacements={['bottom-start']}
+                  padding={2}
+                  placement="bottom"
+                  portal
+                >
+                  <Button
+                    aria-label="Toggle navigator"
+                    fontSize={1}
+                    icon={PanelLeftIcon}
+                    mode="bleed"
+                    onClick={toggleNavigator}
+                    padding={3}
+                    selected={navigatorEnabled}
+                  />
+                </Tooltip>
+              )}
 
-            <Tooltip
-              animate
-              content={
-                <Flex align="center" style={{ whiteSpace: 'nowrap' }}>
-                  <Box padding={1}>
-                    <Text size={1}>
-                      {overlayEnabled
-                        ? 'Disable edit overlay'
-                        : 'Enable edit overlay'}
-                    </Text>
-                  </Box>
-                  <Box paddingY={1}>
-                    <Hotkeys
-                      keys={['Alt']}
-                      style={{ marginTop: -4, marginBottom: -4 }}
-                    />
-                  </Box>
-                </Flex>
-              }
-              fallbackPlacements={['bottom-start']}
-              padding={1}
-              placement="bottom"
-              portal
-            >
-              <Card
-                as="label"
-                flex="none"
-                padding={3}
-                style={{
-                  lineHeight: 0,
-                  borderRadius: 999,
-                  userSelect: 'none',
-                }}
-                tone={overlayEnabled ? 'positive' : undefined}
-              >
-                <Flex align="center" gap={2}>
-                  <div style={{ margin: -2 }}>
-                    <StyledSwitch
-                      checked={overlayEnabled}
-                      onChange={toggleOverlay}
-                      disabled={iframeIsBusy}
-                    />
-                  </div>
-                  <Box>
-                    <Text muted size={1} weight="medium">
-                      Edit
-                    </Text>
-                  </Box>
-                </Flex>
-              </Card>
-            </Tooltip>
-
-            {devMode && (
               <Tooltip
                 animate
                 content={
-                  <Text size={1}>
-                    {refreshing ? 'Refreshing…' : 'Refresh preview'}
-                  </Text>
-                }
-                fallbackPlacements={['bottom-start']}
-                padding={2}
-                placement="bottom"
-                portal
-              >
-                <Button
-                  aria-label="Refresh preview"
-                  fontSize={1}
-                  icon={RefreshIcon}
-                  mode="bleed"
-                  loading={refreshing}
-                  onClick={handleRefresh}
-                  padding={3}
-                />
-              </Tooltip>
-            )}
-
-            <Box flex={1}>
-              <PreviewLocationInput
-                onChange={onPathChange}
-                origin={previewLocationOrigin}
-                value={previewLocationRoute}
-              />
-            </Box>
-
-            <Flex align="center" flex="none" gap={1}>
-              <MenuButton
-                button={
-                  <Button
-                    fontSize={1}
-                    iconRight={ChevronDownIcon}
-                    mode="bleed"
-                    padding={3}
-                    space={2}
-                    text={PERSPECTIVE_TITLES[perspective]}
-                    loading={
-                      iframeIsBusy ||
-                      (loadersConnection === 'connecting' &&
-                        previewKitConnection !== 'connected')
-                    }
-                    disabled={loadersConnection !== 'connected'}
-                  />
-                }
-                id="perspective-menu"
-                menu={
-                  <Menu style={{ maxWidth: 240 }}>
-                    <MenuItem
-                      fontSize={1}
-                      onClick={() => setPerspective('previewDrafts')}
-                      padding={3}
-                      pressed={perspective === 'previewDrafts'}
-                      tone={PERSPECTIVE_TONES['previewDrafts']}
-                    >
-                      <Flex align="flex-start" gap={3}>
-                        <Box flex="none">
-                          <Text size={1}>
-                            {createElement(PERSPECTIVE_ICONS['previewDrafts'])}
-                          </Text>
-                        </Box>
-                        <Stack flex={1} space={2}>
-                          <Text size={1} weight="medium">
-                            {PERSPECTIVE_TITLES['previewDrafts']}
-                          </Text>
-                          <Text muted size={1}>
-                            View this page with latest draft content
-                          </Text>
-                        </Stack>
-                        <Box flex="none">
-                          <Text
-                            muted
-                            size={1}
-                            style={{
-                              opacity: perspective === 'previewDrafts' ? 1 : 0,
-                            }}
-                          >
-                            <CheckmarkIcon />
-                          </Text>
-                        </Box>
-                      </Flex>
-                    </MenuItem>
-                    <MenuItem
-                      fontSize={1}
-                      onClick={() => setPerspective('published')}
-                      padding={3}
-                      pressed={perspective === 'published'}
-                      tone={PERSPECTIVE_TONES['published']}
-                    >
-                      <Flex align="flex-start" gap={3}>
-                        <Box flex="none">
-                          <Text size={1}>
-                            {createElement(PERSPECTIVE_ICONS['published'])}
-                          </Text>
-                        </Box>
-                        <Stack flex={1} space={2}>
-                          <Text size={1} weight="medium">
-                            {PERSPECTIVE_TITLES['published']}
-                          </Text>
-                          <Text muted size={1}>
-                            View this page with published content
-                          </Text>
-                        </Stack>
-                        <Box flex="none">
-                          <Text
-                            muted
-                            size={1}
-                            style={{
-                              opacity: perspective === 'published' ? 1 : 0,
-                            }}
-                          >
-                            <CheckmarkIcon />
-                          </Text>
-                        </Box>
-                      </Flex>
-                    </MenuItem>
-                  </Menu>
-                }
-                popover={{
-                  animate: true,
-                  constrainSize: true,
-                  placement: 'bottom',
-                  portal: true,
-                }}
-              />
-            </Flex>
-
-            <Flex align="center" flex="none" gap={1}>
-              <Tooltip
-                animate
-                content={<Text size={1}>Full viewport</Text>}
-                fallbackPlacements={['bottom-start']}
-                padding={2}
-                placement="bottom"
-                portal
-              >
-                <Button
-                  aria-label="Full viewport"
-                  fontSize={1}
-                  icon={DesktopIcon}
-                  mode="bleed"
-                  onClick={setDesktopMode}
-                  padding={3}
-                  selected={mode === 'desktop'}
-                />
-              </Tooltip>
-              <Tooltip
-                animate
-                content={<Text size={1}>Narrow viewport</Text>}
-                padding={2}
-                placement="bottom"
-                portal
-              >
-                <Button
-                  aria-label="Narrow viewport"
-                  fontSize={1}
-                  icon={MobileDeviceIcon}
-                  mode="bleed"
-                  onClick={setMobileMode}
-                  padding={3}
-                  selected={mode === 'mobile'}
-                />
-              </Tooltip>
-            </Flex>
-          </Flex>
-        </Card>
-
-        <Card flex={1} tone="transparent">
-          <Flex
-            align="center"
-            height="fill"
-            justify="center"
-            padding={mode === 'desktop' ? 0 : 2}
-            sizing="border"
-            style={{
-              position: 'relative',
-              cursor: iframeIsBusy ? 'wait' : undefined,
-            }}
-          >
-            <AnimatePresence>
-              {!somethingIsWrong &&
-              !loading &&
-              !refreshing &&
-              showOverlaysConnectionStatus &&
-              !continueAnyway ? (
-                <MotionFlex
-                  initial="initial"
-                  animate="animate"
-                  exit="exit"
-                  variants={spinnerVariants}
-                  justify="center"
-                  align="center"
-                  style={{
-                    inset: `0`,
-                    position: `absolute`,
-                    backdropFilter: timedOut
-                      ? 'blur(16px) saturate(0.5) grayscale(0.5)'
-                      : 'blur(2px)',
-                    ['transition' as string]:
-                      'backdrop-filter 0.2s ease-in-out',
-                    // @TODO Because of Safari we have to do this
-                    WebkitBackdropFilter: timedOut
-                      ? 'blur(16px) saturate(0.5) grayscale(0.5)'
-                      : 'blur(2px)',
-                    WebkitTransition:
-                      '-webkit-backdrop-filter 0.2s ease-in-out',
-                    zIndex: 1,
-                  }}
-                >
-                  <Flex
-                    style={{ ...sizes[mode] }}
-                    justify="center"
-                    align="center"
-                    direction="column"
-                    gap={4}
-                  >
-                    {timedOut && (
-                      <Button
-                        disabled
-                        fontSize={1}
-                        mode="ghost"
-                        text="Continue anyway"
-                        style={{ opacity: 0 }}
+                  <Flex align="center" style={{ whiteSpace: 'nowrap' }}>
+                    <Box padding={1}>
+                      <Text size={1}>
+                        {overlayEnabled
+                          ? 'Disable edit overlay'
+                          : 'Enable edit overlay'}
+                      </Text>
+                    </Box>
+                    <Box paddingY={1}>
+                      <Hotkeys
+                        keys={['Alt']}
+                        style={{ marginTop: -4, marginBottom: -4 }}
                       />
-                    )}
-                    <Card
-                      radius={2}
-                      tone={timedOut ? 'caution' : 'inherit'}
-                      padding={4}
-                      shadow={1}
-                    >
-                      <Flex
-                        justify="center"
-                        align="center"
-                        direction="column"
-                        gap={4}
-                      >
-                        <Spinner muted />
-                        <Text muted size={1}>
-                          {timedOut ? (
-                            <>
-                              Unable to connect, check the browser console for
-                              more information.
-                            </>
-                          ) : (
-                            'Connecting…'
-                          )}
-                        </Text>
-                      </Flex>
-                    </Card>
-                    {timedOut && (
-                      <Button
-                        fontSize={1}
-                        // mode="ghost"
-                        tone="critical"
-                        onClick={handleContinueAnyway}
-                        text="Continue anyway"
-                      />
-                    )}
+                    </Box>
                   </Flex>
-                </MotionFlex>
-              ) : (loading || iframeIsBusy) && !continueAnyway ? (
-                <MotionFlex
-                  initial="initial"
-                  animate="animate"
-                  exit="exit"
-                  variants={spinnerVariants}
-                  justify="center"
-                  align="center"
+                }
+                fallbackPlacements={['bottom-start']}
+                padding={1}
+                placement="bottom"
+                portal
+              >
+                <Card
+                  as="label"
+                  flex="none"
+                  padding={3}
                   style={{
-                    inset: `0`,
-                    position: `absolute`,
-                    // boxShadow: '0 0 0 1px var(--card-shadow-outline-color)',
+                    lineHeight: 0,
+                    borderRadius: 999,
+                    userSelect: 'none',
                   }}
+                  tone={overlayEnabled ? 'positive' : undefined}
                 >
-                  <Flex
-                    style={{ ...sizes[mode] }}
-                    justify="center"
-                    align="center"
-                    direction="column"
-                    gap={4}
-                  >
-                    <Spinner muted />
-                    <Text muted size={1}>
-                      Loading…
+                  <Flex align="center" gap={2}>
+                    <div style={{ margin: -2 }}>
+                      <StyledSwitch
+                        checked={overlayEnabled}
+                        onChange={toggleOverlay}
+                        disabled={iframeIsBusy}
+                      />
+                    </div>
+                    <Box>
+                      <Text muted size={1} weight="medium">
+                        Edit
+                      </Text>
+                    </Box>
+                  </Flex>
+                </Card>
+              </Tooltip>
+
+              {devMode && (
+                <Tooltip
+                  animate
+                  content={
+                    <Text size={1}>
+                      {refreshing ? 'Refreshing…' : 'Refresh preview'}
                     </Text>
-                  </Flex>
-                </MotionFlex>
-              ) : somethingIsWrong && !continueAnyway ? (
-                <MotionFlex
-                  initial="initial"
-                  animate="animate"
-                  exit="exit"
-                  variants={errorVariants}
-                  justify="center"
-                  align="center"
-                  style={{
-                    background: 'var(--card-bg-color)',
-                    inset: `0`,
-                    position: `absolute`,
-                    borderTop: '1px solid transparent',
-                    boxShadow: '0 0 0 1px var(--card-border-color)',
-                  }}
+                  }
+                  fallbackPlacements={['bottom-start']}
+                  padding={2}
+                  placement="bottom"
+                  portal
                 >
-                  <ErrorCard
-                    flex={1}
-                    message="Could not connect to the preview"
-                    onRetry={handleRetry}
-                    onContinueAnyway={handleContinueAnyway}
-                  >
-                    {devMode && (
-                      <>
-                        {overlaysConnection !== 'connected' && (
-                          <Card padding={3} radius={2} tone="critical">
-                            <Stack space={3}>
-                              <Label muted size={0}>
-                                Overlay connection status
-                              </Label>
-                              <Code size={1}>{overlaysConnection}</Code>
-                            </Stack>
-                          </Card>
-                        )}
+                  <Button
+                    aria-label="Refresh preview"
+                    fontSize={1}
+                    icon={RefreshIcon}
+                    mode="bleed"
+                    loading={refreshing}
+                    onClick={handleRefresh}
+                    padding={3}
+                  />
+                </Tooltip>
+              )}
 
-                        {loadersConnection !== 'connected' && (
-                          <Card padding={3} radius={2} tone="critical">
-                            <Stack space={3}>
-                              <Label muted size={0}>
-                                Loader connection status
-                              </Label>
-                              <Code size={1}>{loadersConnection}</Code>
-                            </Stack>
-                          </Card>
-                        )}
-                      </>
-                    )}
-                  </ErrorCard>
-                </MotionFlex>
-              ) : null}
-            </AnimatePresence>
-            <IFrame
-              ref={ref}
+              <Box flex={1}>
+                <PreviewLocationInput
+                  onChange={onPathChange}
+                  openPopup={openPopup}
+                  origin={previewLocationOrigin}
+                  value={previewLocationRoute}
+                  unstable_showUnsafeShareUrl={unstable_showUnsafeShareUrl}
+                />
+              </Box>
+
+              {unstable_showUnsafeShareUrl && (
+                <Flex align="center" flex="none" gap={1}>
+                  <MenuButton
+                    button={
+                      <Button
+                        fontSize={1}
+                        iconRight={ShareIcon}
+                        mode="bleed"
+                        padding={3}
+                        space={2}
+                      />
+                    }
+                    id="location-menu"
+                    menu={
+                      <Menu>
+                        <ShareUrlMenuItems
+                          initialUrl={initialUrl}
+                          openPopup={openPopup}
+                          previewLocationOrigin={previewLocationOrigin}
+                          previewLocationRoute={previewLocationRoute}
+                        />
+                      </Menu>
+                    }
+                    popover={{
+                      animate: true,
+                      constrainSize: true,
+                      placement: 'bottom',
+                      portal: true,
+                    }}
+                  />
+                </Flex>
+              )}
+
+              <Flex align="center" flex="none" gap={1}>
+                <MenuButton
+                  button={
+                    <Button
+                      fontSize={1}
+                      iconRight={ChevronDownIcon}
+                      mode="bleed"
+                      padding={3}
+                      space={2}
+                      text={PERSPECTIVE_TITLES[perspective]}
+                      loading={
+                        iframeIsBusy ||
+                        (loadersConnection === 'connecting' &&
+                          previewKitConnection !== 'connected')
+                      }
+                      disabled={loadersConnection !== 'connected'}
+                    />
+                  }
+                  id="perspective-menu"
+                  menu={
+                    <Menu style={{ maxWidth: 240 }}>
+                      <MenuItem
+                        fontSize={1}
+                        onClick={() => setPerspective('previewDrafts')}
+                        padding={3}
+                        pressed={perspective === 'previewDrafts'}
+                        tone={PERSPECTIVE_TONES['previewDrafts']}
+                      >
+                        <Flex align="flex-start" gap={3}>
+                          <Box flex="none">
+                            <Text size={1}>
+                              {createElement(
+                                PERSPECTIVE_ICONS['previewDrafts'],
+                              )}
+                            </Text>
+                          </Box>
+                          <Stack flex={1} space={2}>
+                            <Text size={1} weight="medium">
+                              {PERSPECTIVE_TITLES['previewDrafts']}
+                            </Text>
+                            <Text muted size={1}>
+                              View this page with latest draft content
+                            </Text>
+                          </Stack>
+                          <Box flex="none">
+                            <Text
+                              muted
+                              size={1}
+                              style={{
+                                opacity:
+                                  perspective === 'previewDrafts' ? 1 : 0,
+                              }}
+                            >
+                              <CheckmarkIcon />
+                            </Text>
+                          </Box>
+                        </Flex>
+                      </MenuItem>
+                      <MenuItem
+                        fontSize={1}
+                        onClick={() => setPerspective('published')}
+                        padding={3}
+                        pressed={perspective === 'published'}
+                        tone={PERSPECTIVE_TONES['published']}
+                      >
+                        <Flex align="flex-start" gap={3}>
+                          <Box flex="none">
+                            <Text size={1}>
+                              {createElement(PERSPECTIVE_ICONS['published'])}
+                            </Text>
+                          </Box>
+                          <Stack flex={1} space={2}>
+                            <Text size={1} weight="medium">
+                              {PERSPECTIVE_TITLES['published']}
+                            </Text>
+                            <Text muted size={1}>
+                              View this page with published content
+                            </Text>
+                          </Stack>
+                          <Box flex="none">
+                            <Text
+                              muted
+                              size={1}
+                              style={{
+                                opacity: perspective === 'published' ? 1 : 0,
+                              }}
+                            >
+                              <CheckmarkIcon />
+                            </Text>
+                          </Box>
+                        </Flex>
+                      </MenuItem>
+                    </Menu>
+                  }
+                  popover={{
+                    animate: true,
+                    constrainSize: true,
+                    placement: 'bottom',
+                    portal: true,
+                  }}
+                />
+              </Flex>
+
+              <Flex align="center" flex="none" gap={1}>
+                <Tooltip
+                  animate
+                  content={<Text size={1}>Full viewport</Text>}
+                  fallbackPlacements={['bottom-start']}
+                  padding={2}
+                  placement="bottom"
+                  portal
+                >
+                  <Button
+                    aria-label="Full viewport"
+                    fontSize={1}
+                    icon={DesktopIcon}
+                    mode="bleed"
+                    onClick={setDesktopMode}
+                    padding={3}
+                    selected={mode === 'desktop'}
+                  />
+                </Tooltip>
+                <Tooltip
+                  animate
+                  content={<Text size={1}>Narrow viewport</Text>}
+                  padding={2}
+                  placement="bottom"
+                  portal
+                >
+                  <Button
+                    aria-label="Narrow viewport"
+                    fontSize={1}
+                    icon={MobileDeviceIcon}
+                    mode="bleed"
+                    onClick={setMobileMode}
+                    padding={3}
+                    selected={mode === 'mobile'}
+                  />
+                </Tooltip>
+              </Flex>
+            </Flex>
+          </Card>
+
+          <Card flex={1} tone="transparent">
+            <Flex
+              align="center"
+              height="fill"
+              justify="center"
+              padding={mode === 'desktop' ? 0 : 2}
+              sizing="border"
               style={{
-                pointerEvents:
-                  iframeIsBusy && !continueAnyway ? 'none' : 'auto',
-                boxShadow: '0 0 0 1px var(--card-border-color)',
-                borderTop: '1px solid transparent',
+                position: 'relative',
+                cursor: iframeIsBusy ? 'wait' : undefined,
               }}
-              src={initialUrl.toString()}
-              initial={['background']}
-              variants={iframeVariants}
-              animate={[
-                (loading || iframeIsBusy) && !continueAnyway
-                  ? 'background'
-                  : 'active',
-                refreshing ? 'reloading' : 'idle',
-                mode,
-                showOverlaysConnectionStatus && !continueAnyway
-                  ? 'timedOut'
-                  : '',
-              ]}
-              onLoad={onIFrameLoad}
-            />
-          </Flex>
-        </Card>
-      </TooltipDelayGroupProvider>
-    </MotionConfig>
-  )
-})
+            >
+              <AnimatePresence>
+                {!somethingIsWrong &&
+                !loading &&
+                !refreshing &&
+                showOverlaysConnectionStatus &&
+                !continueAnyway ? (
+                  <MotionFlex
+                    initial="initial"
+                    animate="animate"
+                    exit="exit"
+                    variants={spinnerVariants}
+                    justify="center"
+                    align="center"
+                    style={{
+                      inset: `0`,
+                      position: `absolute`,
+                      backdropFilter: timedOut
+                        ? 'blur(16px) saturate(0.5) grayscale(0.5)'
+                        : 'blur(2px)',
+                      ['transition' as string]:
+                        'backdrop-filter 0.2s ease-in-out',
+                      // @TODO Because of Safari we have to do this
+                      WebkitBackdropFilter: timedOut
+                        ? 'blur(16px) saturate(0.5) grayscale(0.5)'
+                        : 'blur(2px)',
+                      WebkitTransition:
+                        '-webkit-backdrop-filter 0.2s ease-in-out',
+                      zIndex: 1,
+                    }}
+                  >
+                    <Flex
+                      style={{ ...sizes[mode] }}
+                      justify="center"
+                      align="center"
+                      direction="column"
+                      gap={4}
+                    >
+                      {timedOut && (
+                        <Button
+                          disabled
+                          fontSize={1}
+                          mode="ghost"
+                          text="Continue anyway"
+                          style={{ opacity: 0 }}
+                        />
+                      )}
+                      <Card
+                        radius={2}
+                        tone={timedOut ? 'caution' : 'inherit'}
+                        padding={4}
+                        shadow={1}
+                      >
+                        <Flex
+                          justify="center"
+                          align="center"
+                          direction="column"
+                          gap={4}
+                        >
+                          <Spinner muted />
+                          <Text muted size={1}>
+                            {timedOut ? (
+                              <>
+                                Unable to connect, check the browser console for
+                                more information.
+                              </>
+                            ) : (
+                              'Connecting…'
+                            )}
+                          </Text>
+                        </Flex>
+                      </Card>
+                      {timedOut && (
+                        <Button
+                          fontSize={1}
+                          // mode="ghost"
+                          tone="critical"
+                          onClick={handleContinueAnyway}
+                          text="Continue anyway"
+                        />
+                      )}
+                    </Flex>
+                  </MotionFlex>
+                ) : (loading || iframeIsBusy) && !continueAnyway ? (
+                  <MotionFlex
+                    initial="initial"
+                    animate="animate"
+                    exit="exit"
+                    variants={spinnerVariants}
+                    justify="center"
+                    align="center"
+                    style={{
+                      inset: `0`,
+                      position: `absolute`,
+                      // boxShadow: '0 0 0 1px var(--card-shadow-outline-color)',
+                    }}
+                  >
+                    <Flex
+                      style={{ ...sizes[mode] }}
+                      justify="center"
+                      align="center"
+                      direction="column"
+                      gap={4}
+                    >
+                      <Spinner muted />
+                      <Text muted size={1}>
+                        Loading…
+                      </Text>
+                    </Flex>
+                  </MotionFlex>
+                ) : somethingIsWrong && !continueAnyway ? (
+                  <MotionFlex
+                    initial="initial"
+                    animate="animate"
+                    exit="exit"
+                    variants={errorVariants}
+                    justify="center"
+                    align="center"
+                    style={{
+                      background: 'var(--card-bg-color)',
+                      inset: `0`,
+                      position: `absolute`,
+                      borderTop: '1px solid transparent',
+                      boxShadow: '0 0 0 1px var(--card-border-color)',
+                    }}
+                  >
+                    <ErrorCard
+                      flex={1}
+                      message="Could not connect to the preview"
+                      onRetry={handleRetry}
+                      onContinueAnyway={handleContinueAnyway}
+                    >
+                      {devMode && (
+                        <>
+                          {overlaysConnection !== 'connected' && (
+                            <Card padding={3} radius={2} tone="critical">
+                              <Stack space={3}>
+                                <Label muted size={0}>
+                                  Overlay connection status
+                                </Label>
+                                <Code size={1}>{overlaysConnection}</Code>
+                              </Stack>
+                            </Card>
+                          )}
+
+                          {loadersConnection !== 'connected' && (
+                            <Card padding={3} radius={2} tone="critical">
+                              <Stack space={3}>
+                                <Label muted size={0}>
+                                  Loader connection status
+                                </Label>
+                                <Code size={1}>{loadersConnection}</Code>
+                              </Stack>
+                            </Card>
+                          )}
+                        </>
+                      )}
+                    </ErrorCard>
+                  </MotionFlex>
+                ) : null}
+              </AnimatePresence>
+              <IFrame
+                ref={ref}
+                style={{
+                  pointerEvents:
+                    iframeIsBusy && !continueAnyway ? 'none' : 'auto',
+                  boxShadow: '0 0 0 1px var(--card-border-color)',
+                  borderTop: '1px solid transparent',
+                }}
+                src={initialUrl.toString()}
+                initial={['background']}
+                variants={iframeVariants}
+                animate={[
+                  (loading || iframeIsBusy) && !continueAnyway
+                    ? 'background'
+                    : 'active',
+                  refreshing ? 'reloading' : 'idle',
+                  mode,
+                  showOverlaysConnectionStatus && !continueAnyway
+                    ? 'timedOut'
+                    : '',
+                ]}
+                onLoad={onIFrameLoad}
+              />
+            </Flex>
+          </Card>
+        </TooltipDelayGroupProvider>
+      </MotionConfig>
+    )
+  },
+)
 
 const sizes = {
   desktop: {
@@ -750,4 +807,129 @@ const iframeVariants = {
   timedOut: {
     opacity: [0, 0, 1],
   },
+}
+
+function ShareUrlMenuItems(
+  props: Pick<PreviewFrameProps, 'initialUrl' | 'openPopup'> & {
+    previewLocationOrigin: string
+    previewLocationRoute: string
+  },
+) {
+  const { initialUrl, openPopup, previewLocationOrigin, previewLocationRoute } =
+    props
+
+  const handleOpenPopup = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+      event.preventDefault()
+      openPopup(event.currentTarget.href)
+    },
+    [openPopup],
+  )
+
+  return (
+    <>
+      <CopyUrlMenuButton
+        initialUrl={initialUrl}
+        previewLocationOrigin={previewLocationOrigin}
+        previewLocationRoute={previewLocationRoute}
+      />
+      <MenuItem
+        icon={LaunchIcon}
+        text="Open preview"
+        as="a"
+        href={`${previewLocationOrigin}${previewLocationRoute}`}
+        onClick={handleOpenPopup as any}
+        rel="opener"
+        target="_blank"
+      />
+    </>
+  )
+}
+
+function CopyUrlMenuButton(
+  props: Pick<PreviewFrameProps, 'initialUrl'> & {
+    previewLocationOrigin: string
+    previewLocationRoute: string
+  },
+) {
+  const { initialUrl, previewLocationOrigin, previewLocationRoute } = props
+
+  const { push: pushToast } = useToast()
+  const client = useClient({ apiVersion: API_VERSION })
+  const currentUser = useCurrentUser()
+  const [disabled, setDisabled] = useState(false)
+
+  return (
+    <MenuItem
+      disabled={disabled}
+      onClick={() => {
+        if (!navigator?.clipboard) {
+          pushToast({
+            closable: true,
+            status: 'error',
+            title: 'Clipboard not supported',
+          })
+          return false
+        }
+        setDisabled(true)
+
+        let id: string | undefined = undefined
+        let url = `${previewLocationOrigin}${previewLocationRoute}`
+        const onFinally = () => {
+          pushToast({
+            id,
+            closable: true,
+            status: 'success',
+            title: 'The URL is copied to the clipboard',
+          })
+          setDisabled(false)
+        }
+        const onError = (error: any) => {
+          pushToast({
+            closable: true,
+            status: 'error',
+            title: 'Copy failed',
+            description: error.message || error.toString(),
+          })
+          setDisabled(false)
+        }
+        if (
+          hasSecretSearchParams(initialUrl) &&
+          typeof ClipboardItem !== 'undefined'
+        ) {
+          const type = 'text/plain'
+          const resolvePreviewUrl = async () => {
+            id = pushToast({
+              closable: true,
+              title: 'Copying URL to clipboard…',
+            })
+            const previewUrlSecret = await createPreviewSecret(
+              client,
+              '@sanity/presentation',
+              typeof window === 'undefined' ? '' : location.href,
+              currentUser?.id,
+            )
+
+            const newUrl = setSecretSearchParams(
+              initialUrl,
+              previewUrlSecret.secret,
+              previewLocationRoute,
+            )
+            url = newUrl.toString()
+            return new Blob([url], { type })
+          }
+
+          // Try to save to clipboard then save it in the state if worked
+          const item = new ClipboardItem({
+            [type]: resolvePreviewUrl(),
+          })
+          navigator.clipboard.write([item]).then(onFinally).catch(onError)
+        } else {
+          navigator.clipboard.writeText(url).then(onFinally).catch(onError)
+        }
+      }}
+      text="Copy link"
+      icon={CopyIcon}
+    />
+  )
 }

--- a/packages/presentation/src/preview/PreviewLocationInput.tsx
+++ b/packages/presentation/src/preview/PreviewLocationInput.tsx
@@ -12,15 +12,27 @@ import {
 } from 'react'
 import { useActiveWorkspace } from 'sanity'
 
+import { PresentationPluginOptions } from '../types'
+
 export const PreviewLocationInput: FunctionComponent<{
   fontSize?: number
   onChange: (value: string) => void
+  openPopup: (url: string) => void
   origin: string
   padding?: number
   value: string
+  unstable_showUnsafeShareUrl: PresentationPluginOptions['unstable_showUnsafeShareUrl']
 }> = function (props) {
   const { basePath = '/' } = useActiveWorkspace()?.activeWorkspace || {}
-  const { fontSize = 1, onChange, origin, padding = 3, value } = props
+  const {
+    fontSize = 1,
+    onChange,
+    openPopup,
+    origin,
+    padding = 3,
+    value,
+    unstable_showUnsafeShareUrl,
+  } = props
   const inputRef = useRef<HTMLInputElement | null>(null)
   const [sessionValue, setSessionValue] = useState<string | undefined>(
     undefined,
@@ -32,6 +44,14 @@ export const PreviewLocationInput: FunctionComponent<{
   const handleChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
     setSessionValue(event.currentTarget.value)
   }, [])
+
+  const handleOpenPopup = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+      event.preventDefault()
+      openPopup(event.currentTarget.href)
+    },
+    [openPopup],
+  )
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLInputElement>) => {
@@ -117,18 +137,21 @@ export const PreviewLocationInput: FunctionComponent<{
         ref={inputRef}
         space={padding}
         suffix={
-          <Box padding={1} style={{ lineHeight: 0, zIndex: -1 }}>
-            <Button
-              as="a"
-              fontSize={fontSize}
-              href={origin + (sessionValue || value)}
-              icon={LaunchIcon}
-              padding={padding - 1}
-              mode="bleed"
-              rel="noreferrer"
-              target="_blank"
-            />
-          </Box>
+          unstable_showUnsafeShareUrl ? undefined : (
+            <Box padding={1} style={{ lineHeight: 0, zIndex: -1 }}>
+              <Button
+                as="a"
+                fontSize={fontSize}
+                href={origin + (sessionValue || value)}
+                icon={LaunchIcon}
+                mode="bleed"
+                onClick={handleOpenPopup as any}
+                padding={padding - 1}
+                rel="opener"
+                target="_blank"
+              />
+            </Box>
+          )
         }
         value={sessionValue === undefined ? `${origin}${value}` : sessionValue}
       />

--- a/packages/presentation/src/types.ts
+++ b/packages/presentation/src/types.ts
@@ -50,6 +50,7 @@ export interface PresentationPluginOptions {
   components?: {
     unstable_navigator?: NavigatorOptions
   }
+  unstable_showUnsafeShareUrl?: boolean
 }
 
 export interface PresentationStateParams {

--- a/packages/preview-kit-compat/src/useDocumentsInUse.ts
+++ b/packages/preview-kit-compat/src/useDocumentsInUse.ts
@@ -20,7 +20,7 @@ export function useDocumentsInUse(
   >()
   const [connected, setConnected] = useState(false)
   useEffect(() => {
-    if (window.self === window.top) {
+    if (window.self === window.top && !window.opener) {
       return
     }
     const channel = createChannelsNode<VisualEditingMsg>({

--- a/packages/preview-url-secret/src/withoutSecretSearchParams.ts
+++ b/packages/preview-url-secret/src/withoutSecretSearchParams.ts
@@ -10,3 +10,20 @@ export function withoutSecretSearchParams(url: URL): URL {
   newUrl.searchParams.delete(urlSearchParamPreviewSecret)
   return newUrl
 }
+
+/** @alpha */
+export function hasSecretSearchParams(url: URL): boolean {
+  return url.searchParams.has(urlSearchParamPreviewSecret)
+}
+
+/** @alpha */
+export function setSecretSearchParams(
+  url: URL,
+  secret: string,
+  redirectTo: string,
+): URL {
+  const newUrl = new URL(url)
+  newUrl.searchParams.set(urlSearchParamPreviewSecret, secret)
+  newUrl.searchParams.set(urlSearchParamPreviewPathname, redirectTo)
+  return newUrl
+}


### PR DESCRIPTION
# New experimental share URL button

Opt in to using it by:

```tsx
presentationTool({
  unstable_showUnsafeShareUrl: true, // defaults to `false`
})
```

Once enabled there's now a share menu next to the location input, rather than inside it, that opens a popover:

<img width="1410" alt="image" src="https://github.com/sanity-io/visual-editing/assets/81981/66efb87a-77ad-4769-9898-14c5cfb323d8">


# Improved popup mode

When using the "Open preview" popup mode it's now live, just like the iframe preview:

https://github.com/sanity-io/visual-editing/assets/81981/46464e73-7126-4159-8ed5-c6e2bd1c7a5f


