### PR TITLE
chore: override `framer-motion` to a single version

### DIFF
--- a/apps/remix/app/root.tsx
+++ b/apps/remix/app/root.tsx
@@ -1,13 +1,5 @@
 import {json, type LinksFunction} from '@vercel/remix'
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-  useLoaderData,
-} from '@remix-run/react'
+import {Links, Meta, Outlet, Scripts, ScrollRestoration, useLoaderData} from '@remix-run/react'
 import {lazy, Suspense, useEffect, useMemo, useState, useSyncExternalStore} from 'react'
 
 import styles from '~/tailwind.css?url'
@@ -44,7 +36,6 @@ export default function App() {
         </Suspense>
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
         <span className="fixed bottom-1 left-1 block rounded bg-slate-900 px-2 py-1 text-xs text-slate-100">
           {data.vercelEnv}
           {', '}

--- a/apps/remix/app/routes/shoes.$slug.tsx
+++ b/apps/remix/app/routes/shoes.$slug.tsx
@@ -79,7 +79,7 @@ export default function ShoePage() {
               aria-current="page"
               className="font-medium text-gray-500 hover:text-gray-600"
             >
-              {loadingShoe ? 'Loading' : <span>{product?.title}</span> || 'Untitled'}
+              {loadingShoe ? 'Loading' : product?.title || 'Untitled'}
             </Link>
           </li>
         </ol>

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@sanity/pkg-utils": "6.8.14",
     "@sanity/prettier-config": "1.0.2",
+    "framer-motion": "11.2.0",
     "husky": "^9.0.11",
     "lint-staged": "^15.2.2",
     "prettier": "3.2.5",
@@ -76,6 +77,7 @@
       "@sanity/vision": "$@sanity/vision",
       "@sanity/visual-editing": "workspace:*",
       "create-sanity": "$create-sanity",
+      "framer-motion": "$framer-motion",
       "groq": "$groq",
       "sanity": "$sanity",
       "styled-components": "$styled-components"

--- a/packages/visual-editing/README.md
+++ b/packages/visual-editing/README.md
@@ -140,15 +140,7 @@ For Remix apps you should use `VisualEditing` from `@sanity/visual-editing/remix
 
 ```tsx
 import {json} from '@remix-run/node'
-import {
-  Links,
-  LiveReload,
-  Meta,
-  Outlet,
-  Scripts,
-  ScrollRestoration,
-  useLoaderData,
-} from '@remix-run/react'
+import {Links, Meta, Outlet, Scripts, ScrollRestoration, useLoaderData} from '@remix-run/react'
 import {VisualEditing} from '@sanity/visual-editing/remix'
 
 export const loader = () => {
@@ -181,7 +173,6 @@ export default function App() {
         )}
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
       </body>
     </html>
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ overrides:
   '@sanity/vision': 3.41.1
   '@sanity/visual-editing': workspace:*
   create-sanity: 3.41.1
+  framer-motion: 11.2.0
   groq: 3.41.1
   sanity: 3.41.1
   styled-components: 6.1.11
@@ -80,6 +81,9 @@ importers:
       '@sanity/prettier-config':
         specifier: 1.0.2
         version: 1.0.2(prettier@3.2.5)
+      framer-motion:
+        specifier: 11.2.0
+        version: 11.2.0(react-dom@18.3.1)(react@18.3.1)
       husky:
         specifier: ^9.0.11
         version: 9.0.11
@@ -3139,22 +3143,10 @@ packages:
   /@emotion/hash@0.9.1:
     resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
 
-  /@emotion/is-prop-valid@0.8.8:
-    resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
-    requiresBuild: true
-    dependencies:
-      '@emotion/memoize': 0.7.4
-    optional: true
-
   /@emotion/is-prop-valid@1.2.2:
     resolution: {integrity: sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==}
     dependencies:
       '@emotion/memoize': 0.8.1
-
-  /@emotion/memoize@0.7.4:
-    resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
-    requiresBuild: true
-    optional: true
 
   /@emotion/memoize@0.8.1:
     resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
@@ -6184,6 +6176,7 @@ packages:
       sanity: 3.41.1(@types/node@20.8.7)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       styled-components: 6.1.11(react-dom@18.3.1)(react@18.3.1)
     transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
       - react-dom
       - react-is
     dev: false
@@ -6205,6 +6198,7 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
       sanity: 3.41.1(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.11)
     transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
       - react-is
       - styled-components
     dev: false
@@ -6728,12 +6722,14 @@ packages:
       '@sanity/color': 2.2.5
       '@sanity/icons': 2.11.8(react@18.3.1)
       csstype: 3.1.3
-      framer-motion: 10.18.0(react-dom@18.3.1)(react@18.3.1)
+      framer-motion: 11.2.0(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-is: 18.3.1
       react-refractor: 2.1.7(react@18.3.1)
       styled-components: 6.1.11(react-dom@18.3.1)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
     dev: false
 
   /@sanity/ui@2.1.7(react-dom@18.3.1)(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.11):
@@ -6749,12 +6745,14 @@ packages:
       '@sanity/color': 3.0.6
       '@sanity/icons': 2.11.8(react@18.3.1)
       csstype: 3.1.3
-      framer-motion: 11.0.8(react-dom@18.3.1)(react@18.3.1)
+      framer-motion: 11.2.0(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-is: 18.3.1
       react-refractor: 2.1.7(react@18.3.1)
       styled-components: 6.1.11(react-dom@18.3.1)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
 
   /@sanity/util@3.41.1:
     resolution: {integrity: sha512-rMOKJqXiJwLvGXx91SiAiBwV1pm4MelAfLOuld3wDWc4XANKSicfX2jcfLhgU3WprOM4aaOEumiA1JEnqdanaQ==}
@@ -6829,6 +6827,7 @@ packages:
       - '@babel/runtime'
       - '@codemirror/lint'
       - '@codemirror/theme-one-dark'
+      - '@emotion/is-prop-valid'
       - '@lezer/common'
       - codemirror
       - react-dom
@@ -7112,6 +7111,7 @@ packages:
       react-rx: 2.1.3(react@18.3.1)(rxjs@7.8.1)
       sanity: 3.41.1(@types/node@20.8.7)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.11)
     transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
       - '@sanity/mutator'
       - '@sanity/util'
       - '@types/node'
@@ -7148,6 +7148,7 @@ packages:
       sanity: 3.41.1(@types/node@20.8.7)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       speakingurl: 14.0.1
     transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
       - '@types/node'
       - '@types/react'
       - bufferutil
@@ -12356,41 +12357,6 @@ packages:
   /fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
-  /framer-motion@10.18.0(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-oGlDh1Q1XqYPksuTD/usb0I70hq95OUzmL9+6Zd+Hs4XV0oaISBa/UUMSjYiq6m8EUF32132mOJ8xVZS+I0S6w==}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      tslib: 2.6.2
-    optionalDependencies:
-      '@emotion/is-prop-valid': 0.8.8
-    dev: false
-
-  /framer-motion@11.0.8(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-1KSGNuqe1qZkS/SWQlDnqK2VCVzRVEoval379j0FiUBJAZoqgwyvqFkfvJbgW2IPFo4wX16K+M0k5jO23lCIjA==}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      tslib: 2.6.2
-    optionalDependencies:
-      '@emotion/is-prop-valid': 0.8.8
-
   /framer-motion@11.2.0(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-LRfLVPEwtO9IXJCAsWvtj3XZxrdZDcTxNNkZEq30aQ8p7/wimfUkDy67TDWdtzPiyKDkqOHDhaQC6XVrQ4Fh7A==}
     peerDependencies:
@@ -12408,7 +12374,6 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.6.2
-    dev: false
 
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -19105,6 +19070,7 @@ packages:
       sanity: 3.41.1(@types/node@20.8.7)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       styled-components: 6.1.11(react-dom@18.3.1)(react@18.3.1)
     transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
       - react-dom
       - react-is
     dev: false
@@ -19222,7 +19188,7 @@ packages:
       esbuild-register: 3.5.0(esbuild@0.21.2)
       execa: 2.1.0
       exif-component: 1.0.1
-      framer-motion: 11.0.8(react-dom@18.3.1)(react@18.3.1)
+      framer-motion: 11.2.0(react-dom@18.3.1)(react@18.3.1)
       get-it: 8.4.29(debug@4.3.4)
       get-random-values-esm: 1.0.2
       groq-js: 1.8.0
@@ -19280,6 +19246,7 @@ packages:
       vite: 4.5.3(@types/node@20.8.7)
       yargs: 17.7.2
     transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
       - '@types/node'
       - '@types/react'
       - bufferutil
@@ -19359,7 +19326,7 @@ packages:
       esbuild-register: 3.5.0(esbuild@0.21.2)
       execa: 2.1.0
       exif-component: 1.0.1
-      framer-motion: 11.0.8(react-dom@18.3.1)(react@18.3.1)
+      framer-motion: 11.2.0(react-dom@18.3.1)(react@18.3.1)
       get-it: 8.4.29(debug@4.3.4)
       get-random-values-esm: 1.0.2
       groq-js: 1.8.0
@@ -19417,6 +19384,7 @@ packages:
       vite: 4.5.3(@types/node@20.8.7)
       yargs: 17.7.2
     transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
       - '@types/node'
       - '@types/react'
       - bufferutil


### PR DESCRIPTION
After testing and merging https://github.com/sanity-io/visual-editing/pull/1216 I realised that it might be possible for the version that `sanity` and `@sanity/ui` is using to still be loaded in the studio.
This PR dedupes and overrides them all to use the same version, allowing us to test if bumping `framer-motion` causes any breaking behaviours in `sanity` and `@sanity/ui` in addition to `@sanity/presentation`.

This is important as those other packages uses this renovate rule: https://github.com/sanity-io/renovate-config/blob/2d752bc97fca2225a35299e6ab629f967b335195/studio-v3.json#L28

Other than that I've done some fixes in the Remix app to remove console warnings :)