### PR TITLE
feat(presentation): support parameterized templates

### DIFF
--- a/apps/studio/presentation/CustomNavigator.tsx
+++ b/apps/studio/presentation/CustomNavigator.tsx
@@ -13,7 +13,12 @@ import {
   Stack,
   Text,
 } from '@sanity/ui'
-import { AddIcon, BulbOutlineIcon, SchemaIcon } from '@sanity/icons'
+import {
+  AddIcon,
+  BulbOutlineIcon,
+  DocumentIcon,
+  SchemaIcon,
+} from '@sanity/icons'
 import { useIntentLink } from 'sanity/router'
 
 export function CustomNavigator() {
@@ -79,6 +84,39 @@ export function CustomNavigator() {
             placement="top-start"
             menu={
               <Menu>
+                <MenuItem
+                  {...useIntentLink({
+                    intent: 'create',
+                    params: [
+                      {
+                        type: 'page',
+                        mode: 'presentation',
+                        preview: params.preview,
+                        template: 'page-basic',
+                      },
+                      {
+                        title: 'Basic Page',
+                      },
+                    ],
+                  })}
+                  as="a"
+                >
+                  <Flex align="center" gap={3}>
+                    <Box flex="none">
+                      <Text size={1}>
+                        <DocumentIcon />
+                      </Text>
+                    </Box>
+                    <Stack flex={1} space={2}>
+                      <Text size={1} weight="medium">
+                        Page (Basic)
+                      </Text>
+                      <Text muted size={1}>
+                        Create a new page document
+                      </Text>
+                    </Stack>
+                  </Flex>
+                </MenuItem>
                 <MenuItem
                   {...useIntentLink({
                     intent: 'create',

--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -22,7 +22,25 @@ import SpaceType from './models/documents/SpaceType'
 const sharedSettings = definePlugin({
   name: 'sharedSettings',
   plugins: [structureTool(), assist(), unsplashImageAsset(), debugSecrets()],
-  schema,
+  schema: {
+    ...schema,
+    templates: [
+      {
+        id: 'page-basic',
+        title: 'Basic page',
+        schemaType: 'page',
+        parameters: [{ name: 'title', title: 'Page Title', type: 'string' }],
+        value: (params: any) => {
+          return {
+            title: params.title,
+            slug: {
+              current: 'basic-slug',
+            },
+          }
+        },
+      },
+    ],
+  },
 })
 
 // If we're on a preview deployment we'll want the iframe URLs to point to the same preview deployment

--- a/packages/presentation/src/editor/DocumentPane.tsx
+++ b/packages/presentation/src/editor/DocumentPane.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from 'react'
 import { Path } from 'sanity'
+import { decodeJsonParams } from 'sanity/router'
 import {
   DocumentPane as DeskDocumentPane,
   DocumentPaneNode,
@@ -33,6 +34,7 @@ export function DocumentPane(props: {
   onFocusPath: (path: Path) => void
 }): ReactElement {
   const { documentId, documentType, params, onDeskParams, onFocusPath } = props
+  const { template, templateParams } = params
   const { devMode } = usePresentationTool()
 
   const paneDocumentNode: DocumentPaneNode = useMemo(
@@ -41,11 +43,13 @@ export function DocumentPane(props: {
       options: {
         id: documentId,
         type: documentType,
+        template,
+        templateParameters: decodeJsonParams(templateParams),
       },
       title: '',
       type: 'document',
     }),
-    [documentId, documentType],
+    [documentId, documentType, template, templateParams],
   )
 
   const [errorParams, setErrorParams] = useState<{

--- a/packages/presentation/src/getIntentState.ts
+++ b/packages/presentation/src/getIntentState.ts
@@ -1,6 +1,6 @@
 import { uuid } from '@sanity/uuid'
 import { getPublishedId } from 'sanity'
-import { SearchParam } from 'sanity/router'
+import { encodeJsonParams, SearchParam } from 'sanity/router'
 
 import { PresentationStateParams } from './types'
 
@@ -32,6 +32,13 @@ export function getIntentState(
       searchParams.preview ||
       new URLSearchParams(window.location.search).get('preview') ||
       '/'
+
+    if (payload && typeof payload === 'object') {
+      searchParams.templateParams = encodeJsonParams(
+        payload as Record<string, unknown>,
+      )
+    }
+
     return {
       type: type || '*',
       id: id || uuid(),

--- a/packages/presentation/src/router.ts
+++ b/packages/presentation/src/router.ts
@@ -5,6 +5,6 @@ export const router = route.create(
   { __unsafe_disableScopedSearchParams: true },
   [
     route.intents('/intent'),
-    route.create('/:type', [route.create('/:id'), route.create('/:id/:path')]),
+    route.create(':type', [route.create(':id', [route.create(':path')])]),
   ],
 )

--- a/packages/presentation/src/types.ts
+++ b/packages/presentation/src/types.ts
@@ -72,6 +72,7 @@ export interface DeskDocumentPaneParams {
   rev?: string
   since?: string
   template?: string
+  templateParams?: string
   view?: string
 
   // assist

--- a/packages/presentation/src/useParams.ts
+++ b/packages/presentation/src/useParams.ts
@@ -53,6 +53,7 @@ export function useParams({
       rev: routerSearchParams.rev,
       since: routerSearchParams.since,
       template: routerSearchParams.template,
+      templateParams: routerSearchParams.templateParams,
       view: routerSearchParams.view,
       // assist
       pathKey: routerSearchParams.pathKey,
@@ -69,6 +70,7 @@ export function useParams({
       rev: params.rev,
       since: params.since,
       template: params.template,
+      templateParams: params.templateParams,
       view: params.view,
       // assist
       pathKey: params.pathKey,
@@ -78,15 +80,16 @@ export function useParams({
     })
     return pruned
   }, [
+    params.comment,
     params.inspect,
+    params.instruction,
     params.path,
+    params.pathKey,
     params.rev,
     params.since,
     params.template,
+    params.templateParams,
     params.view,
-    params.pathKey,
-    params.instruction,
-    params.comment,
   ])
 
   const routerStateRef = useRef(routerState)
@@ -122,6 +125,12 @@ export function useParams({
             ...routerSearchState,
             ...nextSearchState,
           })
+
+          // If the document has changed, clear the template and templateParams
+          if (routerState.id !== state.id) {
+            delete searchState.template
+            delete searchState.templateParams
+          }
 
           state._searchParams = Object.entries(searchState).reduce(
             (acc, [key, value]) => [...acc, [key, value]],


### PR DESCRIPTION
This adds support for [parameterized templates](https://www.sanity.io/docs/initial-value-templates#66d873e2136f).

Also fixes support for initial value templates, we ostensibly supported this via a search param but the value wasn't being passed in the `DocumentPaneNode`.