### PR TITLE
fix: remove `unrecognized previewUrl prop on DOM element` warning

### DIFF
--- a/packages/presentation/src/editor/PresentationPaneRouterProvider.tsx
+++ b/packages/presentation/src/editor/PresentationPaneRouterProvider.tsx
@@ -70,7 +70,7 @@ const ReferenceChildLink = forwardRef(function ReferenceChildLink(
   ref: React.ForwardedRef<HTMLAnchorElement>,
 ) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const {documentId, documentType, parentRefPath, template, ...restProps} = props
+  const {documentId, documentType, parentRefPath, template, previewUrl, ...restProps} = props
 
   return (
     <StateLink
@@ -79,7 +79,7 @@ const ReferenceChildLink = forwardRef(function ReferenceChildLink(
       state={{
         id: documentId,
         type: documentType,
-        _searchParams: Object.entries({preview: props.previewUrl}),
+        _searchParams: Object.entries({preview: previewUrl}),
       }}
       title={undefined}
     />


### PR DESCRIPTION
Fixes this warning:
![image](https://github.com/sanity-io/visual-editing/assets/81981/b08028fb-ec2d-4a55-ba95-2a7f88da6aab)
