### PR TITLE
fix(presentation): remove use of startTransition

### DIFF
--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -15,7 +15,6 @@ import {BoundaryElementProvider, Flex} from '@sanity/ui'
 import {
   lazy,
   type ReactElement,
-  startTransition,
   Suspense,
   useCallback,
   useEffect,
@@ -342,30 +341,28 @@ export default function PresentationTool(props: {
   useEffect(() => {
     const interval = setInterval(
       () =>
-        startTransition(() =>
-          setLiveQueries((liveQueries) => {
-            if (Object.keys(liveQueries).length < 1) {
-              return liveQueries
-            }
+        setLiveQueries((liveQueries) => {
+          if (Object.keys(liveQueries).length < 1) {
+            return liveQueries
+          }
 
-            const now = Date.now()
-            const hasAnyExpired = Object.values(liveQueries).some(
-              (liveQuery) =>
-                liveQuery.heartbeat !== false && now > liveQuery.receivedAt + liveQuery.heartbeat,
-            )
-            if (!hasAnyExpired) {
-              return liveQueries
+          const now = Date.now()
+          const hasAnyExpired = Object.values(liveQueries).some(
+            (liveQuery) =>
+              liveQuery.heartbeat !== false && now > liveQuery.receivedAt + liveQuery.heartbeat,
+          )
+          if (!hasAnyExpired) {
+            return liveQueries
+          }
+          const next = {} as LiveQueriesState
+          for (const [key, value] of Object.entries(liveQueries)) {
+            if (value.heartbeat !== false && now > value.receivedAt + value.heartbeat) {
+              continue
             }
-            const next = {} as LiveQueriesState
-            for (const [key, value] of Object.entries(liveQueries)) {
-              if (value.heartbeat !== false && now > value.receivedAt + value.heartbeat) {
-                continue
-              }
-              next[key] = value
-            }
-            return next
-          }),
-        ),
+            next[key] = value
+          }
+          return next
+        }),
       MIN_LOADER_QUERY_LISTEN_HEARTBEAT_INTERVAL,
     )
     return () => clearInterval(interval)


### PR DESCRIPTION
When investigating #1486 inside
https://github.com/sanity-io/template-nextjs-personal-website I found that the `liveQueries` in `PresentationTool` easily run into an infinite loop causing the component to crash due to `Maximum update depth exceeded`. When inspecting the changes to the `liveQueries` that caused the re-renders I didn't find any differences expect a slight difference in `receivedAt`. Proceeding with the investigation, I couldn't find any odd places where `setLiveQueries` was called or where the `liveQueries` might be mutated. However, as soon as I remove the use of `startTransition`, when expiring the queries at a regular interval, the problem goes away. The component, `PresentationTool`, suddenly feels completely stable and nothing I do in the UI can provoke the infinite loop again. I'm not, however, sure how `startTransition` could cause this issue or what implications it might have that we remove it. All I know is that it fixes the issue at hand.