### PR TITLE
fix: the intial `preview` param no longer "sticks" until page reload

### DIFF
--- a/packages/presentation/test/usePreviewUrl.test.tsx
+++ b/packages/presentation/test/usePreviewUrl.test.tsx
@@ -6,7 +6,7 @@ import type {SanityClient} from 'sanity'
 import {suspend} from 'suspend-react'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {PreviewUrlOption} from '../src/types'
+import type {PreviewUrlOption} from '../src/types'
 import {usePreviewUrl} from '../src/usePreviewUrl'
 
 vi.mock('sanity', () => {


### PR DESCRIPTION
When opening a route, like https://visual-editing-studio.sanity.build/next/app-router?preview=/404, the `preview=/404` state would "stick". You could navigate to other tools and workspaces, click on `Presentation` in the navbar, and it would keep loading the same initial `/404` route instead of falling back to the default route.
With this PR it now "unsticks", and as a side-effect if you click on the tool in the navbar it does a reset, which is useful in dev if the app you're previewing crashed.