### PR TITLE
feat(svelte-loader): support passing single object to `useQuery`

### DIFF
--- a/apps/svelte/src/routes/shoes-with-loaders/+page.svelte
+++ b/apps/svelte/src/routes/shoes-with-loaders/+page.svelte
@@ -4,10 +4,8 @@
   import Shoes from '../../components/Shoes.svelte'
 
   export let data: PageData
-  const { query, params, options } = data
-  const q = useQuery(query, params, options)
-
-  $: ({ data: products, loading } = $q)
+  const query = useQuery(data)
+  $: ({ data: products, loading } = $query)
 </script>
 
 <Shoes {products} {loading} />

--- a/apps/svelte/src/routes/shoes-with-loaders/[slug]/+page.svelte
+++ b/apps/svelte/src/routes/shoes-with-loaders/[slug]/+page.svelte
@@ -4,9 +4,8 @@
   import Shoe from '../../../components/Shoe.svelte'
 
   export let data: PageData
-  const { query, params, options } = data
-  const q = useQuery(query, params, options)
-  $: ({ data: product, loading } = $q)
+  const query = useQuery(data)
+  $: ({ data: product, loading } = $query)
 </script>
 
-<Shoe {product} {loading} slug={params.slug} />
+<Shoe {product} {loading} slug={product.slug.current} />

--- a/packages/svelte-loader/src/defineUseQuery.ts
+++ b/packages/svelte-loader/src/defineUseQuery.ts
@@ -15,11 +15,24 @@ export function defineUseQuery({
   studioUrlStore: ReturnType<typeof defineStudioUrlStore>
 }): UseQuery {
   const DEFAULT_PARAMS = {}
+  const DEFAULT_OPTIONS = {}
   return <QueryResponseResult, QueryResponseError>(
-    query: string,
+    query:
+      | string
+      | {
+          query: string
+          params?: QueryParams
+          options?: UseQueryOptions<QueryResponseResult>
+        },
     params: QueryParams = DEFAULT_PARAMS,
-    options: UseQueryOptions<QueryResponseResult> = {},
+    options: UseQueryOptions<QueryResponseResult> = DEFAULT_OPTIONS,
   ) => {
+    if (typeof query === 'object') {
+      params = query.params || DEFAULT_PARAMS
+      options = query.options || DEFAULT_OPTIONS
+      query = query.query
+    }
+
     const initial = options.initial
       ? {
           perspective: 'published' as const,

--- a/packages/svelte-loader/src/types.ts
+++ b/packages/svelte-loader/src/types.ts
@@ -33,7 +33,13 @@ export type UseQuery = <
   QueryResponseResult = unknown,
   QueryResponseError = unknown,
 >(
-  query: string,
+  query:
+    | string
+    | {
+        query: string
+        params?: QueryParams
+        options?: UseQueryOptions<QueryResponseResult>
+      },
   params?: QueryParams,
   options?: UseQueryOptions<QueryResponseResult>,
 ) => Readable<
@@ -146,7 +152,13 @@ export interface QueryStore {
   setServerClient: ReturnType<typeof createCoreQueryStore>['setServerClient']
   useQuery: {
     <QueryResponseResult = unknown, QueryResponseError = unknown>(
-      query: string,
+      query:
+        | string
+        | {
+            query: string
+            params?: QueryParams
+            options?: UseQueryOptionsUndefinedInitial
+          },
       params?: QueryParams,
       options?: UseQueryOptionsUndefinedInitial,
     ): Readable<
@@ -154,7 +166,13 @@ export interface QueryStore {
         WithEncodeDataAttribute
     >
     <QueryResponseResult = unknown, QueryResponseError = unknown>(
-      query: string,
+      query:
+        | string
+        | {
+            query: string
+            params?: QueryParams
+            options?: UseQueryOptionsDefinedInitial<QueryResponseResult>
+          },
       params?: QueryParams,
       options?: UseQueryOptionsDefinedInitial<QueryResponseResult>,
     ): Readable<


### PR DESCRIPTION
A proposal for a little tweak to `useQuery` in the Svelte loader. Adds the ability to optionally pass a single object instead of three params.

Previously:
```ts
export let data: PageData;
const { query, params, options } = data;
const query = useQuery(query, params, options);
$: ({ data: product } = $query);
```

Now:
```ts
export let data: PageData;
const query = useQuery(data);
$: ({ data: product } = $query);
```
