### PR TITLE
refactor: specify send and receive channel message types

### DIFF
--- a/apps/next-no-cache/src/components/VisualEditing/PostMessageQueries.tsx
+++ b/apps/next-no-cache/src/components/VisualEditing/PostMessageQueries.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { createChannelsNode } from '@sanity/channels'
-import {
-  type VisualEditingConnectionIds,
-  type VisualEditingMsg,
+import type {
+  LoaderMsg,
+  VisualEditingConnectionIds,
 } from '@sanity/visual-editing-helpers'
 import { useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
@@ -12,7 +12,7 @@ export function PostMessageReporter() {
   const router = useRouter()
   const revalidateRef = useRef(0)
   useEffect(() => {
-    const channel = createChannelsNode<VisualEditingMsg>({
+    const channel = createChannelsNode<LoaderMsg, LoaderMsg>({
       id: 'loaders' satisfies VisualEditingConnectionIds,
       connectTo: 'presentation' satisfies VisualEditingConnectionIds,
       onEvent: (type, data) => {

--- a/apps/next-server-only/src/components/VisualEditing/PostMessageQueries.tsx
+++ b/apps/next-server-only/src/components/VisualEditing/PostMessageQueries.tsx
@@ -2,8 +2,8 @@
 
 import { createChannelsNode } from '@sanity/channels'
 import {
+  type LoaderMsg,
   type VisualEditingConnectionIds,
-  type VisualEditingMsg,
 } from '@sanity/visual-editing-helpers'
 import { useEffect, useRef } from 'react'
 import { revalidate } from './actions'
@@ -11,7 +11,7 @@ import { revalidate } from './actions'
 export function PostMessageReporter() {
   const revalidateRef = useRef(0)
   useEffect(() => {
-    const channel = createChannelsNode<VisualEditingMsg>({
+    const channel = createChannelsNode<LoaderMsg, LoaderMsg>({
       id: 'loaders' satisfies VisualEditingConnectionIds,
       connectTo: 'presentation' satisfies VisualEditingConnectionIds,
       onEvent: (type, data) => {

--- a/packages/channels/src/types.ts
+++ b/packages/channels/src/types.ts
@@ -70,19 +70,21 @@ export type HandshakeMsgType = HandshakeMsgTypeTuple[number]
 /**
  * @public
  */
-export type ChannelsEventHandler<T extends ChannelMsg = ChannelMsg> = (
-  ...args: ToArgs<T>
+export type ChannelsEventHandler<Receives extends ChannelMsg = ChannelMsg> = (
+  ...args: ToArgs<Receives>
 ) => void
 
 /**
  * @public
  */
-export interface ChannelsControllerOptions<T extends ChannelMsg = ChannelMsg> {
+export interface ChannelsControllerOptions<
+  Receives extends ChannelMsg = ChannelMsg,
+> {
   id: string
-  connectTo: ChannelsControllerChannelOptions<T>[]
+  connectTo: ChannelsControllerChannelOptions<Receives>[]
   target: Window
   targetOrigin: string
-  onEvent?: ChannelsEventHandler<T>
+  onEvent?: ChannelsEventHandler<Receives>
   onStatusUpdate?: (status: ChannelStatus, connectionId: string) => void
 }
 
@@ -90,21 +92,23 @@ export interface ChannelsControllerOptions<T extends ChannelMsg = ChannelMsg> {
  * @public
  */
 export interface ChannelsControllerChannelOptions<
-  T extends ChannelMsg = ChannelMsg,
+  Receives extends ChannelMsg = ChannelMsg,
 > {
   id: string
   heartbeat?: boolean | number
   onStatusUpdate?: (status: ChannelStatus, connectionId: string) => void
-  onEvent?: ChannelsEventHandler<T>
+  onEvent?: ChannelsEventHandler<Receives>
 }
 
 /**
  * @internal
  */
-export interface ChannelsControllerChannel<T extends ChannelMsg = ChannelMsg> {
+export interface ChannelsControllerChannel<
+  Receives extends ChannelMsg = ChannelMsg,
+> {
   id: string | null
   buffer: ChannelMsg[]
-  config: ChannelsControllerChannelOptions<T>
+  config: ChannelsControllerChannelOptions<Receives>
   handler: (e: MessageEvent) => void
   heartbeat: number | undefined
   interval: number | undefined
@@ -114,19 +118,19 @@ export interface ChannelsControllerChannel<T extends ChannelMsg = ChannelMsg> {
 /**
  * @public
  */
-export interface ChannelsController<T extends ChannelMsg = ChannelMsg> {
+export interface ChannelsController<Sends extends ChannelMsg = ChannelMsg> {
   addSource: (source: MessageEventSource) => void
   destroy: () => void
-  send: (id: string | string[] | undefined, ...args: ToArgs<T>) => void
+  send: (id: string | string[] | undefined, ...args: ToArgs<Sends>) => void
 }
 
 /**
  * @public
  */
-export interface ChannelsNodeOptions<T extends ChannelMsg = ChannelMsg> {
+export interface ChannelsNodeOptions<Receives extends ChannelMsg = ChannelMsg> {
   id: string
   connectTo: string
-  onEvent?: ChannelsEventHandler<T>
+  onEvent?: ChannelsEventHandler<Receives>
   onStatusUpdate?: (status: ChannelStatus) => void
 }
 
@@ -144,8 +148,8 @@ export interface ChannelsNodeChannel {
 /**
  * @public
  */
-export interface ChannelsNode<T extends ChannelMsg = ChannelMsg> {
+export interface ChannelsNode<Sends extends ChannelMsg = ChannelMsg> {
   destroy: () => void
   inFrame: boolean
-  send: (...args: ToArgs<T>) => void
+  send: (...args: ToArgs<Sends>) => void
 }

--- a/packages/core-loader/src/live-mode/enableLiveMode.ts
+++ b/packages/core-loader/src/live-mode/enableLiveMode.ts
@@ -8,9 +8,9 @@ import {
 } from '@sanity/client'
 import { stegaEncodeSourceMap } from '@sanity/client/stega'
 import type {
+  LoaderMsg,
   LoaderPayloads,
   VisualEditingConnectionIds,
-  VisualEditingMsg,
 } from '@sanity/visual-editing-helpers'
 import { atom, MapStore } from 'nanostores'
 
@@ -51,7 +51,7 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
     }
   >()
 
-  const channel = createChannelsNode<VisualEditingMsg>({
+  const channel = createChannelsNode<LoaderMsg, LoaderMsg>({
     id: 'loaders' satisfies VisualEditingConnectionIds,
     connectTo: 'presentation' satisfies VisualEditingConnectionIds,
     onEvent: (type, data) => {

--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -10,6 +10,10 @@ import {
   getQueryCacheKey,
   isAltKey,
   isHotkey,
+  type LoaderMsg,
+  type OverlayMsg,
+  type PresentationMsg,
+  type PreviewKitMsg,
   type VisualEditingConnectionIds,
   type VisualEditingMsg,
 } from '@sanity/visual-editing-helpers'
@@ -107,7 +111,8 @@ export default function PresentationTool(props: {
 
   const iframeRef = useRef<HTMLIFrameElement>(null)
 
-  const [channel, setChannel] = useState<ChannelsController<VisualEditingMsg>>()
+  const [channel, setChannel] =
+    useState<ChannelsController<LoaderMsg | PresentationMsg>>()
 
   const [liveQueries, setLiveQueries] = useState<LiveQueriesState>({})
 
@@ -178,7 +183,10 @@ export default function PresentationTool(props: {
 
     if (!target) return
 
-    const nextChannel = createChannelsController<VisualEditingMsg>({
+    const nextChannel = createChannelsController<
+      PresentationMsg,
+      LoaderMsg | OverlayMsg | VisualEditingMsg | PreviewKitMsg
+    >({
       id: 'presentation' satisfies VisualEditingConnectionIds,
       target,
       targetOrigin,

--- a/packages/presentation/src/loader/LoaderQueries.tsx
+++ b/packages/presentation/src/loader/LoaderQueries.tsx
@@ -6,10 +6,7 @@ import type {
   QueryParams,
 } from '@sanity/client'
 import { applySourceDocuments, getPublishedId } from '@sanity/client/csm'
-import type {
-  LoaderPayloads,
-  VisualEditingMsg,
-} from '@sanity/visual-editing-helpers'
+import type { LoaderMsg, LoaderPayloads } from '@sanity/visual-editing-helpers'
 import {
   useQueryParams,
   useRevalidate,
@@ -27,7 +24,7 @@ import type { LiveQueriesState } from '../types'
 
 export interface LoaderQueriesProps {
   liveDocument: Partial<SanityDocument> | null | undefined
-  channel: ChannelsController<VisualEditingMsg> | undefined
+  channel: ChannelsController<LoaderMsg> | undefined
   perspective: ClientPerspective
   liveQueries: LiveQueriesState
   documentsOnPage: { _id: string; _type: string }[]
@@ -242,7 +239,7 @@ interface QuerySubscriptionProps
   perspective: ClientPerspective
   query: string
   params: QueryParams
-  channel: ChannelsController<VisualEditingMsg> | undefined
+  channel: ChannelsController<LoaderMsg> | undefined
 }
 function QuerySubscription(props: QuerySubscriptionProps) {
   const {

--- a/packages/presentation/src/loader/RevalidateTags.tsx
+++ b/packages/presentation/src/loader/RevalidateTags.tsx
@@ -1,13 +1,10 @@
 import type { ChannelsController } from '@sanity/channels'
-import type {
-  LoaderPayloads,
-  VisualEditingMsg,
-} from '@sanity/visual-editing-helpers'
+import type { LoaderMsg, LoaderPayloads } from '@sanity/visual-editing-helpers'
 import { useEffect, useMemo } from 'react'
 import { getPublishedId, useClient } from 'sanity'
 
 export interface RevalidateTagsProps {
-  channel: ChannelsController<VisualEditingMsg> | undefined
+  channel: ChannelsController<LoaderMsg> | undefined
 }
 
 export default function RevalidateTags(props: RevalidateTagsProps): null {

--- a/packages/preview-kit-compat/src/useDocumentsInUse.ts
+++ b/packages/preview-kit-compat/src/useDocumentsInUse.ts
@@ -1,8 +1,9 @@
 import { type ChannelsNode, createChannelsNode } from '@sanity/channels'
 import type { ContentSourceMapDocuments } from '@sanity/client/csm'
 import {
+  type PresentationMsg,
+  type PreviewKitMsg,
   type VisualEditingConnectionIds,
-  type VisualEditingMsg,
 } from '@sanity/visual-editing-helpers'
 import { useEffect, useState } from 'react'
 
@@ -16,14 +17,14 @@ export function useDocumentsInUse(
   dataset: string,
 ): void {
   const [channel, setChannel] = useState<
-    ChannelsNode<VisualEditingMsg> | undefined
+    ChannelsNode<PreviewKitMsg> | undefined
   >()
   const [connected, setConnected] = useState(false)
   useEffect(() => {
     if (window.self === window.top && !window.opener) {
       return
     }
-    const channel = createChannelsNode<VisualEditingMsg>({
+    const channel = createChannelsNode<PreviewKitMsg, PresentationMsg>({
       id: 'preview-kit' satisfies VisualEditingConnectionIds,
       connectTo: 'presentation' satisfies VisualEditingConnectionIds,
       onStatusUpdate(status) {

--- a/packages/visual-editing-helpers/src/types.ts
+++ b/packages/visual-editing-helpers/src/types.ts
@@ -71,24 +71,59 @@ export type PresentationMsg =
       data: undefined
     }
 
+/**@public */
+export interface VisualEditingPayloads {
+  documents: {
+    projectId: string
+    dataset: string
+    perspective: ClientPerspective
+    documents: ContentSourceMapDocuments
+  }
+  focus: SanityNode | SanityNodeLegacy
+  navigate: HistoryUpdate
+  toggle: {
+    enabled: boolean
+  }
+}
+
 /**
  * Messages emitted by the overlays package
- * @public
+ * @deprecated use VisualEditingMsg instead
  */
 export type OverlayMsg =
   | {
       type: 'overlay/focus'
-      data: SanityNode | SanityNodeLegacy
+      data: VisualEditingPayloads['focus']
     }
   | {
       type: 'overlay/navigate'
-      data: HistoryUpdate
+      data: VisualEditingPayloads['navigate']
     }
   | {
       type: 'overlay/toggle'
-      data: {
-        enabled: boolean
-      }
+      data: VisualEditingPayloads['toggle']
+    }
+
+/**
+ * Messages emitted by the visual-editing package
+ * @public
+ */
+export type VisualEditingMsg =
+  | {
+      type: 'visual-editing/focus'
+      data: VisualEditingPayloads['focus']
+    }
+  | {
+      type: 'visual-editing/navigate'
+      data: VisualEditingPayloads['navigate']
+    }
+  | {
+      type: 'visual-editing/toggle'
+      data: VisualEditingPayloads['toggle']
+    }
+  | {
+      type: 'visual-editing/documents'
+      data: VisualEditingPayloads['documents']
     }
 
 /** @public */
@@ -186,16 +221,6 @@ export type PreviewKitMsg = {
     documents: ContentSourceMapDocuments
   }
 }
-
-/**
- * Union type of visual editing related messages
- * @public
- */
-export type VisualEditingMsg =
-  | PresentationMsg
-  | LoaderMsg
-  | OverlayMsg
-  | PreviewKitMsg
 
 /**
  * Known Channel connection IDs

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -8,7 +8,8 @@ import {
 import {
   isAltKey,
   isHotkey,
-  type VisualEditingMsg,
+  type OverlayMsg,
+  type PresentationMsg,
 } from '@sanity/visual-editing-helpers'
 import {
   FunctionComponent,
@@ -75,7 +76,7 @@ export const Overlays: FunctionComponent<{
   const [overlayEnabled, setOverlayEnabled] = useState(true)
 
   const channelEventHandler = useCallback<
-    ChannelsEventHandler<VisualEditingMsg>
+    ChannelsEventHandler<PresentationMsg>
   >(
     (type, data) => {
       if (type === 'presentation/focus' && data.path?.length) {
@@ -94,7 +95,9 @@ export const Overlays: FunctionComponent<{
     [history],
   )
 
-  const { channel, status } = useChannel<VisualEditingMsg>(channelEventHandler)
+  const { channel, status } = useChannel<OverlayMsg, PresentationMsg>(
+    channelEventHandler,
+  )
 
   const overlayEventHandler: OverlayEventHandler = useCallback(
     (message) => {

--- a/packages/visual-editing/src/ui/useChannel.tsx
+++ b/packages/visual-editing/src/ui/useChannel.tsx
@@ -12,17 +12,20 @@ import { useEffect, useRef, useState } from 'react'
  * Hook for maintaining a channel between overlays and the presentation tool
  * @internal
  */
-export function useChannel<T extends ChannelMsg>(
-  handler: ChannelsEventHandler<T>,
+export function useChannel<
+  Sends extends ChannelMsg,
+  Receives extends ChannelMsg,
+>(
+  handler: ChannelsEventHandler<Receives>,
 ): {
-  channel: ChannelsNode<T> | undefined
+  channel: ChannelsNode<Sends> | undefined
   status: ChannelStatus | undefined
 } {
-  const channelRef = useRef<ChannelsNode<T>>()
+  const channelRef = useRef<ChannelsNode<Sends>>()
   const [status, setStatus] = useState<ChannelStatus>()
 
   useEffect(() => {
-    const channel = createChannelsNode<T>({
+    const channel = createChannelsNode<Sends, Receives>({
       id: 'overlays' satisfies VisualEditingConnectionIds,
       connectTo: 'presentation' satisfies VisualEditingConnectionIds,
       onEvent: handler,


### PR DESCRIPTION
Type updates to differentiate sent and received messages in various parts of the channels mechanism.

A nice to have as part of a larger bit of work, but submitting as a separate PR to avoid later merge conflicts.