### PR TITLE
refactor(ci): enable merge queues and automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,11 @@
   "ignorePresets": [":ignoreModulesAndTests", "github>sanity-io/renovate-config:group-non-major"],
   "packageRules": [
     {
+      "description": "Enable automerge with GitHub merge queues (note that this doesn't bypass required checks and code reviews)",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
       "group": {"semanticCommitType": "chore"},
       "matchDepTypes": [
         "dependencies",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@
 name: CI
 
 on:
+  merge_group:
   pull_request:
     types: [opened, synchronize]
   push:


### PR DESCRIPTION
Note that enabling automerge in renovatebot doesn't allow it to bypass required status checks or code review. It uses the same automerge feature as in the GitHub PR web ui :)
It also updates the default CI workflow to run on `merge_group`, which is required to enable merge queues that have the same required status checks as regular merge rules.