### PR TITLE
feat(astro): add visual editing POC

### DIFF
--- a/apps/astro/astro.config.mjs
+++ b/apps/astro/astro.config.mjs
@@ -15,10 +15,9 @@ export default defineConfig({
       dataset,
       useCdn: true,
       apiVersion,
-      studioUrl: ({_dataset}) =>
-        _dataset === workspaces['cross-dataset-references'].dataset
-          ? `${baseUrl}/${workspaces['cross-dataset-references'].workspace}`
-          : studioUrl,
+      stega: {
+        studioUrl,
+      },
     }),
     tailwind(),
   ],

--- a/apps/astro/package.json
+++ b/apps/astro/package.json
@@ -17,6 +17,7 @@
     "@sanity/astro": "^3.0.0",
     "@sanity/client": "^6.18.2",
     "@sanity/image-url": "^1.0.2",
+    "@sanity/visual-editing": "workspace:^",
     "apps-common": "workspace:^",
     "astro": "^4.8.4",
     "astro-portabletext": "^0.10.0",

--- a/apps/astro/src/components/visual-editing.astro
+++ b/apps/astro/src/components/visual-editing.astro
@@ -1,0 +1,50 @@
+---
+const visualEditingEnabled = import.meta.env.SANITY_VISUAL_EDITING_ENABLED
+---
+
+<sanity-astro-visual-editing enabled={visualEditingEnabled}></sanity-astro-visual-editing>
+
+<script>
+  import {enableVisualEditing} from '@sanity/visual-editing'
+
+  class SanityAstroVisualEditing extends HTMLElement {
+    static observedAttributes = ['enabled']
+    private unsubscribe: (() => void) | null = null
+
+    constructor() {
+      super()
+    }
+
+    disconnectedCallback() {
+      this.teardownVisualEditing()
+    }
+
+    attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null) {
+      if (name === 'enabled' && oldValue !== newValue) {
+        this.updateVisualEditing(newValue === 'true')
+      }
+    }
+
+    private updateVisualEditing(enabled: boolean) {
+      if (enabled) {
+        this.unsubscribe = enableVisualEditing({
+          refresh: () => {
+            return new Promise((resolve) => {
+              window.location.reload()
+              resolve()
+            })
+          },
+        })
+      } else {
+        this.teardownVisualEditing()
+      }
+    }
+
+    private teardownVisualEditing() {
+      this.unsubscribe?.()
+      this.unsubscribe = null
+    }
+  }
+
+  customElements.define('sanity-astro-visual-editing', SanityAstroVisualEditing)
+</script>

--- a/apps/astro/src/env.d.ts
+++ b/apps/astro/src/env.d.ts
@@ -1,3 +1,12 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
 /// <reference types="@sanity/astro/module" />
+
+interface ImportMetaEnv {
+  readonly SANITY_VISUAL_EDITING_ENABLED: string
+  readonly SANITY_API_READ_TOKEN: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/apps/astro/src/layouts/layout.astro
+++ b/apps/astro/src/layouts/layout.astro
@@ -1,4 +1,6 @@
 ---
+import VisualEditing from '../components/visual-editing.astro'
+
 export type props = {
   title: string
 }
@@ -15,5 +17,6 @@ const {title} = Astro.props
   </head>
   <body>
     <slot />
+    <VisualEditing />
   </body>
 </html>

--- a/apps/astro/src/load-query.ts
+++ b/apps/astro/src/load-query.ts
@@ -1,0 +1,34 @@
+import {type QueryParams} from 'sanity'
+import {sanityClient} from 'sanity:client'
+
+const visualEditingEnabled = import.meta.env.SANITY_VISUAL_EDITING_ENABLED === 'true'
+const token = import.meta.env.SANITY_API_READ_TOKEN
+
+export async function loadQuery<QueryResponse>({
+  query,
+  params,
+}: {
+  query: string
+  params?: QueryParams
+}) {
+  if (visualEditingEnabled && !token) {
+    throw new Error('The `SANITY_API_READ_TOKEN` environment variable is required in Draft Mode.')
+  }
+
+  const perspective = visualEditingEnabled ? 'previewDrafts' : 'published'
+
+  const {result, resultSourceMap} = await sanityClient.fetch<QueryResponse>(query, params ?? {}, {
+    filterResponse: false,
+    perspective,
+    resultSourceMap: visualEditingEnabled ? 'withKeyArraySelector' : false,
+    stega: visualEditingEnabled,
+    ...(visualEditingEnabled ? {token} : {}),
+    useCdn: !visualEditingEnabled,
+  })
+
+  return {
+    data: result,
+    sourceMap: resultSourceMap,
+    perspective,
+  }
+}

--- a/apps/astro/src/pages/shoes/[slug].astro
+++ b/apps/astro/src/pages/shoes/[slug].astro
@@ -1,15 +1,15 @@
 ---
-import {sanityClient} from 'sanity:client'
-import {PortableText} from 'astro-portabletext'
 import {shoe, shoesList, type ShoeResult, type ShoesListResult} from 'apps-common/queries'
-import Layout from '../../layouts/layout.astro'
-import {urlFor, urlForCrossDatasetReference} from '../../sanity'
 import {formatCurrency} from 'apps-common/utils'
+import {PortableText} from 'astro-portabletext'
+import Layout from '../../layouts/layout.astro'
+import {loadQuery} from '../../load-query'
+import {urlFor, urlForCrossDatasetReference} from '../../sanity'
 
 const {slug} = Astro.params
 
-const products = await sanityClient.fetch<ShoesListResult>(`${shoesList}[0..3]`)
-const product = await sanityClient.fetch<ShoeResult>(shoe, {slug})
+const {data: products} = await loadQuery<ShoesListResult>({query: `${shoesList}[0..3]`})
+const {data: product} = await loadQuery<ShoeResult>({query: shoe, params: slug ? {slug} : {}})
 const loadingShoe = false
 const loadingShoes = false
 const [coverImage, ...otherImages] = product.media ?? []

--- a/apps/astro/src/pages/shoes/index.astro
+++ b/apps/astro/src/pages/shoes/index.astro
@@ -1,11 +1,11 @@
 ---
-import {sanityClient} from 'sanity:client'
 import {shoesList, type ShoesListResult} from 'apps-common/queries'
-import {urlFor, urlForCrossDatasetReference} from '../../sanity'
 import {formatCurrency} from 'apps-common/utils'
 import Layout from '../../layouts/layout.astro'
+import {loadQuery} from '../../load-query'
+import {urlFor, urlForCrossDatasetReference} from '../../sanity'
 
-const products = await sanityClient.fetch<ShoesListResult>(shoesList)
+const {data: products} = await loadQuery<ShoesListResult>({query: shoesList})
 const _loading = false
 // Only consider it to be loading if there are no products
 const loading = _loading && !products.length

--- a/apps/astro/turbo.json
+++ b/apps/astro/turbo.json
@@ -3,6 +3,8 @@
   "extends": ["//"],
   "pipeline": {
     "build": {
+      "dotEnv": [".env", ".env.local"],
+      "env": ["SANITY_API_READ_TOKEN", "SANITY_VISUAL_EDITING_ENABLED"],
       "outputs": [".vercel/**", "dist/**"]
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       '@sanity/image-url':
         specifier: ^1.0.2
         version: 1.0.2
+      '@sanity/visual-editing':
+        specifier: workspace:*
+        version: link:../../packages/visual-editing
       apps-common:
         specifier: workspace:^
         version: link:../common


### PR DESCRIPTION
It's not much, but I think it's enough to get the ball rolling on visual editing in Astro.

All queries are now passed through a `loadQuery` function similar to the one found in the Next.js server-only example. Here, we set the proper config to support visual editing in case that env var is set to `'true'`. Similarly, a `<VisualEditing />` component is added to the root layout in order to toggle visual editing if enabled. The `<VisualEditing />` component just triggeres a full page refresh whenever a refresh should happen.

Some questions that pop up are:

- What is the best way to toggle visual editing in Astro? Is it an env var like we use here, or is there a better way a la `draftMode` in Next.js?
- How do you best encapsulate the `<VisualEditing />` component to make sure its script is only loaded and run when visual editing is enabled? In the current implementation, `enableVisualEditing` is only called if the env var flag is set, but the `@sanity/visual-editing` module is still included, which might not be ideal. I've tried different techniques outlined in https://docs.astro.build/en/guides/client-side-scripts/, and the data-attribute-passed-to-custom-component is the technique I found to work the best. But maybe I missed something.
- Is there a better way to refresh the page on changes than using `window.location.reload()`?

---

Test it locally:

1. Linking the Vercel project and pull the env vars
2. `pnpm dev:astro`

I'll try to figure out how to get the deployment preview to work.