### PR TITLE
doc: correct Next.js draftMode().isEnabled usage

### DIFF
--- a/packages/visual-editing/README.md
+++ b/packages/visual-editing/README.md
@@ -79,7 +79,7 @@ export default function RootLayout({
     <html lang="en">
       <body>
         {children}
-        {draftMode().isEnabled() && (
+        {draftMode().isEnabled && (
           <VisualEditing
             zIndex={1000} // Optional
           />


### PR DESCRIPTION
This updates the Next.js app router example to the correct way of using `draftMode().isEnabled`. 