### PR TITLE
fix: panels should recover from broken local storage state

### DIFF
--- a/packages/presentation/src/panels/usePanelsStorage.ts
+++ b/packages/presentation/src/panels/usePanelsStorage.ts
@@ -20,7 +20,7 @@ const getKeyForPanels = (panels: PanelElement[]) => {
 }
 
 export function usePanelsStorage(): {
-  get: (panels: PanelElement[]) => number[]
+  get: (panels: PanelElement[]) => number[] | undefined
   set: (panels: PanelElement[], widths: number[]) => void
   setDebounced: (panels: PanelElement[], widths: number[]) => void
 } {
@@ -28,7 +28,9 @@ export function usePanelsStorage(): {
     const get = (panels: PanelElement[]) => {
       const stored = getStoredItem()
       const key = getKeyForPanels(panels)
-      return stored[key]
+      return Array.isArray(stored[key]) && stored[key].some((val) => val === null)
+        ? undefined
+        : stored[key]
     }
 
     const set = (panels: PanelElement[], widths: number[]) => {


### PR DESCRIPTION
Sometimes the localStorage for panel sizes are corrupted, and it causes Presentation to render a WSOD since all panels effectively has zero width:
<img width="1393" alt="Screenshot 2024-04-25 at 21 17 27" src="https://github.com/sanity-io/visual-editing/assets/81981/78807e95-6fc2-4427-bd03-1070ff4cdca0">

I don't have a consistent way of reproducing it, or an explanation for how it stores `null` values to begin with. Since I had a local repro I was able to test the fix though and confirm it is able to restore default panel settings when the localStorage state has `null` instead of numbers.