### PR TITLE
feat: support react 19

### DIFF
--- a/packages/react-loader/package.json
+++ b/packages/react-loader/package.json
@@ -150,7 +150,7 @@
   },
   "peerDependencies": {
     "@sanity/client": "^6.19.0",
-    "react": "^18.2.0"
+    "react": "^18.3 || >=19.0.0-rc"
   },
   "engines": {
     "node": ">=18"

--- a/packages/react-loader/src/jsx/SanityElement.tsx
+++ b/packages/react-loader/src/jsx/SanityElement.tsx
@@ -1,6 +1,6 @@
 import {encodeSanityNodeData, type SourceNode} from '@repo/visual-editing-helpers/csm'
 import type {HTMLProps, Ref} from 'react'
-import {createElement, forwardRef} from 'react'
+import {forwardRef} from 'react'
 
 export interface SanityElementProps {
   children?: SourceNode | null
@@ -10,19 +10,16 @@ export const SanityElement = forwardRef(function SanityElement(
   props: {as: string} & SanityElementProps & Omit<HTMLProps<HTMLElement>, 'children'>,
   ref: Ref<HTMLElement | SVGElement>,
 ) {
-  const {as, children: node, ...restProps} = props
+  const {as: As, children: node, ...restProps} = props
 
   if (node?.source) {
-    return createElement(
-      as,
-      {
-        ...restProps,
-        'data-sanity': encodeSanityNodeData(node.source),
-        ref,
-      },
-      node.value,
+    return (
+      // @ts-expect-error @TODO find out why children is not allowed in IntrinsicAttributes
+      <As {...restProps} data-sanity={encodeSanityNodeData(node.source)} ref={ref}>
+        {node.value}
+      </As>
     )
   }
 
-  return createElement(as, restProps, node?.value)
+  return <As {...restProps}>{node?.value}</As>
 })

--- a/packages/react-loader/src/jsx/jsx.tsx
+++ b/packages/react-loader/src/jsx/jsx.tsx
@@ -1,5 +1,5 @@
 import type {ForwardRefExoticComponent, HTMLProps, ReactElement, Ref, SVGProps} from 'react'
-import {createElement, forwardRef} from 'react'
+import {forwardRef} from 'react'
 
 import {htmlElements} from './html'
 import type {SanityElementProps} from './SanityElement'
@@ -35,7 +35,7 @@ const sanity = new Proxy({} as SanityElements, {
         props: SanityElementProps & Omit<HTMLProps<HTMLElement>, 'children' | 'ref'>,
         ref: Ref<HTMLElement>,
       ): ReactElement {
-        return createElement(SanityElement, {as: prop, ref, ...props})
+        return <SanityElement {...props} as={prop} ref={ref} />
       })
 
       SanityComponent.displayName = `sanity.${prop}`
@@ -52,7 +52,7 @@ const sanity = new Proxy({} as SanityElements, {
         props: SanityElementProps & Omit<SVGProps<SVGElement>, 'children' | 'ref'>,
         ref: Ref<SVGElement>,
       ): ReactElement {
-        return createElement(SanityElement, {as: prop, ref, ...props} as any)
+        return <SanityElement {...(props as any)} as={prop} ref={ref} />
       })
 
       SanityComponent.displayName = `sanity.${prop}`


### PR DESCRIPTION
The rewrite of `createElement` is to ensure we take full advantage of the JSX transform enhancements in React 19: https://react.dev/blog/2024/04/25/react-19-upgrade-guide#new-jsx-transform-is-now-required
