### PR TITLE
fix: improve createDataAttribute types

### DIFF
--- a/packages/visual-editing-helpers/src/createDataAttribute.test.ts
+++ b/packages/visual-editing-helpers/src/createDataAttribute.test.ts
@@ -12,17 +12,25 @@ describe('createDataAttribute', () => {
 
   test('throws if id is omitted', () => {
     const scopedWithoutId = createDataAttribute({type})
+    // @ts-expect-error expected throw
     expect(() => scopedWithoutId(path)).toThrowError('required')
   })
 
   test('throws if type is omitted', () => {
     const scopedWithoutType = createDataAttribute({id})
+    // @ts-expect-error expected throw
     expect(() => scopedWithoutType(path)).toThrowError('required')
   })
 
   test('throws if path is omitted', () => {
     const scoped = createDataAttribute({id, type})
+    // @ts-expect-error expected throw
     expect(() => scoped()).toThrowError('required')
+  })
+
+  test('throws if `.toString` is used without a path', () => {
+    const scopedWithPath = createDataAttribute({id, type})
+    expect(() => scopedWithPath.toString()).toThrowError('required')
   })
 
   test('resolves using function call', () => {

--- a/packages/visual-editing-helpers/src/createDataAttribute.ts
+++ b/packages/visual-editing-helpers/src/createDataAttribute.ts
@@ -4,9 +4,13 @@ import {encodeSanityNodeData} from './csm/transformSanityNodeData'
 import type {CreateDataAttribute, CreateDataAttributeProps, SanityNode} from './types'
 
 /**
+ * A helper function for creating `data-sanity` attributes by explicitly providing metadata.
+ * @returns An object with methods for incrementally adding and scoping metadata, and for generating a data attribute string.
  * @public
  */
-export function createDataAttribute(props: CreateDataAttributeProps): CreateDataAttribute {
+export function createDataAttribute<T extends CreateDataAttributeProps>(
+  props: T,
+): CreateDataAttribute<T> {
   // Internal function for normalizing a path
   function normalizePath(path?: StudioPathLike) {
     if (!path) return []
@@ -33,7 +37,7 @@ export function createDataAttribute(props: CreateDataAttributeProps): CreateData
   }
 
   // The returned function call, calls the internal `toString` function with an optional concatenated path
-  const DataAttribute: CreateDataAttribute = function (path?: StudioPathLike) {
+  const DataAttribute = (path?: StudioPathLike): string => {
     return toString({
       ...props,
       path: [...normalizePath(props.path), ...normalizePath(path)],
@@ -45,19 +49,19 @@ export function createDataAttribute(props: CreateDataAttributeProps): CreateData
     return toString(props)
   }
 
-  DataAttribute.combine = function (attrs: CreateDataAttributeProps) {
-    return createDataAttribute({
+  DataAttribute.combine = function <U extends CreateDataAttributeProps>(attrs: U) {
+    return createDataAttribute<T & U>({
       ...props,
       ...attrs,
     })
   }
 
   DataAttribute.scope = function (path: StudioPathLike) {
-    return createDataAttribute({
+    return createDataAttribute<T & {path: StudioPathLike}>({
       ...props,
       path: [...normalizePath(props.path), ...normalizePath(path)],
     })
   }
 
-  return DataAttribute
+  return DataAttribute as CreateDataAttribute<T>
 }

--- a/packages/visual-editing-helpers/src/types.ts
+++ b/packages/visual-editing-helpers/src/types.ts
@@ -289,44 +289,73 @@ export type PreviewKitMsg = {
 export type VisualEditingConnectionIds = 'presentation' | 'loaders' | 'overlays' | 'preview-kit'
 
 /**
+ * Helper
+ * @internal
+ */
+export type WithRequired<T, K extends keyof T> = T & {[P in K]-?: T[P]}
+
+/**
+ * The metadata that can be embedded in a data attribute.
+ * All values are marked optional in the base type as they can be provided incrementally using the `createDataAttribute` function.
  * @public
  */
 export interface CreateDataAttributeProps {
+  /** The studio base URL, optional */
   baseUrl?: string
+  /** The dataset, optional */
   dataset?: string
+  /** The document ID, required */
   id?: string
+  /** The field path, required */
   path?: StudioPathLike
+  /** The project ID, optional */
   projectId?: string
+  /** The studio tool name, optional */
   tool?: string
+  /** The document type, required */
   type?: string
+  /** The studio workspace, optional */
   workspace?: string
 }
 
 /**
  * @public
  */
-export type CreateDataAttribute = {
+export type CreateDataAttribute<T extends CreateDataAttributeProps> = (T extends WithRequired<
+  CreateDataAttributeProps,
+  'id' | 'type' | 'path'
+>
+  ? {
+      /**
+       * Returns a string representation of the data attribute
+       * @param path - An optional path to concatenate with any existing path
+       * @public
+       */
+      (path?: StudioPathLike): string
+      /**
+       * Returns a string representation of the data attribute
+       * @public
+       */
+      toString(): string
+    }
+  : T extends WithRequired<CreateDataAttributeProps, 'id' | 'type'>
+    ? /**
+       * Returns a string representation of the data attribute
+       * @param path - An optional path to concatenate with any existing path
+       * @public
+       */
+      (path: StudioPathLike) => string
+    : object) & {
   /**
-   * @public
-   * Returns a string representation of the data attribute
-   * @param path - An optional path to concatenate with any existing path
-   */
-  (path?: StudioPathLike): string
-  /**
-   * @public
-   * Concatenate the data attribute current path with a new path
+   * Concatenate the current path with a new path
    * @param path - A path to concatenate with any existing path
-   */
-  scope(path: StudioPathLike): CreateDataAttribute
-  /**
    * @public
-   * Combines the current data attribute props with additional props
+   */
+  scope(path: StudioPathLike): CreateDataAttribute<T & {path: StudioPathLike}>
+  /**
+   * Combines the current props with additional props
    * @param props - New props to merge with any existing props
-   */
-  combine(props: CreateDataAttributeProps): CreateDataAttribute
-  /**
    * @public
-   * Returns a string representation of the data attribute
    */
-  toString(): string
+  combine: <U extends CreateDataAttributeProps>(props: U) => CreateDataAttribute<T & U>
 }

--- a/packages/visual-editing/src/create-data-attribute.ts
+++ b/packages/visual-editing/src/create-data-attribute.ts
@@ -2,4 +2,5 @@ export {
   type CreateDataAttribute,
   createDataAttribute,
   type CreateDataAttributeProps,
+  type WithRequired,
 } from '@repo/visual-editing-helpers'

--- a/packages/visual-editing/src/index.ts
+++ b/packages/visual-editing/src/index.ts
@@ -34,4 +34,5 @@ export {
   type CreateDataAttribute,
   createDataAttribute,
   type CreateDataAttributeProps,
+  type WithRequired,
 } from '@repo/visual-editing-helpers'

--- a/packages/visual-editing/src/next-pages-router/index.ts
+++ b/packages/visual-editing/src/next-pages-router/index.ts
@@ -11,4 +11,5 @@ export {
   type CreateDataAttribute,
   createDataAttribute,
   type CreateDataAttributeProps,
+  type WithRequired,
 } from '@repo/visual-editing-helpers'

--- a/packages/visual-editing/src/remix/index.ts
+++ b/packages/visual-editing/src/remix/index.ts
@@ -11,4 +11,5 @@ export {
   type CreateDataAttribute,
   createDataAttribute,
   type CreateDataAttributeProps,
+  type WithRequired,
 } from '@repo/visual-editing-helpers'


### PR DESCRIPTION
Improvements to help TS users avoid unexpected runtime errors when using `createDataAttribute`.

Draft as I can't figure out custom error messages for cases where `This expression is not callable` 😄 