### PR TITLE
docs: fixed imports from stega client

### DIFF
--- a/packages/react-loader/README.md
+++ b/packages/react-loader/README.md
@@ -51,7 +51,7 @@ Later in the server side of the app, you setup the client. The `.server.ts` suff
 
 ```ts
 // ./src/app/sanity.loader.server.ts
-import { createClient } from '@sanity/client/stega'
+import { createClient } from '@sanity/client'
 import { setServerClient, loadQuery } from './sanity.loader'
 
 const client = createClient({
@@ -146,7 +146,7 @@ export default function VisualEditing() {
 ### Adding overlays to any element
 
 You can use the `encodeDataAttribute` function returned by `useQuery` to create `data-sanity` attributes, that are picked up by `@sanity/visual-editing`.
-This allows you to link to elements that otherwise isn't automatically linked to using `@sanity/client/stega`, such as array root item, or an image field.
+This allows you to link to elements that otherwise isn't automatically linked to using `@sanity/client`, such as array root item, or an image field.
 
 If you aren't using stega and don't have a `studioUrl` defined in the `createClient` call, then you add it to the `useLiveMode` hook:
 


### PR DESCRIPTION
Since 6.12.0 these are imported from the main package.

https://github.com/sanity-io/client/pull/495

Might want to update these references elsewhere as well: https://github.com/search?q=repo%3Asanity-io%2Fvisual-editing+%40sanity%2Fclient%2Fstega&type=code cc @stipsan 