### PR TITLE
fix: use client perspective in loadQuery if not passed explicitly

### DIFF
--- a/apps/svelte/src/hooks.server.ts
+++ b/apps/svelte/src/hooks.server.ts
@@ -6,6 +6,7 @@ setServerClient(
   client.withConfig({
     token: SANITY_API_READ_TOKEN,
     useCdn: false,
+    perspective: 'previewDrafts',
     // stega: {
     //   ...client.config().stega,
     //   enabled: process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview',

--- a/apps/svelte/src/routes/shoes/+page.server.ts
+++ b/apps/svelte/src/routes/shoes/+page.server.ts
@@ -3,11 +3,6 @@ import { loadQuery } from '@sanity/svelte-loader'
 import type { PageServerLoad } from './$types'
 
 export const load: PageServerLoad = async () => {
-  const initial = await loadQuery<ShoesListResult>(
-    shoesList,
-    {},
-    { perspective: 'previewDrafts' },
-  )
-
+  const initial = await loadQuery<ShoesListResult>(shoesList, {})
   return { initial }
 }

--- a/apps/svelte/src/routes/shoes/[slug]/+page.server.ts
+++ b/apps/svelte/src/routes/shoes/[slug]/+page.server.ts
@@ -5,11 +5,7 @@ import type { PageServerLoad } from './$types'
 export const load: PageServerLoad = async ({ params }) => {
   const { slug } = params
 
-  const initial = await loadQuery<ShoeResult>(
-    shoe,
-    { slug },
-    { perspective: 'previewDrafts' },
-  )
+  const initial = await loadQuery<ShoeResult>(shoe, { slug })
 
   return { initial, params: { slug } }
 }

--- a/packages/react-loader/src/createQueryStore/server-only.ts
+++ b/packages/react-loader/src/createQueryStore/server-only.ts
@@ -33,7 +33,12 @@ export const createQueryStore = (
     sourceMap: ContentSourceMap | undefined
     perspective?: ClientPerspective
   }> => {
-    const { perspective = 'published', cache, next, stega } = _options
+    const { cache, next, stega } = _options
+    const perspective =
+      _options.perspective ||
+      unstable__serverClient.instance?.config().perspective ||
+      'published'
+
     if (
       perspective === 'previewDrafts' &&
       !unstable__serverClient.canPreviewDrafts

--- a/packages/react-loader/src/createQueryStore/universal.ts
+++ b/packages/react-loader/src/createQueryStore/universal.ts
@@ -40,7 +40,11 @@ export const createQueryStore = (
     params: QueryParams = {},
     options: Parameters<QueryStore['loadQuery']>[2] = {},
   ): Promise<QueryResponseInitial<QueryResponseResult>> => {
-    const { perspective = 'published' } = options
+    const perspective =
+      options.perspective ||
+      unstable__serverClient.instance?.config().perspective ||
+      'published'
+
     if (typeof document !== 'undefined') {
       throw new Error(
         'Cannot use `loadQuery` in a browser environment, you should use it inside a loader, getStaticProps, getServerSideProps, getInitialProps, or in a React Server Component.',

--- a/packages/svelte-loader/README.md
+++ b/packages/svelte-loader/README.md
@@ -62,7 +62,7 @@ export const client = createClient({
 })
 ```
 
-On the server, we use a Sanity client configured with a read token and CDN disabled to allow the fetching of draft content. We pass this client instance to `setServerClient` in the [server hooks](https://kit.svelte.dev/docs/hooks#server-hooks) file as this code will only be executed once during app initialization.
+On the server, we use a Sanity client configured with a read token, CDN disabled and specified perspective to allow the fetching of draft content. We pass this client instance to `setServerClient` in the [server hooks](https://kit.svelte.dev/docs/hooks#server-hooks) file as this code will only be executed once during app initialization.
 
 ```ts
 // src/hooks.server.ts
@@ -74,6 +74,7 @@ setServerClient(
   client.withConfig({
     token: SANITY_API_READ_TOKEN,
     useCdn: false,
+    perspective: 'previewDrafts',
   }),
 )
 ```
@@ -107,11 +108,7 @@ import type { PageServerLoad } from './$types'
 export const load: PageServerLoad = async ({ params }) => {
   const { slug } = params
 
-  const initial = loadQuery<PageResult>(
-    pageQuery,
-    { slug },
-    { perspective: 'previewDrafts' },
-  )
+  const initial = loadQuery<PageResult>(pageQuery, { slug })
 
   return { initial, params: { slug } }
 }

--- a/packages/svelte-loader/src/createQueryStore.ts
+++ b/packages/svelte-loader/src/createQueryStore.ts
@@ -39,7 +39,11 @@ export const createQueryStore = (
     params: QueryParams = {},
     options: Parameters<QueryStore['loadQuery']>[2] = {},
   ): Promise<QueryResponseInitial<QueryResponseResult>> => {
-    const { perspective = 'published' } = options
+    const perspective =
+      options.perspective ||
+      unstable__serverClient.instance?.config().perspective ||
+      'published'
+
     if (typeof document !== 'undefined') {
       throw new Error(
         'Cannot use `loadQuery` in a browser environment, you should use it inside a loader, getStaticProps, getServerSideProps, getInitialProps, or in a React Server Component.',


### PR DESCRIPTION
`loadQuery` was defaulting to using `published` if a perspective was not passed explicitly. Users may want to set perspective at client level when calling `setServerClient`, this PR allows for that.