### PR TITLE
feat(core-loader): createDataAttribute

### DIFF
--- a/packages/core-loader/package.json
+++ b/packages/core-loader/package.json
@@ -58,6 +58,9 @@
     "*": {
       "encode-data-attribute": [
         "./dist/encode-data-attribute.d.ts"
+      ],
+      "create-data-attribute": [
+        "./dist/create-data-attribute.d.ts"
       ]
     }
   },

--- a/packages/core-loader/package.json
+++ b/packages/core-loader/package.json
@@ -37,6 +37,17 @@
       "import": "./dist/encode-data-attribute.js",
       "default": "./dist/encode-data-attribute.js"
     },
+    "./create-data-attribute": {
+      "types": "./dist/create-data-attribute.d.ts",
+      "source": "./src/createDataAttribute.ts",
+      "require": "./dist/create-data-attribute.cjs",
+      "node": {
+        "module": "./dist/create-data-attribute.js",
+        "import": "./dist/create-data-attribute.cjs.js"
+      },
+      "import": "./dist/create-data-attribute.js",
+      "default": "./dist/create-data-attribute.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",

--- a/packages/core-loader/src/createDataAttribute.ts
+++ b/packages/core-loader/src/createDataAttribute.ts
@@ -5,124 +5,108 @@ import { encodeSanityNodeData } from '@sanity/visual-editing-helpers/csm'
 /**
  * @public
  */
-export type CreateDataAttributeStudioOptions = {
-  baseUrl: string
+export interface CreateDataAttributeProps {
+  baseUrl?: string
   dataset?: string
+  id?: string
+  path?: StudioPathLike
   projectId?: string
   tool?: string
+  type?: string
   workspace?: string
 }
 
 /**
  * @public
  */
-export type CreateDataAttributeDocument = {
-  id: string
-  type: string
+export type CreateDataAttribute = {
+  /**
+   * @public
+   * Returns a string representation of the data attribute
+   * @param path - An optional path to concatenate with any existing path
+   */
+  (path?: StudioPathLike): string
+  /**
+   * @public
+   * Concatenate the data attribute current path with a new path
+   * @param path - A path to concatenate with any existing path
+   */
+  scope(path: StudioPathLike): CreateDataAttribute
+  /**
+   * @public
+   * Combines the current data attribute props with additional props
+   * @param props - New props to merge with any existing props
+   */
+  combine(props: CreateDataAttributeProps): CreateDataAttribute
+  /**
+   * @public
+   * Returns a string representation of the data attribute
+   */
+  toString(): string
 }
 
 /**
  * @public
  */
-export type CreateDataAttributeFromPath = {
-  (path: StudioPathLike): string | undefined
-  scope: (path: StudioPathLike) => CreateDataAttributeFromPath
-}
-
-/**
- * @public
- */
-export type CreateDataAttributeFromDocument = (
-  document: CreateDataAttributeDocument,
-  path?: StudioPathLike,
-) => CreateDataAttributeFromPath
-
-/**
- * @internal
- */
-function createScopedDataAttributeWithDocument(
-  studioOptions: CreateDataAttributeStudioOptions,
-  document: CreateDataAttributeDocument,
-  basePath?: StudioPathLike,
-): CreateDataAttributeFromPath {
-  const parse = (path?: StudioPathLike) => {
+export function createDataAttribute(
+  props: CreateDataAttributeProps,
+): CreateDataAttribute {
+  // Internal function for normalizing a path
+  function normalizePath(path?: StudioPathLike) {
     if (!path) return []
     return typeof path === 'string' ? studioPath.fromString(path) : path
   }
 
-  const parsedBasePath = parse(basePath)
+  // Internal function for building a data attribute string
+  function toString(props: CreateDataAttributeProps): string {
+    if (!props.id)
+      throw new Error('`id` is required to create a data attribute')
+    if (!props.type)
+      throw new Error('`type` is required to create a data attribute')
+    if (!props.path || !props.path.length)
+      throw new Error('`path` is required to create a data attribute')
 
-  return Object.assign(
-    (path: StudioPathLike) =>
-      createDataAttribute(studioOptions, document, [
-        ...parsedBasePath,
-        ...parse(path),
-      ]),
-    {
-      scope: (scope: StudioPathLike) =>
-        createScopedDataAttributeWithDocument(studioOptions, document, [
-          ...parsedBasePath,
-          ...parse(scope),
-        ]),
-    },
-  )
-}
-
-/**
- * @public
- */
-export function createDataAttribute(
-  studioOptions: CreateDataAttributeStudioOptions,
-): CreateDataAttributeFromDocument
-export function createDataAttribute(
-  studioOptions: CreateDataAttributeStudioOptions,
-  document: CreateDataAttributeDocument,
-): CreateDataAttributeFromPath
-export function createDataAttribute(
-  studioOptions: CreateDataAttributeStudioOptions,
-  document: CreateDataAttributeDocument,
-  path: StudioPathLike,
-): string
-export function createDataAttribute(
-  studioOptions: CreateDataAttributeStudioOptions,
-  document?: CreateDataAttributeDocument,
-  path?: StudioPathLike,
-): CreateDataAttributeFromDocument | CreateDataAttributeFromPath | string {
-  if (!document) {
-    function createDataAttributeWithStudioOptions(
-      document: CreateDataAttributeDocument,
-    ): CreateDataAttributeFromPath
-    function createDataAttributeWithStudioOptions(
-      document: CreateDataAttributeDocument,
-      path: StudioPathLike,
-    ): string
-    // eslint-disable-next-line no-inner-declarations
-    function createDataAttributeWithStudioOptions(
-      document: CreateDataAttributeDocument,
-      path?: StudioPathLike,
-    ): CreateDataAttributeFromPath | string {
-      return path
-        ? createDataAttribute(studioOptions, document, path)
-        : createDataAttribute(studioOptions, document)
-    }
-
-    return createDataAttributeWithStudioOptions
-  }
-
-  const createDataAttributeWithDocument = (path: StudioPathLike) => {
     const attrs = {
-      baseUrl: studioOptions.baseUrl,
-      workspace: studioOptions.workspace,
-      tool: studioOptions.tool,
-      type: document.type,
-      id: document.id,
-      path: typeof path === 'string' ? path : studioPath.toString(path),
+      baseUrl: props.baseUrl || '/',
+      workspace: props.workspace,
+      tool: props.tool,
+      type: props.type,
+      id: props.id,
+      path:
+        typeof props.path === 'string'
+          ? props.path
+          : studioPath.toString(props.path),
     } satisfies SanityNode
 
     return encodeSanityNodeData(attrs)!
   }
 
-  return path
-    ? createDataAttributeWithDocument(path)
-    : createScopedDataAttributeWithDocument(studioOptions, document)
+  // The returned function call, calls the internal `toString` function with an optional concatenated path
+  const DataAttribute: CreateDataAttribute = function (path?: StudioPathLike) {
+    return toString({
+      ...props,
+      path: [...normalizePath(props.path), ...normalizePath(path)],
+    })
+  }
+
+  // Alternative to the function call, but does not accept a path to concatenate
+  DataAttribute.toString = function () {
+    return toString(props)
+  }
+
+  DataAttribute.combine = function (attrs: CreateDataAttributeProps) {
+    return createDataAttribute({
+      ...props,
+      ...attrs,
+    })
+  }
+
+  DataAttribute.scope = function (path: StudioPathLike) {
+    return createDataAttribute({
+      ...props,
+      path: [...normalizePath(props.path), ...normalizePath(path)],
+    })
+  }
+
+  return DataAttribute
 }

--- a/packages/core-loader/src/createDataAttribute.ts
+++ b/packages/core-loader/src/createDataAttribute.ts
@@ -1,0 +1,128 @@
+import { studioPath, type StudioPathLike } from '@sanity/client/csm'
+import type { SanityNode } from '@sanity/visual-editing-helpers'
+import { encodeSanityNodeData } from '@sanity/visual-editing-helpers/csm'
+
+/**
+ * @public
+ */
+export type CreateDataAttributeStudioOptions = {
+  baseUrl: string
+  dataset?: string
+  projectId?: string
+  tool?: string
+  workspace?: string
+}
+
+/**
+ * @public
+ */
+export type CreateDataAttributeDocument = {
+  id: string
+  type: string
+}
+
+/**
+ * @public
+ */
+export type CreateDataAttributeFromPath = {
+  (path: StudioPathLike): string | undefined
+  scope: (path: StudioPathLike) => CreateDataAttributeFromPath
+}
+
+/**
+ * @public
+ */
+export type CreateDataAttributeFromDocument = (
+  document: CreateDataAttributeDocument,
+  path?: StudioPathLike,
+) => CreateDataAttributeFromPath
+
+/**
+ * @internal
+ */
+function createScopedDataAttributeWithDocument(
+  studioOptions: CreateDataAttributeStudioOptions,
+  document: CreateDataAttributeDocument,
+  basePath?: StudioPathLike,
+): CreateDataAttributeFromPath {
+  const parse = (path?: StudioPathLike) => {
+    if (!path) return []
+    return typeof path === 'string' ? studioPath.fromString(path) : path
+  }
+
+  const parsedBasePath = parse(basePath)
+
+  return Object.assign(
+    (path: StudioPathLike) =>
+      createDataAttribute(studioOptions, document, [
+        ...parsedBasePath,
+        ...parse(path),
+      ]),
+    {
+      scope: (scope: StudioPathLike) =>
+        createScopedDataAttributeWithDocument(studioOptions, document, [
+          ...parsedBasePath,
+          ...parse(scope),
+        ]),
+    },
+  )
+}
+
+/**
+ * @public
+ */
+export function createDataAttribute(
+  studioOptions: CreateDataAttributeStudioOptions,
+): CreateDataAttributeFromDocument
+export function createDataAttribute(
+  studioOptions: CreateDataAttributeStudioOptions,
+  document: CreateDataAttributeDocument,
+): CreateDataAttributeFromPath
+export function createDataAttribute(
+  studioOptions: CreateDataAttributeStudioOptions,
+  document: CreateDataAttributeDocument,
+  path: StudioPathLike,
+): string
+export function createDataAttribute(
+  studioOptions: CreateDataAttributeStudioOptions,
+  document?: CreateDataAttributeDocument,
+  path?: StudioPathLike,
+): CreateDataAttributeFromDocument | CreateDataAttributeFromPath | string {
+  if (!document) {
+    function createDataAttributeWithStudioOptions(
+      document: CreateDataAttributeDocument,
+    ): CreateDataAttributeFromPath
+    function createDataAttributeWithStudioOptions(
+      document: CreateDataAttributeDocument,
+      path: StudioPathLike,
+    ): string
+    // eslint-disable-next-line no-inner-declarations
+    function createDataAttributeWithStudioOptions(
+      document: CreateDataAttributeDocument,
+      path?: StudioPathLike,
+    ): CreateDataAttributeFromPath | string {
+      return path
+        ? createDataAttribute(studioOptions, document, path)
+        : createDataAttribute(studioOptions, document)
+    }
+
+    return createDataAttributeWithStudioOptions
+  }
+
+  const createDataAttributeWithDocument = (path: StudioPathLike) => {
+    const attrs = {
+      baseUrl: studioOptions.baseUrl,
+      workspace: studioOptions.workspace,
+      tool: studioOptions.tool,
+      type: document.type,
+      id: document.id,
+      path: typeof path === 'string' ? path : studioPath.toString(path),
+    } satisfies SanityNode
+
+    return encodeSanityNodeData(attrs)!
+  }
+
+  return path
+    ? createDataAttributeWithDocument(path)
+    : createScopedDataAttributeWithDocument(studioOptions, document)
+}

--- a/packages/core-loader/test/createDataAttribute.test.ts
+++ b/packages/core-loader/test/createDataAttribute.test.ts
@@ -15,6 +15,17 @@ describe('createDataAttribute', () => {
     ).toMatchInlineSnapshot(snapshot)
   })
 
+  test('returns a resolved string (2 steps)', () => {
+    const fromDocument = createDataAttribute({ baseUrl })
+    expect(fromDocument({ id, type }, path)).toMatchInlineSnapshot(snapshot)
+  })
+
+  test('returns a resolved string (3 steps)', () => {
+    const fromDocument = createDataAttribute({ baseUrl })
+    const fromPath = fromDocument({ id, type })
+    expect(fromPath(path)).toMatchInlineSnapshot(snapshot)
+  })
+
   test('returns a function if document is omitted', () => {
     expect(createDataAttribute({ baseUrl })).toBeTypeOf('function')
   })
@@ -25,22 +36,17 @@ describe('createDataAttribute', () => {
     )
   })
 
-  test('returns a function if path is omitted after scoping', () => {
-    expect(createDataAttribute({ baseUrl })({ id, type })).toBeTypeOf(
-      'function',
+  test('returns a function if path is omitted (2 steps)', () => {
+    const fromDocument = createDataAttribute({ baseUrl })
+    const fromPath = fromDocument({ id, type })
+    expect(fromPath).toBeTypeOf('function')
+  })
+
+  test('returns a resolved string using `scope`', () => {
+    const fromPath = createDataAttribute({ baseUrl }, { id, type })
+    const scoped = fromPath.scope(['sections'])
+    expect(scoped([{ _key: '0bd049fc047a' }, 'style'])).toMatchInlineSnapshot(
+      snapshot,
     )
-  })
-
-  test('returns a resolved string if first scoped to studio', () => {
-    const createFromDocument = createDataAttribute({ baseUrl })
-    const createFromPath = createFromDocument({ id, type })
-    expect(createFromPath(path)).toMatchInlineSnapshot(snapshot)
-  })
-
-  test('returns a resolved string if first scoped to path', () => {
-    const createFromDocument = createDataAttribute({ baseUrl })
-    const createFromPath = createFromDocument({ id, type })
-    const scoped = createFromPath.scope(['sections', { _key: '0bd049fc047a' }])
-    expect(scoped('style')).toMatchInlineSnapshot(snapshot)
   })
 })

--- a/packages/core-loader/test/createDataAttribute.test.ts
+++ b/packages/core-loader/test/createDataAttribute.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest'
+
+import { createDataAttribute } from '../src/createDataAttribute'
+
+describe('createDataAttribute', () => {
+  const type = 'page'
+  const id = 'drafts.home'
+  const path = 'sections:0bd049fc047a.style'
+  const baseUrl = '/studio'
+  const snapshot = `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2Fstudio"`
+
+  test('returns a resolved string', () => {
+    expect(
+      createDataAttribute({ baseUrl }, { id, type }, path),
+    ).toMatchInlineSnapshot(snapshot)
+  })
+
+  test('returns a function if document is omitted', () => {
+    expect(createDataAttribute({ baseUrl })).toBeTypeOf('function')
+  })
+
+  test('returns a function if path is omitted', () => {
+    expect(createDataAttribute({ baseUrl }, { id, type })).toBeTypeOf(
+      'function',
+    )
+  })
+
+  test('returns a function if path is omitted after scoping', () => {
+    expect(createDataAttribute({ baseUrl })({ id, type })).toBeTypeOf(
+      'function',
+    )
+  })
+
+  test('returns a resolved string if first scoped to studio', () => {
+    const createFromDocument = createDataAttribute({ baseUrl })
+    const createFromPath = createFromDocument({ id, type })
+    expect(createFromPath(path)).toMatchInlineSnapshot(snapshot)
+  })
+
+  test('returns a resolved string if first scoped to path', () => {
+    const createFromDocument = createDataAttribute({ baseUrl })
+    const createFromPath = createFromDocument({ id, type })
+    const scoped = createFromPath.scope(['sections', { _key: '0bd049fc047a' }])
+    expect(scoped('style')).toMatchInlineSnapshot(snapshot)
+  })
+})

--- a/packages/react-loader/src/index.ts
+++ b/packages/react-loader/src/index.ts
@@ -1,2 +1,3 @@
 export * from './createQueryStore/universal'
 export * from './useEncodeDataAttribute'
+export * from '@sanity/core-loader/create-data-attribute'

--- a/packages/svelte-loader/src/index.ts
+++ b/packages/svelte-loader/src/index.ts
@@ -15,3 +15,4 @@ export type {
   WithEncodeDataAttribute,
 } from './types'
 export * from './useEncodeDataAttribute'
+export * from '@sanity/core-loader/create-data-attribute'


### PR DESCRIPTION
# `createDataAttribute`

### Draft for visibility and until API is decided.

## Considerations

- Is this trying to do too much within a single function?
- Are the type names too verbose?

## Overview

| Function                                                           | Returns                              |
| ------------------------------------------------------------------ | ------------------------------------ |
| `createDataAttribute({baseUrl})`                                   | Function scoped to studio            |
| `createDataAttribute({baseUrl}, {id, type})`                       | Function scoped to studio & document |
| `createDataAttribute({baseUrl})({id, type})`                       | Function scoped to studio & document |
| `createDataAttribute({baseUrl}, {id, type}).scope(rootPath)`       | Function scoped to path              |
| `createDataAttribute({baseUrl})({id, type}).scope(rootPath)`       | Function scoped to path              |
| `createDataAttribute({baseUrl}, {id, type}, path)`                 | String                               |
| `createDataAttribute({baseUrl})({id, type})(path)`                 | String                               |
| `createDataAttribute({baseUrl})({id, type}).scope(rootPath)(path)` | String                               |

## Example use

```ts
// ./data-attribute.ts
const studioOptions = { baseUrl: "/studio", workspace: "next" };
export const studioDataAttr = createDataAttribute(studioOptions);
```

```tsx
// ./routes/route.tsx
import {studioDataAttr} from '../data-attribute'

export default async function() {
  const page = await client.fetch(...)
  const dataAttr = useMemo(() => studioDataAttr({id: page._id, type: page._type}), [page])

  return (
  <div>
    <h1 data-sanity={dataAttr('title')}>{page.subtitle}</h1>
    <h2 data-sanity={dataAttr('subtitle')}>{page.subtitle}</h2>
  </div>)
}
```

## Todo

- [x] Export `createDataAttribute` from framework specific loaders
