### PR TITLE
fix(visual-editing): prevent focusing both clicked and focused elements

### DIFF
--- a/packages/visual-editing/src/ui/elementsReducer.ts
+++ b/packages/visual-editing/src/ui/elementsReducer.ts
@@ -77,20 +77,27 @@ export const elementsReducer = (
         return { ...e, focused: false }
       })
     case 'presentation/focus': {
-      // This event will be reflected from the presentation tool after a click event, so check if an element has been clicked
+      // Before setting the focus state of each element, check to see if any
+      // element has gained focus from an `element/click` message. Presentation
+      // tool "reflects" these back as a `presentation/focus` message.
       const clickedElement = elements.find((e) => e.focused === 'clicked')
       return elements.map((e) => {
-        if (e === clickedElement) {
-          return e
-        }
-        // We want to focus any element which matches the id and path...
+        // We want to focus any element which matches the received id and path
         const focused =
           'path' in e.sanity &&
           e.sanity.id === message.data.id &&
           e.sanity.path === message.data.path
+
+        // If we have a 'clicked' element, and that element matches, it is a
+        // reflection, so we maintain the focus state
+        if (clickedElement && e === clickedElement && focused) {
+          return e
+        }
+
         return {
           ...e,
-          // ... but mark as a dupe if another matching item has been clicked to prevent scrolling
+          // Mark as a dupe if another matching item has been clicked to prevent
+          // scrolling, otherwise just set focus as a boolean
           focused: focused && clickedElement ? 'duplicate' : focused,
         }
       })


### PR DESCRIPTION
I'm not sure how I didn't pick up on this one before, or if this is a result of the focus path changes I made in core, but it seems it's currently possible to focus two disparate overlay elements:

1. Click an element in the app preview.
2. The corresponding field gains focus in the document pane.
3. Focus a **different** field in the document pane.
4. There will be two active overlay elements (the clicked element does not lose focus).

Looks like this was a side effect of attempting to capture "reflected" events that occur when clicking on an element. Clicked elements were just left in place, regardless of whether or not the reflected event had a matching id/path.

This PR fixes that, so focusing on a different field should correctly drop focus of the previously clicked element.