### PR TITLE
refactor: use event subscriber pattern over config handler

### DIFF
--- a/apps/next-no-cache/src/components/VisualEditing/PostMessageQueries.tsx
+++ b/apps/next-no-cache/src/components/VisualEditing/PostMessageQueries.tsx
@@ -15,17 +15,19 @@ export function PostMessageReporter() {
     const channel = createChannelsNode<LoaderMsg, LoaderMsg>({
       id: 'loaders' satisfies VisualEditingConnectionIds,
       connectTo: 'presentation' satisfies VisualEditingConnectionIds,
-      onEvent: (type, data) => {
-        if (type === 'loader/revalidate-tags') {
-          console.log('revalidate', data, 'calling router refresh')
-          clearTimeout(revalidateRef.current)
-          router.refresh()
-          revalidateRef.current = window.setTimeout(() => {
-            router.refresh()
-          }, 1000)
-        }
-      },
     })
+
+    channel.subscribe((type, data) => {
+      if (type === 'loader/revalidate-tags') {
+        console.log('revalidate', data, 'calling router refresh')
+        clearTimeout(revalidateRef.current)
+        router.refresh()
+        revalidateRef.current = window.setTimeout(() => {
+          router.refresh()
+        }, 1000)
+      }
+    })
+
     return () => {
       channel.destroy()
     }

--- a/apps/next-server-only/src/components/VisualEditing/PostMessageQueries.tsx
+++ b/apps/next-server-only/src/components/VisualEditing/PostMessageQueries.tsx
@@ -14,17 +14,19 @@ export function PostMessageReporter() {
     const channel = createChannelsNode<LoaderMsg, LoaderMsg>({
       id: 'loaders' satisfies VisualEditingConnectionIds,
       connectTo: 'presentation' satisfies VisualEditingConnectionIds,
-      onEvent: (type, data) => {
-        if (type === 'loader/revalidate-tags') {
-          console.log('revalidate', data, 'calling router refresh')
-          clearTimeout(revalidateRef.current)
-          revalidate({ tags: data.tags as string[] })
-          revalidateRef.current = window.setTimeout(() => {
-            revalidate({ tags: data.tags as string[] })
-          }, 1000)
-        }
-      },
     })
+
+    channel.subscribe((type, data) => {
+      if (type === 'loader/revalidate-tags') {
+        console.log('revalidate', data, 'calling router refresh')
+        clearTimeout(revalidateRef.current)
+        revalidate({ tags: data.tags as string[] })
+        revalidateRef.current = window.setTimeout(() => {
+          revalidate({ tags: data.tags as string[] })
+        }, 1000)
+      }
+    })
+
     return () => {
       channel.destroy()
     }

--- a/apps/nuxt/pages/channels/child.vue
+++ b/apps/nuxt/pages/channels/child.vue
@@ -28,16 +28,21 @@
 <script lang="ts" setup>
 import { type ChannelsNode, createChannelsNode } from '@sanity/channels'
 
+interface Sends {
+  type: 'child/event'
+  data: { datetime: string }
+}
+
 const log = ref<any[]>([])
-const channel = ref<ChannelsNode | undefined>()
+const channel = ref<ChannelsNode<Sends, any> | undefined>()
 
 onMounted(() => {
   channel.value = createChannelsNode({
     id: 'child',
     connectTo: 'parent',
-    onEvent(type, data) {
-      log.value.unshift({ ...data, type })
-    },
+  })
+  channel.value.subscribe((type, data) => {
+    log.value.unshift({ ...data, type })
   })
 })
 

--- a/packages/channels/src/types.ts
+++ b/packages/channels/src/types.ts
@@ -77,6 +77,14 @@ export type ChannelsEventHandler<Receives extends ChannelMsg = ChannelMsg> = (
 /**
  * @public
  */
+export type ChannelsControllerStatusSubscriber = (
+  status: ChannelStatus,
+  connectionId: string,
+) => void
+
+/**
+ * @public
+ */
 export interface ChannelsControllerOptions<
   Receives extends ChannelMsg = ChannelMsg,
 > {
@@ -85,7 +93,7 @@ export interface ChannelsControllerOptions<
   target: Window
   targetOrigin: string
   onEvent?: ChannelsEventHandler<Receives>
-  onStatusUpdate?: (status: ChannelStatus, connectionId: string) => void
+  onStatusUpdate?: ChannelsControllerStatusSubscriber
 }
 
 /**
@@ -96,8 +104,8 @@ export interface ChannelsControllerChannelOptions<
 > {
   id: string
   heartbeat?: boolean | number
-  onStatusUpdate?: (status: ChannelStatus, connectionId: string) => void
   onEvent?: ChannelsEventHandler<Receives>
+  onStatusUpdate?: ChannelsControllerStatusSubscriber
 }
 
 /**
@@ -127,11 +135,9 @@ export interface ChannelsController<Sends extends ChannelMsg = ChannelMsg> {
 /**
  * @public
  */
-export interface ChannelsNodeOptions<Receives extends ChannelMsg = ChannelMsg> {
+export interface ChannelsNodeOptions {
   id: string
   connectTo: string
-  onEvent?: ChannelsEventHandler<Receives>
-  onStatusUpdate?: (status: ChannelStatus) => void
 }
 
 /**
@@ -148,8 +154,25 @@ export interface ChannelsNodeChannel {
 /**
  * @public
  */
-export interface ChannelsNode<Sends extends ChannelMsg = ChannelMsg> {
+export type ChannelsEventSubscriber<Receives extends ChannelMsg> = (
+  ...args: ToArgs<Receives>
+) => void
+
+/**
+ * @public
+ */
+export type ChannelsNodeStatusSubscriber = (status: ChannelStatus) => void
+
+/**
+ * @public
+ */
+export interface ChannelsNode<
+  Sends extends ChannelMsg,
+  Receives extends ChannelMsg,
+> {
   destroy: () => void
   inFrame: boolean
+  onStatusUpdate: (subscriber: ChannelsNodeStatusSubscriber) => () => void
   send: (...args: ToArgs<Sends>) => void
+  subscribe: (subscriber: ChannelsEventSubscriber<Receives>) => () => void
 }

--- a/packages/preview-kit-compat/src/useDocumentsInUse.ts
+++ b/packages/preview-kit-compat/src/useDocumentsInUse.ts
@@ -17,7 +17,7 @@ export function useDocumentsInUse(
   dataset: string,
 ): void {
   const [channel, setChannel] = useState<
-    ChannelsNode<PreviewKitMsg> | undefined
+    ChannelsNode<PreviewKitMsg, PresentationMsg> | undefined
   >()
   const [connected, setConnected] = useState(false)
   useEffect(() => {
@@ -27,14 +27,16 @@ export function useDocumentsInUse(
     const channel = createChannelsNode<PreviewKitMsg, PresentationMsg>({
       id: 'preview-kit' satisfies VisualEditingConnectionIds,
       connectTo: 'presentation' satisfies VisualEditingConnectionIds,
-      onStatusUpdate(status) {
-        if (status === 'connected') {
-          setConnected(true)
-        } else if (status === 'disconnected') {
-          setConnected(false)
-        }
-      },
     })
+
+    channel.onStatusUpdate((status) => {
+      if (status === 'connected') {
+        setConnected(true)
+      } else if (status === 'disconnected') {
+        setConnected(false)
+      }
+    })
+
     const timeout = setTimeout(() => setChannel(channel), 0)
     return () => {
       clearTimeout(timeout)

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -1,7 +1,11 @@
+import { ChannelsNode } from '@sanity/channels'
 import type {
   HistoryUpdate,
+  OverlayMsg as OverlayChannelsMsg,
+  PresentationMsg,
   SanityNode,
   SanityNodeLegacy,
+  VisualEditingMsg,
 } from '@sanity/visual-editing-helpers'
 
 export type {
@@ -195,3 +199,21 @@ export interface _EventHandlers {
   mouseleave: (event: MouseEvent) => void
   mousemove: (event: MouseEvent) => void
 }
+
+/**
+ * @internal
+ */
+export type VisualEditingChannelSends = OverlayChannelsMsg | VisualEditingMsg
+
+/**
+ * @internal
+ */
+export type VisualEditingChannelReceives = PresentationMsg
+
+/**
+ * @internal
+ */
+export type VisualEditingChannel = ChannelsNode<
+  VisualEditingChannelSends,
+  VisualEditingChannelReceives
+>

--- a/packages/visual-editing/src/ui/VisualEditing.tsx
+++ b/packages/visual-editing/src/ui/VisualEditing.tsx
@@ -1,0 +1,23 @@
+import { FunctionComponent } from 'react'
+
+import { VisualEditingOptions } from './enableVisualEditing'
+import { Overlays } from './Overlays'
+import { useChannel } from './useChannel'
+
+/**
+ * @internal
+ */
+export const VisualEditing: FunctionComponent<VisualEditingOptions> = function (
+  props,
+) {
+  const { history, zIndex } = props
+  const channel = useChannel()
+
+  return (
+    channel && (
+      <>
+        <Overlays channel={channel} history={history} zIndex={zIndex} />
+      </>
+    )
+  )
+}

--- a/packages/visual-editing/src/ui/enableVisualEditing.tsx
+++ b/packages/visual-editing/src/ui/enableVisualEditing.tsx
@@ -1,7 +1,7 @@
 import type { Root } from 'react-dom/client'
 
 import { OVERLAY_ID } from '../constants'
-import { HistoryAdapter } from '../types'
+import type { HistoryAdapter } from '../types'
 
 /**
  * Cleanup function used when e.g. unmounting
@@ -40,11 +40,9 @@ export function enableVisualEditing(
   const controller = new AbortController()
 
   // Lazy load everything needed to render the app
-  Promise.all([import('react-dom/client'), import('./Overlays')]).then(
-    ([reactClient, { Overlays }]) => {
+  Promise.all([import('react-dom/client'), import('./VisualEditing')]).then(
+    ([reactClient, { VisualEditing }]) => {
       if (controller.signal.aborted) return
-
-      const { history, zIndex } = options
 
       if (!node) {
         node = document.createElement('div')
@@ -58,7 +56,11 @@ export function enableVisualEditing(
         root = createRoot(node)
       }
 
-      root.render(<Overlays history={history} zIndex={zIndex} />)
+      root.render(
+        <>
+          <VisualEditing {...options} />
+        </>,
+      )
     },
   )
 

--- a/packages/visual-editing/src/ui/useChannel.tsx
+++ b/packages/visual-editing/src/ui/useChannel.tsx
@@ -1,45 +1,30 @@
-import {
-  type ChannelMsg,
-  type ChannelsEventHandler,
-  type ChannelsNode,
-  type ChannelStatus,
-  createChannelsNode,
-} from '@sanity/channels'
+import { type ChannelsNode, createChannelsNode } from '@sanity/channels'
 import type { VisualEditingConnectionIds } from '@sanity/visual-editing-helpers'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
+
+import {
+  VisualEditingChannelReceives as Receives,
+  VisualEditingChannelSends as Sends,
+} from '../types'
 
 /**
  * Hook for maintaining a channel between overlays and the presentation tool
  * @internal
  */
-export function useChannel<
-  Sends extends ChannelMsg,
-  Receives extends ChannelMsg,
->(
-  handler: ChannelsEventHandler<Receives>,
-): {
-  channel: ChannelsNode<Sends> | undefined
-  status: ChannelStatus | undefined
-} {
-  const channelRef = useRef<ChannelsNode<Sends>>()
-  const [status, setStatus] = useState<ChannelStatus>()
+export function useChannel(): ChannelsNode<Sends, Receives> | undefined {
+  const channelRef = useRef<ChannelsNode<Sends, Receives>>()
 
   useEffect(() => {
     const channel = createChannelsNode<Sends, Receives>({
       id: 'overlays' satisfies VisualEditingConnectionIds,
       connectTo: 'presentation' satisfies VisualEditingConnectionIds,
-      onEvent: handler,
-      onStatusUpdate: setStatus,
     })
     channelRef.current = channel
     return () => {
       channel.destroy()
       channelRef.current = undefined
     }
-  }, [handler])
+  }, [])
 
-  return {
-    channel: channelRef.current,
-    status,
-  }
+  return channelRef.current
 }

--- a/packages/visual-editing/src/util/findSanityNodes.ts
+++ b/packages/visual-editing/src/util/findSanityNodes.ts
@@ -42,7 +42,7 @@ export function findCommonPath(first: string, second: string): string {
 
 /**
  * Returns common Sanity node data from multiple nodes
- * If doocument paths are present, tries to resolve a common path
+ * If document paths are present, tries to resolve a common path
  * @param nodes An array of Sanity nodes
  * @returns A single sanity node or undefined
  * @internal


### PR DESCRIPTION
This is some prep work primarily for comments (another PR for that will follow once the studio side changes are merged and released).

It replaces the handlers passed as config to channel nodes with a subscriber pattern, i.e. `channel.subscribe(...)` and `channel.onStatusUpdate(...)` (LMK you have thoughts on those method names 😄).

It should be useful for separating subscriber logic as and when we add more components to visual editing, rather than adding more nodes.


