### PR TITLE
feat(visual-editing): export svelte preview store, deprecate in loader

### DIFF
--- a/apps/svelte/src/routes/+layout.svelte
+++ b/apps/svelte/src/routes/+layout.svelte
@@ -2,8 +2,7 @@
   import '../app.css'
   import { page } from '$app/stores'
 
-  import { VisualEditing } from '@sanity/visual-editing/svelte'
-  import { isPreviewing } from '@sanity/svelte-loader'
+  import { VisualEditing, isPreviewing } from '@sanity/visual-editing/svelte'
 </script>
 
 <div class="app">

--- a/apps/svelte/src/routes/+layout.ts
+++ b/apps/svelte/src/routes/+layout.ts
@@ -1,4 +1,4 @@
-import { setPreviewing } from '@sanity/svelte-loader'
+import { setPreviewing } from '@sanity/visual-editing/svelte'
 import type { LayoutLoad } from './$types'
 
 export const load: LayoutLoad = ({ data: { preview } }) => {

--- a/packages/svelte-loader/src/previewStore.ts
+++ b/packages/svelte-loader/src/previewStore.ts
@@ -1,13 +1,10 @@
-import { readonly, writable } from 'svelte/store'
-
-const previewStore = writable(false)
-
-/**
- * @beta
- */
-export const isPreviewing = readonly(previewStore)
-
-/**
- * @beta
- */
-export const setPreviewing = previewStore.set
+export {
+  /**
+   * @deprecated use `import {isPreviewing} from '@sanity/visual-editing/svelte'` instead
+   */
+  isPreviewing,
+  /**
+   * @deprecated use `import {setPreviewing} from '@sanity/visual-editing/svelte'` instead
+   */
+  setPreviewing,
+} from '@sanity/visual-editing/svelte'

--- a/packages/visual-editing/svelte/index.ts
+++ b/packages/visual-editing/svelte/index.ts
@@ -1,3 +1,4 @@
 export * from './hooks'
+export * from './previewStore'
 export * from './types'
 export { default as VisualEditing } from './VisualEditing.svelte'

--- a/packages/visual-editing/svelte/previewStore.ts
+++ b/packages/visual-editing/svelte/previewStore.ts
@@ -1,0 +1,13 @@
+import { readonly, writable } from 'svelte/store'
+
+const previewStore = writable(false)
+
+/**
+ * @beta
+ */
+export const isPreviewing = readonly(previewStore)
+
+/**
+ * @beta
+ */
+export const setPreviewing = previewStore.set


### PR DESCRIPTION
Moves the Svelte preview store to `@sanity/visual-editing` package, and adds a deprecated message in `@sanity/svelte-loader`.

```diff
-import {isPreviewing, setPreviewing} from '@sanity/svelte-loader'
+import {isPreviewing, setPreviewing} from '@sanity/visual-editing/svelte'
```

