### PR TITLE
feat(studio): configure Astro presentation workspace URL

### DIFF
--- a/apps/astro/package.json
+++ b/apps/astro/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "astro": "astro",
     "build": "astro check && astro build",
-    "dev": "astro dev",
+    "dev": "astro dev --port 3006",
     "preview": "astro preview",
     "start": "astro dev"
   },

--- a/apps/astro/src/pages/shoes/[slug].astro
+++ b/apps/astro/src/pages/shoes/[slug].astro
@@ -1,4 +1,5 @@
 ---
+import {sanityClient} from 'sanity:client'
 import {PortableText} from 'astro-portabletext'
 import {shoe, shoesList, type ShoeResult, type ShoesListResult} from 'apps-common/queries'
 import Layout from '../../../layouts/layout.astro'

--- a/apps/astro/src/pages/shoes/index.astro
+++ b/apps/astro/src/pages/shoes/index.astro
@@ -1,4 +1,5 @@
 ---
+import {sanityClient} from 'sanity:client'
 import {shoesList, type ShoesListResult} from 'apps-common/queries'
 import {urlFor, urlForCrossDatasetReference} from '../../sanity'
 import {formatCurrency} from 'apps-common/utils'

--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -115,6 +115,7 @@ const presentationWorkspaces = Object.entries({
   },
   'page-builder-demo':
     process.env.SANITY_STUDIO_PAGE_BUILDER_DEMO_PREVIEW_URL || 'http://localhost:3005/',
+  'astro': process.env.SANITY_STUDIO_ASTRO_PREVIEW_URL || 'http://localhost:3006/shoes',
 } as const).map(([name, previewUrl]) => {
   const {
     projectId,


### PR DESCRIPTION
I've also configured the `SANITY_STUDIO_ASTRO_PREVIEW_URL` env var of the studio on Vercel to point to `https://visual-editing-astro.sanity.build/shoes`.