### PR TITLE
fix(presentation): prevent panel vertical scroll

### DIFF
--- a/packages/presentation/src/panels/Panel.tsx
+++ b/packages/presentation/src/panels/Panel.tsx
@@ -17,7 +17,7 @@ interface PanelProps extends PropsWithChildren {
 }
 
 const Root = styled.div`
-  overflow-x: hidden;
+  overflow: hidden;
   flex-basis: 0;
   flex-shrink: 1;
 `


### PR DESCRIPTION
I've noticed scrollbars appearing intermittently since the collapsed state commit was merged, panels seem to overflow by ~a pixel. This removes them.