### PR TITLE
chore(visual-editing): inherit root prettier config

### DIFF
--- a/packages/visual-editing/package.json
+++ b/packages/visual-editing/package.json
@@ -88,7 +88,6 @@
     "watch": "pkg watch --strict"
   },
   "browserslist": "extends @sanity/browserslist-config",
-  "prettier": "@sanity/prettier-config",
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",
     "parserOptions": {

--- a/packages/visual-editing/svelte/VisualEditing.svelte
+++ b/packages/visual-editing/svelte/VisualEditing.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
-  import {
-    enableVisualEditing,
-    type HistoryAdapterNavigate,
-  } from '../dist/index.js'
-  import { afterNavigate, goto, invalidateAll } from '$app/navigation'
-  import type { VisualEditingProps } from './types'
+  import {onMount} from 'svelte'
+  import {enableVisualEditing, type HistoryAdapterNavigate} from '../dist/index.js'
+  import {afterNavigate, goto, invalidateAll} from '$app/navigation'
+  import type {VisualEditingProps} from './types'
 
   export let zIndex: VisualEditingProps['zIndex'] = undefined
   /**
@@ -47,7 +44,7 @@
         update: (update) => {
           if (update.type === 'push' || update.type === 'replace') {
             navigatingFromUpdate = true
-            goto(update.url, { replaceState: update.type === 'replace' })
+            goto(update.url, {replaceState: update.type === 'replace'})
           } else if (update.type === 'pop') {
             history.back()
           }
@@ -56,10 +53,10 @@
     }),
   )
 
-  afterNavigate(async ({ to, complete }) => {
+  afterNavigate(async ({to, complete}) => {
     if (navigate && to && !navigatingFromUpdate) {
       await complete
-      navigate({ type: 'push', url: to.url.pathname + to.url.search })
+      navigate({type: 'push', url: to.url.pathname + to.url.search})
     }
     navigatingFromUpdate = false
   })


### PR DESCRIPTION
To allow formatting of `.svelte` and `.astro` files in the package.