### PR TITLE
refactor(presentation): restyle main document badge

### DIFF
--- a/packages/presentation/src/editor/ContentEditor.tsx
+++ b/packages/presentation/src/editor/ContentEditor.tsx
@@ -1,5 +1,5 @@
 import {WarningOutlineIcon} from '@sanity/icons'
-import {Badge, Box, Card, Flex, Text} from '@sanity/ui'
+import {Box, Card, Flex, Text} from '@sanity/ui'
 import {type HTMLProps, type ReactElement, useCallback} from 'react'
 import {type Path, Translate, useSchema, useTranslation} from 'sanity'
 import {StateLink} from 'sanity/router'
@@ -71,7 +71,13 @@ export function ContentEditor(props: {
             <Card as={MainDocumentLink} data-as="a" padding={0} radius={2}>
               <Preview
                 schemaType={schema.get(mainDocumentState.document._type)!}
-                status={<Badge>{t('main-document.label')}</Badge>}
+                status={
+                  <Card padding={1} radius={2} shadow={1}>
+                    <Text muted size={0} weight="medium">
+                      {t('main-document.label')}
+                    </Text>
+                  </Card>
+                }
                 value={mainDocumentState.document}
               />
             </Card>


### PR DESCRIPTION
Changes the "Main document" badge styling from this:

<img width="640" alt="Screenshot 2024-05-02 at 17 40 14" src="https://github.com/sanity-io/visual-editing/assets/8467307/234dabc9-bcf0-46fd-8ead-8531351e545f">

To this:

<img width="640" alt="Screenshot 2024-05-02 at 17 40 05" src="https://github.com/sanity-io/visual-editing/assets/8467307/8fc572b8-e05e-44ce-b1f2-0ffe7653e26e">

The styling loosely follows that of the "Latest" badge here, which doesn't itself use the `<Badge>` component.

<img width="252" alt="Screenshot 2024-05-02 at 17 41 24" src="https://github.com/sanity-io/visual-editing/assets/8467307/59c7bdff-cac4-4d9c-93e5-e00e6f02dccf">

