### PR TITLE
fix: improve lazy loading of `enableVisualEditing`

### DIFF
--- a/packages/overlays/package.json
+++ b/packages/overlays/package.json
@@ -102,7 +102,7 @@
     "root": true
   },
   "dependencies": {
-    "@sanity/visual-editing": "1.8.20"
+    "@sanity/visual-editing": "workspace:*"
   },
   "devDependencies": {
     "@repo/package.config": "workspace:*",

--- a/packages/svelte-loader/package.json
+++ b/packages/svelte-loader/package.json
@@ -98,7 +98,7 @@
     "@sanity/client": "^6.18.2",
     "@sanity/pkg-utils": "6.8.15",
     "@sanity/preview-url-secret": "^1.6.13",
-    "@sanity/visual-editing": "1.8.20",
+    "@sanity/visual-editing": "workspace:*",
     "@sveltejs/kit": "^2.5.8",
     "@typescript-eslint/eslint-plugin": "^7.9.0",
     "@typescript-eslint/parser": "^7.9.0",

--- a/packages/visual-editing/src/ui/renderVisualEditing.tsx
+++ b/packages/visual-editing/src/ui/renderVisualEditing.tsx
@@ -1,0 +1,52 @@
+/**
+ * The purpose of this file is to contain the logic for rendering the <VisualEditing />
+ * component in a way that is easy to lazy load for the `enableVisualEditing` function.
+ */
+
+import {createRoot, type Root} from 'react-dom/client'
+
+import {OVERLAY_ID} from '../constants'
+import type {VisualEditingOptions} from '../types'
+import {VisualEditing} from './VisualEditing'
+
+let node: HTMLElement | null = null
+let root: Root | null = null
+let cleanup: ReturnType<typeof setTimeout> | null = null
+
+export function renderVisualEditing(
+  signal: AbortSignal,
+  {history, refresh, zIndex}: VisualEditingOptions,
+): void {
+  // Cancel pending cleanups, this is useful to avoid overlays blinking as the parent app transition between URLs, or hot module reload is happening
+  if (cleanup) clearTimeout(cleanup)
+  // Setup a cleanup function listener right away, as the signal might abort in-between the next steps
+  signal.addEventListener('abort', () => {
+    // Handle React StrictMode, delay cleanup for a second in case it's a rerender
+    cleanup = setTimeout(() => {
+      if (root) {
+        root.unmount()
+        root = null
+      }
+      if (node) {
+        document.body.removeChild(node)
+        node = null
+      }
+    }, 1000)
+  })
+
+  if (!node) {
+    // eslint-disable-next-line no-warning-comments
+    // @TODO use 'sanity-visual-editing' instead of 'div'
+    node = document.createElement('div')
+    // eslint-disable-next-line no-warning-comments
+    // @TODO after the element is `sanity-visual-editing` instead of `div`, stop setting this ID
+    node.id = OVERLAY_ID
+    document.body.appendChild(node)
+  }
+
+  if (!root) {
+    root = createRoot(node)
+  }
+
+  root.render(<VisualEditing history={history} refresh={refresh} zIndex={zIndex} />)
+}


### PR DESCRIPTION
Improves lazy loading by shifting more code into the lazy loaded function itself.

[Before](https://esm.sh/@sanity/visual-editing@1.8.20?exports=enableVisualEditing):
```js
/* esm.sh - esbuild bundle(@sanity/visual-editing@1.8.20) es2022 production */
import{jsx as i,Fragment as m}from"/stable/react@18.3.1/es2022/jsx-runtime.js";var u="sanity-visual-editing",e=null,t=null,r=null;function a(l={}){r&&clearTimeout(r);let n=new AbortController;return Promise.all([import("/v135/react-dom@18.3.1/es2022/client.js"),import("/v135/@sanity/visual-editing@1.8.20/X-dHMvZW5hYmxlVmlzdWFsRWRpdGluZw/es2022/dist/_chunks-es/VisualEditing.js")]).then(([o,{VisualEditing:s}])=>{if(!n.signal.aborted){if(e||(e=document.createElement("div"),e.id=u,document.body.appendChild(e)),!t){let{createRoot:d}="default"in o?o.default:o;t=d(e)}t.render(i(m,{children:i(s,{...l})}))}}),()=>{n.abort(),r=window.setTimeout(()=>{t&&(t.unmount(),t=null),e&&(document.body.removeChild(e),e=null)},1e3)}}export{a as enableVisualEditing};
```
This import causes a lot of code to load even though `enableVisualEditing` isn't called yet:
```
import{jsx as i,Fragment as m}from"/stable/react@18.3.1/es2022/jsx-runtime.js"
```

[After](https://esm.sh/@sanity/visual-editing@1.8.21-canary.0?exports=enableVisualEditing)
```js
function e(o={}){let r=new AbortController;return import("/v135/@sanity/visual-editing@1.8.21-canary.0/X-dHMvZW5hYmxlVmlzdWFsRWRpdGluZw/es2022/dist/_chunks-es/renderVisualEditing.js").then(({renderVisualEditing:n})=>{let{signal:t}=r;t.aborted||n(t,o)}),()=>{r.abort()}}export{e as enableVisualEditing};
```
Much better, the only import is the dynamic `import("/dist/_chunks-es/renderVisualEditing.js")`, and the surrounding code is minimal 🎉 