### PR TITLE
fix(insert-menu): properly define @sanity/types dependency

### DIFF
--- a/packages/insert-menu/package.json
+++ b/packages/insert-menu/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@sanity/pkg-utils": "^6.9.1",
+    "@sanity/types": "^3.45.0",
     "@typescript-eslint/eslint-plugin": "^7.12.0",
     "@typescript-eslint/parser": "^7.12.0",
     "eslint": "^8.57.0",
@@ -52,10 +53,10 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-is": "^18.3.1",
-    "sanity": "3.45.0",
     "typescript": "^5.4.5"
   },
   "peerDependencies": {
+    "@sanity/types": "^3.45.0",
     "react": "^18.3 || >=19.0.0-rc",
     "react-dom": "^18.3 || >=19.0.0-rc",
     "react-is": "^18.3 || >=19.0.0-rc"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1026,6 +1026,9 @@ importers:
       '@sanity/pkg-utils':
         specifier: ^6.9.1
         version: 6.9.1(typescript@5.4.5)
+      '@sanity/types':
+        specifier: 3.45.0
+        version: 3.45.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.12.0
         version: 7.12.0(@typescript-eslint/parser@7.12.0)(eslint@8.57.0)(typescript@5.4.5)
@@ -1053,9 +1056,6 @@ importers:
       react-is:
         specifier: ^18.3.1
         version: 18.3.1
-      sanity:
-        specifier: 3.45.0
-        version: 3.45.0(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.11)
       typescript:
         specifier: ^5.4.5
         version: 5.4.5


### PR DESCRIPTION
`sanity` was mistakenly added as a dependency instead of `@sanity/types`. Furthermore, `@sanity/types` needs to be defined as a peer dependency in order to avoid `Types of parameters 'schemaType' and 'schemaType' are incompatible.` errors when using this package inside the `sanity` monorepo.