### PR TITLE
fix(presentation): maintain preview param on reference link

### DIFF
--- a/packages/presentation/src/editor/ContentEditor.tsx
+++ b/packages/presentation/src/editor/ContentEditor.tsx
@@ -32,6 +32,7 @@ export function ContentEditor(props: {
         documentType={documentType}
         onDeskParams={onDeskParams}
         onFocusPath={onFocusPath}
+        previewUrl={previewUrl}
       />
     )
   }

--- a/packages/presentation/src/editor/DocumentPane.tsx
+++ b/packages/presentation/src/editor/DocumentPane.tsx
@@ -32,8 +32,16 @@ export function DocumentPane(props: {
   params: DeskDocumentPaneParams
   onDeskParams: (params: DeskDocumentPaneParams) => void
   onFocusPath: (path: Path) => void
+  previewUrl?: string
 }): ReactElement {
-  const { documentId, documentType, params, onDeskParams, onFocusPath } = props
+  const {
+    documentId,
+    documentType,
+    params,
+    onDeskParams,
+    onFocusPath,
+    previewUrl,
+  } = props
   const { template, templateParams } = params
   const { devMode } = usePresentationTool()
 
@@ -105,6 +113,7 @@ export function DocumentPane(props: {
         <PresentationPaneRouterProvider
           onDeskParams={onDeskParams}
           params={params}
+          previewUrl={previewUrl}
         >
           <DeskDocumentPane
             paneKey="document"

--- a/packages/presentation/src/editor/DocumentPanel.tsx
+++ b/packages/presentation/src/editor/DocumentPanel.tsx
@@ -11,9 +11,16 @@ export function DocumentPanel(props: {
   documentType: string
   onDeskParams: (params: DeskDocumentPaneParams) => void
   onFocusPath: (path: Path) => void
+  previewUrl?: string
 }): ReactElement {
-  const { deskParams, documentId, documentType, onDeskParams, onFocusPath } =
-    props
+  const {
+    deskParams,
+    documentId,
+    documentType,
+    onDeskParams,
+    onFocusPath,
+    previewUrl,
+  } = props
   return (
     <StructureToolProvider>
       <DocumentPane
@@ -22,6 +29,7 @@ export function DocumentPanel(props: {
         params={deskParams}
         onDeskParams={onDeskParams}
         onFocusPath={onFocusPath}
+        previewUrl={previewUrl}
       />
     </StructureToolProvider>
   )

--- a/packages/presentation/src/editor/PresentationPaneRouterProvider.tsx
+++ b/packages/presentation/src/editor/PresentationPaneRouterProvider.tsx
@@ -74,7 +74,7 @@ const BackLink = forwardRef(function BackLink(
 })
 
 const ReferenceChildLink = forwardRef(function ReferenceChildLink(
-  props: ReferenceChildLinkProps,
+  props: ReferenceChildLinkProps & { previewUrl?: string },
   ref: React.ForwardedRef<HTMLAnchorElement>,
 ) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -85,7 +85,11 @@ const ReferenceChildLink = forwardRef(function ReferenceChildLink(
     <StateLink
       {...restProps}
       ref={ref}
-      state={{ id: documentId, type: documentType }}
+      state={{
+        id: documentId,
+        type: documentType,
+        _searchParams: Object.entries({ preview: props.previewUrl }),
+      }}
       title={undefined}
     />
   )
@@ -152,7 +156,9 @@ export function PresentationPaneRouterProvider(
         return <div {...restProps} />
       },
       BackLink,
-      ReferenceChildLink,
+      ReferenceChildLink: (childLinkProps) => (
+        <ReferenceChildLink {...childLinkProps} previewUrl={previewUrl} />
+      ),
       ParameterizedLink: () => <>ParameterizedLink</>,
       closeCurrentAndAfter: () => {
         console.warn('closeCurrentAndAfter')


### PR DESCRIPTION
Maintains the preview parameter when navigating to referenced documents from the document pane. Currently the preview parameter is lost, triggering the app to redirect to the initial preview URL.