### PR TITLE
feat(visual-editing): report documents on page

### DIFF
--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -149,6 +149,7 @@ export default function PresentationTool(props: {
 
   const [documentsOnPage, setDocumentsOnPage] = useDocumentsOnPage(
     state.perspective,
+    frameStateRef,
   )
 
   const projectId = useProjectId()
@@ -226,13 +227,19 @@ export default function PresentationTool(props: {
           heartbeat: true,
           onStatusUpdate: setOverlaysConnection,
           onEvent(type, data) {
-            if (type === 'overlay/focus' && 'id' in data) {
+            if (
+              (type === 'visual-editing/focus' || type === 'overlay/focus') &&
+              'id' in data
+            ) {
               navigate({
                 type: data.type,
                 id: data.id,
                 path: data.path,
               })
-            } else if (type === 'overlay/navigate') {
+            } else if (
+              type === 'visual-editing/navigate' ||
+              type === 'overlay/navigate'
+            ) {
               const { title, url } = data
               if (frameStateRef.current.url !== url) {
                 navigate({}, { preview: url })
@@ -240,11 +247,21 @@ export default function PresentationTool(props: {
               frameStateRef.current = { title, url }
             } else if (type === 'visual-editing/meta') {
               frameStateRef.current.title = data.title
-            } else if (type === 'overlay/toggle') {
+            } else if (
+              type === 'visual-editing/toggle' ||
+              type === 'overlay/toggle'
+            ) {
               dispatch({
                 type: ACTION_VISUAL_EDITING_OVERLAYS_TOGGLE,
                 enabled: data.enabled,
               })
+            } else if (type === 'visual-editing/documents') {
+              setDocumentsOnPage(
+                'visual-editing',
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                data.perspective as unknown as any,
+                data.documents,
+              )
             }
           },
         },
@@ -259,6 +276,7 @@ export default function PresentationTool(props: {
               data.dataset === dataset
             ) {
               setDocumentsOnPage(
+                'loaders',
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 data.perspective as unknown as any,
                 data.documents,
@@ -300,6 +318,7 @@ export default function PresentationTool(props: {
               data.dataset === dataset
             ) {
               setDocumentsOnPage(
+                'preview-kit',
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 data.perspective as unknown as any,
                 data.documents,

--- a/packages/presentation/src/lib/debounce.ts
+++ b/packages/presentation/src/lib/debounce.ts
@@ -1,9 +1,9 @@
-export function debounce<F extends (...args: any[]) => void>(
+export function debounce<F extends (...args: Parameters<F>) => ReturnType<F>>(
   fn: F,
   timeout: number,
 ): F {
-  let timer: any
-  return ((...args: any[]) => {
+  let timer: ReturnType<typeof setTimeout>
+  return ((...args: Parameters<F>) => {
     clearTimeout(timer)
     timer = setTimeout(() => {
       fn.apply(fn, args)

--- a/packages/visual-editing-helpers/src/types.ts
+++ b/packages/visual-editing-helpers/src/types.ts
@@ -18,9 +18,7 @@ export type QueryCacheKey = `${string}-${string}`
  * @public
  */
 export type SanityNode = {
-  /** @deprecated */
   projectId?: string
-  /** @deprecated */
   dataset?: string
   id: string
   path: string
@@ -31,13 +29,13 @@ export type SanityNode = {
 }
 
 /**
- * Data resolved from a (legacy) Sanity node
+ * Data resolved from a Sanity Stega node
  * @public
  */
-export type SanityNodeLegacy = {
+export type SanityStegaNode = {
   origin: string
   href: string
-  data?: string
+  data?: unknown
 }
 
 /**
@@ -75,12 +73,12 @@ export type PresentationMsg =
 /**@public */
 export interface VisualEditingPayloads {
   documents: {
-    projectId: string
-    dataset: string
+    projectId?: string
+    dataset?: string
     perspective: ClientPerspective
     documents: ContentSourceMapDocuments
   }
-  focus: SanityNode | SanityNodeLegacy
+  focus: SanityNode | SanityStegaNode
   meta: {
     title: string
   }

--- a/packages/visual-editing/src/index.ts
+++ b/packages/visual-editing/src/index.ts
@@ -24,7 +24,7 @@ export type {
   OverlayOptions,
   OverlayRect,
   SanityNode,
-  SanityNodeLegacy,
+  SanityStegaNode,
 } from './types'
 export {
   type DisableVisualEditing,

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -4,14 +4,14 @@ import type {
   OverlayMsg as OverlayChannelsMsg,
   PresentationMsg,
   SanityNode,
-  SanityNodeLegacy,
+  SanityStegaNode,
   VisualEditingMsg,
 } from '@sanity/visual-editing-helpers'
 
 export type {
   HistoryUpdate,
   SanityNode,
-  SanityNodeLegacy,
+  SanityStegaNode,
 } from '@sanity/visual-editing-helpers'
 
 /**
@@ -41,7 +41,7 @@ export interface OverlayMsgElement<T extends string>
 
 /** @public */
 export type OverlayMsgElementActivate = OverlayMsgElement<'activate'> & {
-  sanity: SanityNode | SanityNodeLegacy
+  sanity: SanityNode | SanityStegaNode
   rect: OverlayRect
 }
 
@@ -59,7 +59,7 @@ export type OverlayMsgElementDeactivate = OverlayMsgElement<'deactivate'>
 
 /** @public */
 export type OverlayMsgElementClick = OverlayMsgElement<'click'> & {
-  sanity: SanityNode | SanityNodeLegacy
+  sanity: SanityNode | SanityStegaNode
 }
 
 /** @public */
@@ -72,7 +72,7 @@ export type OverlayMsgElementMouseLeave = OverlayMsgElement<'mouseleave'>
 
 /** @public */
 export type OverlayMsgElementRegister = OverlayMsgElement<'register'> & {
-  sanity: SanityNode | SanityNodeLegacy
+  sanity: SanityNode | SanityStegaNode
   rect: OverlayRect
 }
 
@@ -142,7 +142,7 @@ export interface ElementState {
   focused: ElementFocusedState
   hovered: boolean
   rect: OverlayRect
-  sanity: SanityNode | SanityNodeLegacy
+  sanity: SanityNode | SanityStegaNode
 }
 
 /**
@@ -174,7 +174,7 @@ export interface _SanityNodeElements {
  */
 export interface _ResolvedElement {
   elements: _SanityNodeElements
-  sanity: SanityNode | SanityNodeLegacy
+  sanity: SanityNode | SanityStegaNode
 }
 
 /**
@@ -185,7 +185,7 @@ export interface _OverlayElement {
   id: string
   elements: _SanityNodeElements
   handlers: _EventHandlers
-  sanity: SanityNode | SanityNodeLegacy
+  sanity: SanityNode | SanityStegaNode
 }
 
 /**

--- a/packages/visual-editing/src/ui/ElementOverlay.tsx
+++ b/packages/visual-editing/src/ui/ElementOverlay.tsx
@@ -9,7 +9,7 @@ import {
   ElementFocusedState,
   OverlayRect,
   SanityNode,
-  SanityNodeLegacy,
+  SanityStegaNode,
 } from '../types'
 
 const Root = styled(Card)`
@@ -102,7 +102,7 @@ export const ElementOverlay = memo(function ElementOverlay(props: {
   hovered: boolean
   rect: OverlayRect
   showActions: boolean
-  sanity: SanityNode | SanityNodeLegacy
+  sanity: SanityNode | SanityStegaNode
   wasMaybeCollapsed: boolean
 }) {
   const { focused, hovered, rect, showActions, sanity, wasMaybeCollapsed } =

--- a/packages/visual-editing/src/util/findSanityNodes.ts
+++ b/packages/visual-editing/src/util/findSanityNodes.ts
@@ -1,7 +1,7 @@
 import { decodeSanityNodeData } from '@sanity/visual-editing-helpers/csm'
 
 import { OVERLAY_ID } from '../constants'
-import { _ResolvedElement, SanityNode, SanityNodeLegacy } from '../types'
+import { _ResolvedElement, SanityNode, SanityStegaNode } from '../types'
 import { findNonInlineElement } from './findNonInlineElement'
 import { testAndDecodeStega } from './stega'
 
@@ -14,7 +14,7 @@ const isImgElement = (el: HTMLElement): el is HTMLImageElement =>
 const isTimeElement = (el: HTMLElement): el is HTMLTimeElement =>
   el.tagName === 'TIME'
 
-function isSanityNode(node: SanityNode | SanityNodeLegacy): node is SanityNode {
+function isSanityNode(node: SanityNode | SanityStegaNode): node is SanityNode {
   return 'path' in node
 }
 
@@ -48,8 +48,8 @@ export function findCommonPath(first: string, second: string): string {
  * @internal
  */
 export function findCommonSanityData(
-  nodes: (SanityNode | SanityNodeLegacy)[],
-): SanityNode | SanityNodeLegacy | undefined {
+  nodes: (SanityNode | SanityStegaNode)[],
+): SanityNode | SanityStegaNode | undefined {
   // If there are no nodes, or inconsistent node types
   if (
     !nodes.length ||
@@ -95,7 +95,7 @@ export function findSanityNodes(
 ): _ResolvedElement[] {
   const elements: _ResolvedElement[] = []
 
-  function addElement(element: HTMLElement, data: string) {
+  function addElement(element: HTMLElement, data: SanityStegaNode | string) {
     const sanity = decodeSanityNodeData(data)
     if (!sanity) {
       return
@@ -171,6 +171,7 @@ export function findSanityNodes(
           continue
         } else if (isTimeElement(node)) {
           const data = testAndDecodeStega(node.dateTime, true)
+          if (!data) continue
           addElement(node, data)
         }
 

--- a/packages/visual-editing/src/util/stega.ts
+++ b/packages/visual-editing/src/util/stega.ts
@@ -1,3 +1,4 @@
+import type { SanityStegaNode } from '@sanity/visual-editing-helpers'
 import { vercelStegaDecode } from '@vercel/stega'
 
 import { VERCEL_STEGA_REGEX } from '../constants'
@@ -11,24 +12,26 @@ export function testVercelStegaRegex(input: string): boolean {
   return VERCEL_STEGA_REGEX.test(input)
 }
 
-export function decodeStega(str: string, isAltText = false): string {
-  const decoded = vercelStegaDecode<{
-    origin?: string
-    href?: string
-    data?: unknown
-  }>(str)
+export function decodeStega(
+  str: string,
+  isAltText = false,
+): SanityStegaNode | null {
+  const decoded = vercelStegaDecode<SanityStegaNode>(str)
   if (!decoded || decoded.origin !== 'sanity.io') {
-    return ''
+    return null
   }
   if (isAltText) {
     decoded.href = decoded.href?.replace('.alt', '')
   }
-  return JSON.stringify(decoded)
+  return decoded
 }
 
-export function testAndDecodeStega(str: string, isAltText = false): string {
+export function testAndDecodeStega(
+  str: string,
+  isAltText = false,
+): SanityStegaNode | null {
   if (testVercelStegaRegex(str)) {
     return decodeStega(str, isAltText)
   }
-  return ''
+  return null
 }


### PR DESCRIPTION
Adds document reporting from the `visual-editing` package. This means loaders or preview kit are not strictly required for reporting documents.

Each method of document reporting now provides a key to `setDocumentsOnPage`, so the cache can store them as separate objects, which are merged and deduped by when returned as `documentsOnPage`. The entire cache is replaced when some new documents are received and the frame url has changed.

Also removes some unnecessary JSON stringifying and parsing when traversing and decoding overlay nodes.