### PR TITLE
fix(presentation): prevent horizontal scroll on narrow document pane

### DIFF
--- a/packages/presentation/src/editor/DocumentPane.tsx
+++ b/packages/presentation/src/editor/DocumentPane.tsx
@@ -64,15 +64,13 @@ export function DocumentPane(props: {
     setErrorParams(null)
   }, [documentId, documentType, params])
 
-  const { setLayoutCollapsed } = useStructureTool()
-  const handleRootCollapse = useCallback(
-    () => setLayoutCollapsed(true),
-    [setLayoutCollapsed],
-  )
-  const handleRootExpand = useCallback(
-    () => setLayoutCollapsed(false),
-    [setLayoutCollapsed],
-  )
+  const { layoutCollapsed, setLayoutCollapsed } = useStructureTool()
+  const handleRootCollapse = useCallback(() => {
+    setLayoutCollapsed(true)
+  }, [setLayoutCollapsed])
+  const handleRootExpand = useCallback(() => {
+    setLayoutCollapsed(false)
+  }, [setLayoutCollapsed])
 
   if (errorParams) {
     return (
@@ -99,9 +97,10 @@ export function DocumentPane(props: {
   return (
     <ErrorBoundary onCatch={setErrorParams}>
       <PaneLayout
-        style={{ height: '100%' }}
+        style={layoutCollapsed ? { minHeight: '100%' } : { height: '100%' }}
         onExpand={handleRootExpand}
         onCollapse={handleRootCollapse}
+        minWidth={640}
       >
         <PresentationPaneRouterProvider
           onDeskParams={onDeskParams}

--- a/packages/presentation/src/panels/Panel.tsx
+++ b/packages/presentation/src/panels/Panel.tsx
@@ -17,7 +17,7 @@ interface PanelProps extends PropsWithChildren {
 }
 
 const Root = styled.div`
-  overflow: hidden;
+  overflow-x: hidden;
   flex-basis: 0;
   flex-shrink: 1;
 `


### PR DESCRIPTION
Finally, adds support for collapsed state and prevents overscroll.

Collapsed state is triggered at 640px, this could be adjusted.

https://github.com/sanity-io/visual-editing/assets/8467307/96919201-108f-4685-9d7f-9ee971a5bea3

