### PR TITLE
feat: support comments intent

### DIFF
--- a/apps/svelte/src/routes/shoes/[slug]/+page.svelte
+++ b/apps/svelte/src/routes/shoes/[slug]/+page.svelte
@@ -16,6 +16,10 @@
   $: [coverImage, ...otherImages] = product?.media || []
 </script>
 
+<svelte:head>
+  <title>{product.title}</title>
+</svelte:head>
+
 <div class="min-h-screen bg-white">
   <nav aria-label="Breadcrumb" class="pt-16 sm:pt-24">
     <ol

--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -449,7 +449,7 @@ export default function PresentationTool(props: {
       }
       return undefined
     },
-    [name, params, workspace.name],
+    [name, params.preview, workspace.name],
   )
 
   return (

--- a/packages/presentation/src/constants.ts
+++ b/packages/presentation/src/constants.ts
@@ -4,6 +4,9 @@ export const DEFAULT_TOOL_ICON = ComposeIcon
 export const DEFAULT_TOOL_NAME = 'presentation'
 export const DEFAULT_TOOL_TITLE = 'Presentation'
 
+// @todo import from core sanity package
+export const COMMENTS_INSPECTOR_NAME = 'sanity/structure/comments'
+
 export const EDIT_INTENT_MODE = 'presentation'
 
 // How long we wait until an iframe is loaded until we consider it to be slow and possibly failed

--- a/packages/presentation/src/types.ts
+++ b/packages/presentation/src/types.ts
@@ -118,3 +118,9 @@ export interface LiveQueriesStateValue {
    */
   heartbeat: number | false
 }
+
+/** @internal */
+export interface FrameState {
+  title: string | undefined
+  url: string | undefined
+}

--- a/packages/presentation/src/useParams.ts
+++ b/packages/presentation/src/useParams.ts
@@ -5,6 +5,7 @@ import { debounce } from './lib/debounce'
 import { parseRouterState } from './lib/parse'
 import {
   DeskDocumentPaneParams,
+  FrameState,
   PresentationNavigate,
   PresentationParams,
   PresentationSearchParams,
@@ -24,7 +25,7 @@ export function useParams({
   routerNavigate,
   routerState,
   routerSearchParams,
-  previewRef,
+  frameStateRef,
 }: {
   initialPreviewUrl: URL
   routerNavigate: RouterContextValue['navigate']
@@ -32,7 +33,7 @@ export function useParams({
   routerSearchParams: {
     [k: string]: string
   }
-  previewRef: MutableRefObject<string | undefined>
+  frameStateRef: MutableRefObject<FrameState>
 }): {
   deskParams: DeskDocumentPaneParams
   navigate: PresentationNavigate
@@ -138,13 +139,13 @@ export function useParams({
           )
 
           const replace =
-            forceReplace ?? searchState.preview === previewRef.current
+            forceReplace ?? searchState.preview === frameStateRef.current.url
 
           routerNavigate(state, { replace })
         },
         50,
       ),
-    [routerNavigate, previewRef],
+    [routerNavigate, frameStateRef],
   )
 
   return {

--- a/packages/visual-editing-helpers/src/types.ts
+++ b/packages/visual-editing-helpers/src/types.ts
@@ -46,6 +46,7 @@ export type SanityNodeLegacy = {
  */
 export type HistoryUpdate = {
   type: 'push' | 'pop' | 'replace'
+  title?: string
   url: string
 }
 
@@ -80,6 +81,9 @@ export interface VisualEditingPayloads {
     documents: ContentSourceMapDocuments
   }
   focus: SanityNode | SanityNodeLegacy
+  meta: {
+    title: string
+  }
   navigate: HistoryUpdate
   toggle: {
     enabled: boolean
@@ -120,6 +124,10 @@ export type VisualEditingMsg =
   | {
       type: 'visual-editing/toggle'
       data: VisualEditingPayloads['toggle']
+    }
+  | {
+      type: 'visual-editing/meta'
+      data: VisualEditingPayloads['meta']
     }
   | {
       type: 'visual-editing/documents'

--- a/packages/visual-editing/src/ui/Meta.ts
+++ b/packages/visual-editing/src/ui/Meta.ts
@@ -1,0 +1,36 @@
+import { FunctionComponent, useEffect } from 'react'
+
+import { type VisualEditingChannel } from '../types'
+
+/**
+ * @internal
+ */
+export const Meta: FunctionComponent<{
+  channel?: VisualEditingChannel
+}> = function (props) {
+  const { channel } = props
+
+  useEffect(() => {
+    const sendMeta = () => {
+      channel?.send('visual-editing/meta', { title: document.title })
+    }
+
+    const observer = new MutationObserver(([mutation]) => {
+      if (mutation.target.nodeName === 'TITLE') {
+        sendMeta()
+      }
+    })
+
+    observer.observe(document.head, {
+      subtree: true,
+      characterData: true,
+      childList: true,
+    })
+
+    sendMeta()
+
+    return () => observer.disconnect()
+  }, [channel])
+
+  return null
+}

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -178,6 +178,7 @@ export const Overlays: FunctionComponent<{
   useEffect(() => {
     if (history) {
       return history.subscribe((update) => {
+        update.title = update.title || document.title
         channel.send('overlay/navigate', update)
       })
     }

--- a/packages/visual-editing/src/ui/VisualEditing.tsx
+++ b/packages/visual-editing/src/ui/VisualEditing.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from 'react'
 
 import { VisualEditingOptions } from './enableVisualEditing'
+import { Meta } from './Meta'
 import { Overlays } from './Overlays'
 import { useChannel } from './useChannel'
 
@@ -17,6 +18,7 @@ export const VisualEditing: FunctionComponent<VisualEditingOptions> = function (
     channel && (
       <>
         <Overlays channel={channel} history={history} zIndex={zIndex} />
+        <Meta channel={channel} />
       </>
     )
   )


### PR DESCRIPTION
As part of displaying Presentation related intent links. PR does a few things:

- Adds a `CommentIntentProvider` for providing intent link data.
- Adds a new channel message type for reporting the document title.
- Adds an optional parameter to the navigation message type for explicitly providing a title.