### PR TITLE
fix: revert react peer dep to ^18.2.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,7 +36,10 @@
         "next",
         "vue-router",
         "nuxt",
-        "@remix-run/react"
+        "@remix-run/react",
+        "react",
+        "react-dom",
+        "styled-components"
       ],
       "rangeStrategy": "bump"
     },

--- a/packages/preview-kit-compat/package.json
+++ b/packages/preview-kit-compat/package.json
@@ -113,7 +113,7 @@
   },
   "peerDependencies": {
     "@sanity/client": "^6.15.20",
-    "react": "^18.3.0"
+    "react": "^18.2.0"
   },
   "engines": {
     "node": ">=18"

--- a/packages/react-loader/package.json
+++ b/packages/react-loader/package.json
@@ -150,7 +150,7 @@
   },
   "peerDependencies": {
     "@sanity/client": "^6.15.20",
-    "react": "^18.3.0"
+    "react": "^18.2.0"
   },
   "engines": {
     "node": ">=18"

--- a/packages/visual-editing-helpers/package.json
+++ b/packages/visual-editing-helpers/package.json
@@ -122,7 +122,7 @@
   },
   "peerDependencies": {
     "@sanity/client": "^6.15.20",
-    "react": "^18.3.0",
+    "react": "^18.2.0",
     "valibot": "0.30.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
The bump of peer deps in #1409 of `react` to `^18.3.0` was a mistake. We don't actually require it, the only difference between 18.3 and 18.2 are deprecation warnings. Requiring 18.3 creates unnecessary churn later as `@sanity/presentation` is a dependency of `sanity` and it'll effectively require all users of `sanity` to also upgrade to `18.3` and all we'll gain from doing so is frustrating our users 😅 