### PR TITLE
feat: add option to use cdn in loadquery

### DIFF
--- a/packages/react-loader/src/createQueryStore/server-only.ts
+++ b/packages/react-loader/src/createQueryStore/server-only.ts
@@ -38,6 +38,7 @@ export const createQueryStore = (
       _options.perspective ||
       unstable__serverClient.instance?.config().perspective ||
       'published'
+    const useCdn = _options.useCdn || unstable__serverClient.instance!.config().useCdn
 
     if (
       perspective === 'previewDrafts' &&
@@ -47,8 +48,6 @@ export const createQueryStore = (
         `You cannot use "previewDrafts" unless you set a "token" in the "client" instance you're pasing to "setServerClient".`,
       )
     }
-    // @TODO can this be removed, and `useCdn: undefined` be used instead?
-    const useCdn = unstable__serverClient.instance!.config().useCdn
 
     const { result, resultSourceMap } =
       await unstable__serverClient.instance!.fetch<QueryResponseResult>(

--- a/packages/react-loader/src/types.ts
+++ b/packages/react-loader/src/types.ts
@@ -112,7 +112,10 @@ export interface QueryStore {
   loadQuery: <QueryResponseResult>(
     query: string,
     params?: QueryParams,
-    options?: Pick<ResponseQueryOptions, 'perspective' | 'cache' | 'next'> & {
+    options?: Pick<
+      ResponseQueryOptions,
+      'perspective' | 'cache' | 'next' | 'useCdn'
+    > & {
       stega?: boolean | StegaConfig
     },
   ) => Promise<QueryResponseInitial<QueryResponseResult>>


### PR DESCRIPTION
In my application, I have a need to selectively set `useCdn` based on factors other than those that impact the current perspective or stega settings. So exposing this option when invoking `loadQuery` is required.