### PR TITLE
fix: improve vite compat with styled-components

### DIFF
--- a/apps/studio/presentation/DebugStega.tsx
+++ b/apps/studio/presentation/DebugStega.tsx
@@ -9,7 +9,7 @@ import { vercelStegaDecodeAll } from '@vercel/stega'
 import { useEffect, useMemo } from 'react'
 import { InputProps, isDocumentSchemaType } from 'sanity'
 import { useDocumentPane, usePaneRouter } from 'sanity/structure'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 export function StegaDebugger(props: InputProps): JSX.Element {
   if (isDocumentSchemaType(props.schemaType)) {

--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -41,7 +41,7 @@ import {
   type CommentIntentGetter,
   CommentsIntentProvider,
 } from 'sanity/structure'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 import {
   COMMENTS_INSPECTOR_NAME,

--- a/packages/presentation/src/components/Resizable.tsx
+++ b/packages/presentation/src/components/Resizable.tsx
@@ -8,7 +8,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 import { useLocalState } from '../useLocalState'
 import { Resizer } from './Resizer'

--- a/packages/presentation/src/components/Resizer.tsx
+++ b/packages/presentation/src/components/Resizer.tsx
@@ -4,7 +4,7 @@ import {
   useCallback,
   useRef,
 } from 'react'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 const Root = styled.div`
   position: absolute;

--- a/packages/presentation/src/document/PresentationDocumentHeader.tsx
+++ b/packages/presentation/src/document/PresentationDocumentHeader.tsx
@@ -1,7 +1,7 @@
 import { rem, Stack } from '@sanity/ui'
 import { type ReactNode, useContext } from 'react'
 import { type ObjectSchemaType, type PublishedId } from 'sanity'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 import type { PresentationPluginOptions } from '../types'
 import { LocationsBanner } from './LocationsBanner'

--- a/packages/presentation/src/editor/DocumentListPane.tsx
+++ b/packages/presentation/src/editor/DocumentListPane.tsx
@@ -13,7 +13,7 @@ import {
   PaneNode,
   StructureToolProvider,
 } from 'sanity/structure'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 import { ErrorCard } from '../components/ErrorCard'
 import { DeskDocumentPaneParams } from '../types'

--- a/packages/presentation/src/editor/DocumentPane.tsx
+++ b/packages/presentation/src/editor/DocumentPane.tsx
@@ -14,7 +14,7 @@ import {
   DocumentPaneNode,
   PaneLayout,
 } from 'sanity/structure'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 import { ErrorCard } from '../components/ErrorCard'
 import { DeskDocumentPaneParams } from '../types'

--- a/packages/presentation/src/panels/Panel.tsx
+++ b/packages/presentation/src/panels/Panel.tsx
@@ -4,7 +4,7 @@ import {
   useContext,
   useLayoutEffect,
 } from 'react'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 import { PanelsContext } from './PanelsContext'
 

--- a/packages/presentation/src/panels/PanelResizer.tsx
+++ b/packages/presentation/src/panels/PanelResizer.tsx
@@ -7,7 +7,7 @@ import {
   useLayoutEffect,
   useRef,
 } from 'react'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 import { PanelsContext } from './PanelsContext'
 import { usePanelId } from './usePanelId'

--- a/packages/presentation/src/panels/Panels.tsx
+++ b/packages/presentation/src/panels/Panels.tsx
@@ -12,7 +12,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 import { PanelsContext } from './PanelsContext'
 import {

--- a/packages/presentation/src/preview/IFrame.tsx
+++ b/packages/presentation/src/preview/IFrame.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 export const IFrame = motion(styled.iframe`
   border: 0;

--- a/packages/presentation/src/preview/PreviewFrame.tsx
+++ b/packages/presentation/src/preview/PreviewFrame.tsx
@@ -41,7 +41,7 @@ import {
   useState,
 } from 'react'
 import { Hotkeys } from 'sanity'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 import { ErrorCard } from '../components/ErrorCard'
 import { MAX_TIME_TO_OVERLAYS_CONNECTION } from '../constants'

--- a/packages/visual-editing/src/ui/ElementOverlay.tsx
+++ b/packages/visual-editing/src/ui/ElementOverlay.tsx
@@ -3,7 +3,7 @@ import { Box, Card, Flex, Text } from '@sanity/ui'
 import { pathToUrlString } from '@sanity/visual-editing-helpers'
 import { memo, useEffect, useMemo, useRef } from 'react'
 import scrollIntoView from 'scroll-into-view-if-needed'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 import type {
   ElementFocusedState,

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -24,7 +24,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import styled from 'styled-components'
+import { styled } from 'styled-components'
 
 import type {
   HistoryAdapter,


### PR DESCRIPTION
Seeing a lot of smoke around issues like https://github.com/styled-components/styled-components/issues/4275 and it seems the best way to protect against it is to never do:
```tsx
import styled from 'styled-components'
```
and instead always use the named export:
```tsx
import {styled} from 'styled-components'
```

I've tried adding a guard in `@sanity/pkg-utils` that automatically protects against it, but got blocked by: https://github.com/rollup/rollup/issues/5265