### PR TITLE
fix(visual-editing): maintain overlay element registration when toggling

### DIFF
--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -125,6 +125,7 @@ export interface OverlayOptions {
 export interface OverlayController {
   activate: () => void
   deactivate: () => void
+  destroy: () => void
 }
 
 /**

--- a/packages/visual-editing/src/ui/useController.tsx
+++ b/packages/visual-editing/src/ui/useController.tsx
@@ -24,7 +24,7 @@ export function useController(
     })
 
     return () => {
-      overlayController.current?.deactivate()
+      overlayController.current?.destroy()
       overlayController.current = undefined
     }
   }, [element, handler, preventDefault])


### PR DESCRIPTION
Toggling "Edit" on and off currently causes the overlay controller instance to essentially be destroyed and recreated, meaning visibility of overlay elements is "lost" when in the off state.

This PR changes the behaviour so that the controller instance is maintained, along with the state which tracks elements, even when "Edit" mode is off. Instead just the elements themselves are activated and deactivated internally.

This has the side effect of preventing the documents on screen being reported each time "Edit" is toggled, which was in turn causing a loading state to be repeatedly displayed in the Document list.