### PR TITLE
feat(presentation): combine viewport buttons into single toggle

### DIFF
--- a/packages/presentation/src/i18n/resources.ts
+++ b/packages/presentation/src/i18n/resources.ts
@@ -74,14 +74,12 @@ export default {
   /** Text describing the current status of the preview frame */
   'preview-frame.status_timeout':
     'Unable to connect, check the browser console for more information.',
-  /** The `aria-label` for the button that switches to a full viewport */
-  'preview-frame.viewport-full-button.aria-label': 'Full viewport',
-  /** The tooltip text for the button that switches to a full viewport */
-  'preview-frame.viewport-full-button.tooltip': 'Full viewport',
-  /** The `aria-label` for the button that switches to a narrow viewport */
-  'preview-frame.viewport-narrow-button.aria-label': 'Narrow viewport',
-  /** The tooltip text for the button that switches to a narrow viewport */
-  'preview-frame.viewport-narrow-button.tooltip': 'Narrow viewport',
+  /** The `aria-label` for the button that switches viewport size */
+  'preview-frame.viewport-button.aria-label': 'Toggle viewport size',
+  /** The viewport size button tooltip text when switching to a full width viewport */
+  'preview-frame.viewport-button.tooltip_full': 'Switch to full viewport',
+  /** The viewport size button tooltip text when switching to a narrow viewport */
+  'preview-frame.viewport-button.tooltip_narrow': 'Switch to narrow viewport',
   /** The validation error message shown when the preview location input is missing an origin */
   'preview-location-input.error_missing-origin': 'URL must start with ${{origin}}',
   /** The validation error message shown when the preview location input's base path matches that of the studio */

--- a/packages/presentation/src/preview/PreviewFrame.tsx
+++ b/packages/presentation/src/preview/PreviewFrame.tsx
@@ -489,7 +489,9 @@ export const PreviewFrame = forwardRef<HTMLIFrameElement, PreviewFrameProps>(
                   animate
                   content={
                     <Text size={1}>
-                      Switch to {viewport === 'desktop' ? 'narrow' : 'full'} viewport
+                      {t('preview-frame.viewport-button.tooltip', {
+                        context: viewport === 'desktop' ? 'narrow' : 'full',
+                      })}
                     </Text>
                   }
                   fallbackPlacements={['bottom-start']}
@@ -498,7 +500,7 @@ export const PreviewFrame = forwardRef<HTMLIFrameElement, PreviewFrameProps>(
                   portal
                 >
                   <Button
-                    aria-label={`Toggle viewport size`}
+                    aria-label={t('preview-frame.viewport-button.aria-label')}
                     fontSize={1}
                     icon={viewport === 'desktop' ? MobileDeviceIcon : DesktopIcon}
                     mode="bleed"

--- a/packages/presentation/src/preview/PreviewFrame.tsx
+++ b/packages/presentation/src/preview/PreviewFrame.tsx
@@ -120,6 +120,10 @@ export const PreviewFrame = forwardRef<HTMLIFrameElement, PreviewFrameProps>(
     const {devMode} = usePresentationTool()
     const prefersReducedMotion = usePrefersReducedMotion()
 
+    const toggleViewportSize = useCallback(
+      () => setViewport(viewport === 'desktop' ? 'mobile' : 'desktop'),
+      [setViewport, viewport],
+    )
     const loading = iframe.status === 'loading' || iframe.status === 'reloading'
     const [timedOut, setTimedOut] = useState(false)
     const refreshing = iframe.status === 'refreshing'
@@ -480,42 +484,26 @@ export const PreviewFrame = forwardRef<HTMLIFrameElement, PreviewFrameProps>(
                 />
               </Flex>
 
-              <Flex align="center" flex="none" gap={1} padding={1}>
+              <Flex align="center" flex="none" gap={1}>
                 <Tooltip
                   animate
-                  content={<Text size={1}>{t('preview-frame.viewport-full-button.tooltip')}</Text>}
+                  content={
+                    <Text size={1}>
+                      Switch to {viewport === 'desktop' ? 'narrow' : 'full'} viewport
+                    </Text>
+                  }
                   fallbackPlacements={['bottom-start']}
                   padding={2}
                   placement="bottom"
                   portal
                 >
                   <Button
-                    aria-label={t('preview-frame.viewport-full-button.aria-label')}
+                    aria-label={`Toggle viewport size`}
                     fontSize={1}
-                    icon={DesktopIcon}
+                    icon={viewport === 'desktop' ? MobileDeviceIcon : DesktopIcon}
                     mode="bleed"
-                    onClick={() => setViewport('desktop')}
+                    onClick={toggleViewportSize}
                     padding={2}
-                    selected={viewport === 'desktop'}
-                  />
-                </Tooltip>
-                <Tooltip
-                  animate
-                  content={
-                    <Text size={1}>{t('preview-frame.viewport-narrow-button.tooltip')}</Text>
-                  }
-                  padding={2}
-                  placement="bottom"
-                  portal
-                >
-                  <Button
-                    aria-label={t('preview-frame.viewport-narrow-button.aria-label')}
-                    fontSize={1}
-                    icon={MobileDeviceIcon}
-                    mode="bleed"
-                    onClick={() => setViewport('mobile')}
-                    padding={2}
-                    selected={viewport === 'mobile'}
                   />
                 </Tooltip>
               </Flex>


### PR DESCRIPTION
I'm dropping this here for consideration but I've _slightly_ unconvinced myself because of the classic flip-flop button issue.

The PR combines the two viewport buttons into a single toggle. That means we only get to display one icon at a time.

When in desktop mode, do we show the desktop icon (current state) or the mobile icon (anticipated state on click)? Does it matter?