### PR TITLE
feat(presentation): support create intent and document navigation

### DIFF
--- a/apps/studio/presentation/CustomNavigator.tsx
+++ b/apps/studio/presentation/CustomNavigator.tsx
@@ -2,43 +2,143 @@ import {
   usePresentationNavigate,
   usePresentationParams,
 } from '@sanity/presentation'
-import { Card, Stack, Text } from '@sanity/ui'
+import {
+  Box,
+  Button,
+  Card,
+  Flex,
+  Menu,
+  MenuButton,
+  MenuItem,
+  Stack,
+  Text,
+} from '@sanity/ui'
+import { AddIcon, BulbOutlineIcon, SchemaIcon } from '@sanity/icons'
+import { useIntentLink } from 'sanity/router'
 
 export function CustomNavigator() {
   const navigate = usePresentationNavigate()
-  const { preview } = usePresentationParams()
+  const params = usePresentationParams()
+  const { preview } = params
 
   return (
-    <Card>
-      <Stack padding={2} space={1}>
-        <Card
-          as="button"
-          onClick={() => navigate('/')}
-          padding={3}
-          pressed={preview === '/'}
-          radius={2}
-        >
-          <Text>Home</Text>
-        </Card>
-        <Card
-          as="button"
-          onClick={() => navigate('/projects')}
-          padding={3}
-          pressed={preview === '/projects'}
-          radius={2}
-        >
-          <Text>Projects</Text>
-        </Card>
-        <Card
-          as="button"
-          onClick={() => navigate('/products')}
-          padding={3}
-          pressed={preview === '/products'}
-          radius={2}
-        >
-          <Text>Products</Text>
-        </Card>
-      </Stack>
+    <Card flex={1} height="fill">
+      <Flex height="fill" direction="column" justify="space-between" flex={1}>
+        <Stack padding={2} space={1}>
+          <Card
+            as="button"
+            onClick={() => navigate('/')}
+            padding={3}
+            pressed={preview === '/'}
+            radius={2}
+          >
+            <Text>Home</Text>
+          </Card>
+          <Card
+            as="button"
+            onClick={() => navigate('/projects')}
+            padding={3}
+            pressed={preview === '/projects'}
+            radius={2}
+          >
+            <Text>Projects</Text>
+          </Card>
+          <Card
+            as="button"
+            onClick={() => navigate('/products')}
+            padding={3}
+            pressed={preview === '/products'}
+            radius={2}
+          >
+            <Text>Products</Text>
+          </Card>
+          <Card
+            as="button"
+            onClick={() =>
+              navigate('/product/highline', {
+                type: 'product',
+                id: '807cc05c-8c4c-443a-a9c1-198fd3fd7b16',
+              })
+            }
+            padding={3}
+            pressed={preview === '/product/highline'}
+            radius={2}
+          >
+            <Stack space={2}>
+              <Text size={0} muted>
+                Product
+              </Text>
+              <Text>Highline</Text>
+            </Stack>
+          </Card>
+        </Stack>
+        <Stack padding={2} space={1}>
+          <MenuButton
+            button={<Button icon={AddIcon} text="New Document" mode="ghost" />}
+            id="create-menu-button"
+            placement="top-start"
+            menu={
+              <Menu>
+                <MenuItem
+                  {...useIntentLink({
+                    intent: 'create',
+                    params: {
+                      type: 'project',
+                      mode: 'presentation',
+                      preview: params.preview,
+                    },
+                  })}
+                  as="a"
+                >
+                  <Flex align="center" gap={3}>
+                    <Box flex="none">
+                      <Text size={1}>
+                        <SchemaIcon />
+                      </Text>
+                    </Box>
+                    <Stack flex={1} space={2}>
+                      <Text size={1} weight="medium">
+                        Project
+                      </Text>
+                      <Text muted size={1}>
+                        Create a new project document
+                      </Text>
+                    </Stack>
+                  </Flex>
+                </MenuItem>
+                <MenuItem
+                  {...useIntentLink({
+                    intent: 'create',
+                    params: {
+                      type: 'product',
+                      mode: 'presentation',
+                      preview: params.preview,
+                    },
+                  })}
+                  as="a"
+                >
+                  <Flex align="center" gap={3}>
+                    <Box flex="none">
+                      <Text size={1}>
+                        <BulbOutlineIcon />
+                      </Text>
+                    </Box>
+                    <Stack flex={1} space={2}>
+                      <Text size={1} weight="medium">
+                        Product
+                      </Text>
+                      <Text muted size={1}>
+                        Create a new product document
+                      </Text>
+                    </Stack>
+                  </Flex>
+                </MenuItem>
+              </Menu>
+            }
+            popover={{ portal: true }}
+          />
+        </Stack>
+      </Flex>
     </Card>
   )
 }

--- a/packages/presentation/package.json
+++ b/packages/presentation/package.json
@@ -115,6 +115,7 @@
   "dependencies": {
     "@sanity/icons": "^2.8.0",
     "@sanity/preview-url-secret": "^1.5.3",
+    "@sanity/uuid": "3.0.2",
     "@types/lodash.isequal": "^4.5.8",
     "fast-deep-equal": "3.1.3",
     "framer-motion": "^10.18.0",

--- a/packages/presentation/src/PresentationNavigateContext.ts
+++ b/packages/presentation/src/PresentationNavigateContext.ts
@@ -1,6 +1,9 @@
 import { createContext } from 'react'
 
-export type PresentationNavigateContextValue = (preview: string) => void
+export type PresentationNavigateContextValue = (
+  preview: string | undefined,
+  document?: { type: string; id: string },
+) => void
 
 export const PresentationNavigateContext =
   createContext<PresentationNavigateContextValue | null>(null)

--- a/packages/presentation/src/PresentationNavigateProvider.tsx
+++ b/packages/presentation/src/PresentationNavigateProvider.tsx
@@ -1,9 +1,4 @@
-import {
-  FunctionComponent,
-  PropsWithChildren,
-  useCallback,
-  useMemo,
-} from 'react'
+import { FunctionComponent, PropsWithChildren, useCallback } from 'react'
 
 import {
   PresentationNavigateContext,
@@ -18,20 +13,15 @@ export const PresentationNavigateProvider: FunctionComponent<
 > = function (props) {
   const { children, navigate: _navigate } = props
 
-  const navigate = useCallback(
-    (preview: string) => {
-      _navigate({}, { preview })
+  const navigate = useCallback<PresentationNavigateContextValue>(
+    (preview, document = undefined) => {
+      _navigate(document || {}, preview ? { preview } : {})
     },
     [_navigate],
   )
 
-  const context = useMemo<PresentationNavigateContextValue>(
-    () => navigate,
-    [navigate],
-  )
-
   return (
-    <PresentationNavigateContext.Provider value={context}>
+    <PresentationNavigateContext.Provider value={navigate}>
       {children}
     </PresentationNavigateContext.Provider>
   )

--- a/packages/presentation/src/constants.ts
+++ b/packages/presentation/src/constants.ts
@@ -4,7 +4,6 @@ export const DEFAULT_TOOL_ICON = ComposeIcon
 export const DEFAULT_TOOL_NAME = 'presentation'
 export const DEFAULT_TOOL_TITLE = 'Presentation'
 
-export const CREATE_INTENT_MODE = 'presentation'
 export const EDIT_INTENT_MODE = 'presentation'
 
 // How long we wait until an iframe is loaded until we consider it to be slow and possibly failed

--- a/packages/presentation/src/constants.ts
+++ b/packages/presentation/src/constants.ts
@@ -4,6 +4,7 @@ export const DEFAULT_TOOL_ICON = ComposeIcon
 export const DEFAULT_TOOL_NAME = 'presentation'
 export const DEFAULT_TOOL_TITLE = 'Presentation'
 
+export const CREATE_INTENT_MODE = 'presentation'
 export const EDIT_INTENT_MODE = 'presentation'
 
 // How long we wait until an iframe is loaded until we consider it to be slow and possibly failed

--- a/packages/presentation/src/getIntentState.ts
+++ b/packages/presentation/src/getIntentState.ts
@@ -1,3 +1,4 @@
+import { uuid } from '@sanity/uuid'
 import { getPublishedId } from 'sanity'
 import { SearchParam } from 'sanity/router'
 
@@ -21,6 +22,14 @@ export function getIntentState(
       type: type || '*',
       id: getPublishedId(id),
       path,
+      _searchParams: Object.entries(searchParams),
+    }
+  }
+  if (intent === 'create') {
+    searchParams.preview = searchParams.preview || '/'
+    return {
+      type: type || '*',
+      id: id || uuid(),
       _searchParams: Object.entries(searchParams),
     }
   }

--- a/packages/presentation/src/plugin.tsx
+++ b/packages/presentation/src/plugin.tsx
@@ -8,7 +8,6 @@ import {
 } from 'sanity'
 
 import {
-  CREATE_INTENT_MODE,
   DEFAULT_TOOL_ICON,
   DEFAULT_TOOL_NAME,
   EDIT_INTENT_MODE,

--- a/packages/presentation/src/plugin.tsx
+++ b/packages/presentation/src/plugin.tsx
@@ -64,9 +64,7 @@ export const presentationTool = definePlugin<PresentationPluginOptions>(
         return false
       }
 
-      return 'mode' in params
-        ? { mode: params.mode === CREATE_INTENT_MODE }
-        : true
+      return 'template' in params ? { template: true } : true
     }
 
     function canHandleEditIntent(params: Record<string, unknown>) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -887,6 +887,9 @@ importers:
       '@sanity/preview-url-secret':
         specifier: ^1.5.3
         version: link:../preview-url-secret
+      '@sanity/uuid':
+        specifier: 3.0.2
+        version: 3.0.2
       '@types/lodash.isequal':
         specifier: ^4.5.8
         version: 4.5.8
@@ -8173,6 +8176,7 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+    bundledDependencies: false
 
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}


### PR DESCRIPTION
`unstable_navigator` related improvements to support the following within Presentation:

- navigate to a document by ID
- navigate to a new document creation intent