### PR TITLE
refactor(visual-editing): use state over ref for channel instance

### DIFF
--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -1,4 +1,4 @@
-import { ChannelStatus } from '@sanity/channels'
+import type { ChannelStatus } from '@sanity/channels'
 import {
   isHTMLAnchorElement,
   isHTMLElement,
@@ -57,7 +57,7 @@ function raf2(fn: () => void) {
  * @internal
  */
 export const Overlays: FunctionComponent<{
-  channel?: VisualEditingChannel
+  channel: VisualEditingChannel
   history?: HistoryAdapter
   zIndex?: string | number
 }> = function (props) {
@@ -78,8 +78,8 @@ export const Overlays: FunctionComponent<{
   const [overlayEnabled, setOverlayEnabled] = useState(true)
 
   useEffect(() => {
-    const unsubscribeFromStatus = channel?.onStatusUpdate(setStatus)
-    const unsubscribeFromEvents = channel?.subscribe((type, data) => {
+    const unsubscribeFromStatus = channel.onStatusUpdate(setStatus)
+    const unsubscribeFromEvents = channel.subscribe((type, data) => {
       if (type === 'presentation/focus' && data.path?.length) {
         dispatch({ type, data })
       } else if (type === 'presentation/blur') {
@@ -92,19 +92,19 @@ export const Overlays: FunctionComponent<{
     })
 
     return () => {
-      unsubscribeFromEvents?.()
-      unsubscribeFromStatus?.()
+      unsubscribeFromEvents()
+      unsubscribeFromStatus()
     }
   }, [channel, history])
 
   const overlayEventHandler: OverlayEventHandler = useCallback(
     (message) => {
       if (message.type === 'element/click') {
-        channel?.send('overlay/focus', message.sanity)
+        channel.send('overlay/focus', message.sanity)
       } else if (message.type === 'overlay/activate') {
-        channel?.send('overlay/toggle', { enabled: true })
+        channel.send('overlay/toggle', { enabled: true })
       } else if (message.type === 'overlay/deactivate') {
-        channel?.send('overlay/toggle', { enabled: false })
+        channel.send('overlay/toggle', { enabled: false })
       }
       dispatch(message)
     },
@@ -114,7 +114,7 @@ export const Overlays: FunctionComponent<{
   const controller = useController(
     rootElement,
     overlayEventHandler,
-    !!channel?.inFrame,
+    !!channel.inFrame,
   )
 
   useEffect(() => {
@@ -176,7 +176,7 @@ export const Overlays: FunctionComponent<{
   }, [setOverlayEnabled])
 
   useEffect(() => {
-    if (channel && history) {
+    if (history) {
       return history.subscribe((update) => {
         channel.send('overlay/navigate', update)
       })
@@ -232,7 +232,7 @@ export const Overlays: FunctionComponent<{
               rect={rect}
               focused={focused}
               hovered={hovered}
-              showActions={!channel?.inFrame}
+              showActions={!channel.inFrame}
               sanity={sanity}
               wasMaybeCollapsed={focused && wasMaybeCollapsed}
             />

--- a/packages/visual-editing/src/ui/useChannel.tsx
+++ b/packages/visual-editing/src/ui/useChannel.tsx
@@ -1,6 +1,6 @@
 import { type ChannelsNode, createChannelsNode } from '@sanity/channels'
 import type { VisualEditingConnectionIds } from '@sanity/visual-editing-helpers'
-import { useEffect, useRef } from 'react'
+import { useEffect, useState } from 'react'
 
 import {
   VisualEditingChannelReceives as Receives,
@@ -12,19 +12,18 @@ import {
  * @internal
  */
 export function useChannel(): ChannelsNode<Sends, Receives> | undefined {
-  const channelRef = useRef<ChannelsNode<Sends, Receives>>()
+  const [channel, setChannel] = useState<ChannelsNode<Sends, Receives>>()
 
   useEffect(() => {
-    const channel = createChannelsNode<Sends, Receives>({
+    const channelInstance = createChannelsNode<Sends, Receives>({
       id: 'overlays' satisfies VisualEditingConnectionIds,
       connectTo: 'presentation' satisfies VisualEditingConnectionIds,
     })
-    channelRef.current = channel
+    setChannel(channelInstance)
     return () => {
-      channel.destroy()
-      channelRef.current = undefined
+      channelInstance.destroy()
     }
   }, [])
 
-  return channelRef.current
+  return channel
 }


### PR DESCRIPTION
Fixes failing overlays: Channel was stored as a ref, which means no reactivity, which is needed in order to render the Overlays element.