### PR TITLE
fix: regression causing a crash in embedded studios

### DIFF
--- a/packages/presentation/src/useMainDocument.ts
+++ b/packages/presentation/src/useMainDocument.ts
@@ -111,7 +111,7 @@ export function useMainDocument(props: {
       typeof previewUrl === 'string'
         ? previewUrl
         : typeof previewUrl === 'object'
-          ? previewUrl?.origin
+          ? previewUrl?.origin || location.origin
           : location.origin
 
     return new URL(relativeUrl, base)


### PR DESCRIPTION
In embedded Studios the `previewUrl` option typically won't have `origin` specified, leading to a crash:
![image](https://github.com/sanity-io/visual-editing/assets/81981/b7b6c9d0-dfd5-4a2f-bf5f-76888c96a89e)

Tested this fix on https://github.com/sanity-io/nextjs-blog-cms-sanity-v3/pull/505

I would write a test for it but I feel we should fast track a fix and ask Studio DX to do a patch of `sanity` and circle back later instead, since everyone on embedded studios are currently unable to use Presentation Tool 😅 