### PR TITLE
fix(insert-menu): adjust `InsertMenuOptions` slightly

### DIFF
--- a/packages/insert-menu/src/InsertMenu.tsx
+++ b/packages/insert-menu/src/InsertMenu.tsx
@@ -71,7 +71,7 @@ export type InsertMenuProps = InsertMenuOptions & {
 
 /** @alpha */
 export function InsertMenu(props: InsertMenuProps): React.JSX.Element {
-  const showIcons = props.icons === undefined ? true : props.icons
+  const showIcons = props.showIcons === undefined ? true : props.showIcons
   const [state, send] = useReducer(fullInsertMenuReducer, {
     query: '',
     groups: props.groups

--- a/packages/insert-menu/src/InsertMenu.tsx
+++ b/packages/insert-menu/src/InsertMenu.tsx
@@ -176,7 +176,7 @@ export function InsertMenu(props: InsertMenuProps): React.JSX.Element {
                   onClick={() => {
                     props.onSelect(schemaType)
                   }}
-                  previewUrl={selectedView.previewUrl}
+                  previewImageUrl={selectedView.previewImageUrl}
                   schemaType={schemaType}
                 />
               ))}
@@ -245,7 +245,10 @@ type GridMenuItemProps = {
   onClick: () => void
   schemaType: SchemaType
   icon: MenuItemProps['icon']
-  previewUrl: Extract<NonNullable<InsertMenuOptions['views']>[number], {name: 'grid'}>['previewUrl']
+  previewImageUrl: Extract<
+    NonNullable<InsertMenuOptions['views']>[number],
+    {name: 'grid'}
+  >['previewImageUrl']
 }
 
 function GridMenuItem(props: GridMenuItemProps) {
@@ -279,7 +282,7 @@ function GridMenuItem(props: GridMenuItemProps) {
           ) : null}
           {failedToLoad ? null : (
             <img
-              src={props.previewUrl(props.schemaType.name)}
+              src={props.previewImageUrl(props.schemaType.name)}
               style={{
                 objectFit: 'contain',
                 width: '100%',

--- a/packages/insert-menu/src/InsertMenu.tsx
+++ b/packages/insert-menu/src/InsertMenu.tsx
@@ -72,6 +72,7 @@ export type InsertMenuProps = InsertMenuOptions & {
 /** @alpha */
 export function InsertMenu(props: InsertMenuProps): React.JSX.Element {
   const showIcons = props.showIcons === undefined ? true : props.showIcons
+  const showFilter = props.filter ?? props.schemaTypes.length > 5
   const [state, send] = useReducer(fullInsertMenuReducer, {
     query: '',
     groups: props.groups
@@ -91,7 +92,7 @@ export function InsertMenu(props: InsertMenuProps): React.JSX.Element {
   })
   const filteredSchemaTypes = filterSchemaTypes(props.schemaTypes, state.query, state.groups)
   const selectedView = state.views.find((view) => view.selected)
-  const showingFilterOrViews = props.filter || state.views.length > 1
+  const showingFilterOrViews = showFilter || state.views.length > 1
   const showingTabs = state.groups && state.groups.length > 0
   const showingAnyOptions = showingFilterOrViews || showingTabs
 
@@ -109,7 +110,7 @@ export function InsertMenu(props: InsertMenuProps): React.JSX.Element {
           {/* filter and views button */}
           {showingFilterOrViews ? (
             <Flex flex="none" align="center" paddingTop={1} paddingX={1} gap={1}>
-              {props.filter ? (
+              {showFilter ? (
                 <Box flex={1}>
                   <TextInput
                     autoFocus

--- a/packages/insert-menu/src/InsertMenu.tsx
+++ b/packages/insert-menu/src/InsertMenu.tsx
@@ -176,7 +176,7 @@ export function InsertMenu(props: InsertMenuProps): React.JSX.Element {
                   onClick={() => {
                     props.onSelect(schemaType)
                   }}
-                  previewImageUrl={selectedView.previewImageUrl}
+                  previewImageUrl={selectedView.previewImageUrl(schemaType.name)}
                   schemaType={schemaType}
                 />
               ))}
@@ -245,10 +245,9 @@ type GridMenuItemProps = {
   onClick: () => void
   schemaType: SchemaType
   icon: MenuItemProps['icon']
-  previewImageUrl: Extract<
-    NonNullable<InsertMenuOptions['views']>[number],
-    {name: 'grid'}
-  >['previewImageUrl']
+  previewImageUrl: ReturnType<
+    Extract<NonNullable<InsertMenuOptions['views']>[number], {name: 'grid'}>['previewImageUrl']
+  >
 }
 
 function GridMenuItem(props: GridMenuItemProps) {
@@ -280,9 +279,9 @@ function GridMenuItem(props: GridMenuItemProps) {
               <Text size={1}>{createElement(props.icon)}</Text>
             </Flex>
           ) : null}
-          {failedToLoad ? null : (
+          {!props.previewImageUrl || failedToLoad ? null : (
             <img
-              src={props.previewImageUrl(props.schemaType.name)}
+              src={props.previewImageUrl}
               style={{
                 objectFit: 'contain',
                 width: '100%',

--- a/packages/insert-menu/src/InsertMenuOptions.ts
+++ b/packages/insert-menu/src/InsertMenuOptions.ts
@@ -6,5 +6,7 @@ export interface InsertMenuOptions {
   /** defaultValue `true` */
   showIcons?: boolean
   /** @defaultValue `[{name: 'list'}]` */
-  views?: Array<{name: 'list'} | {name: 'grid'; previewUrl: (schemaTypeName: string) => string}>
+  views?: Array<
+    {name: 'list'} | {name: 'grid'; previewImageUrl: (schemaTypeName: string) => string}
+  >
 }

--- a/packages/insert-menu/src/InsertMenuOptions.ts
+++ b/packages/insert-menu/src/InsertMenuOptions.ts
@@ -4,7 +4,7 @@ export interface InsertMenuOptions {
   filter?: boolean
   groups?: Array<{name: string; title?: string; of?: Array<string>}>
   /** defaultValue `true` */
-  icons?: boolean
+  showIcons?: boolean
   /** @defaultValue `[{name: 'list'}]` */
   views?: Array<{name: 'list'} | {name: 'grid'; previewUrl: (schemaTypeName: string) => string}>
 }

--- a/packages/insert-menu/src/InsertMenuOptions.ts
+++ b/packages/insert-menu/src/InsertMenuOptions.ts
@@ -7,6 +7,6 @@ export interface InsertMenuOptions {
   showIcons?: boolean
   /** @defaultValue `[{name: 'list'}]` */
   views?: Array<
-    {name: 'list'} | {name: 'grid'; previewImageUrl: (schemaTypeName: string) => string}
+    {name: 'list'} | {name: 'grid'; previewImageUrl: (schemaTypeName: string) => string | undefined}
   >
 }

--- a/packages/insert-menu/src/__workshop__/full.tsx
+++ b/packages/insert-menu/src/__workshop__/full.tsx
@@ -65,7 +65,7 @@ const views: InsertMenuProps['views'] = [
   {name: 'list'},
   {
     name: 'grid',
-    previewImageUrl: (_typeName) => '', // `https://prj-page-builder.sanity.build/preview-${typeName}.png`,
+    previewImageUrl: (_typeName) => undefined, // `https://prj-page-builder.sanity.build/preview-${typeName}.png`,
   },
 ]
 

--- a/packages/insert-menu/src/__workshop__/full.tsx
+++ b/packages/insert-menu/src/__workshop__/full.tsx
@@ -1,4 +1,11 @@
-import {CommentIcon, DesktopIcon, EnvelopeIcon, InfoOutlineIcon, SyncIcon} from '@sanity/icons'
+import {
+  CommentIcon,
+  DesktopIcon,
+  EnvelopeIcon,
+  InfoOutlineIcon,
+  SyncIcon,
+  DocumentVideoIcon,
+} from '@sanity/icons'
 import type {ObjectSchemaType} from '@sanity/types'
 import {Box, Card, LayerProvider} from '@sanity/ui'
 import {useAction, useSelect} from '@sanity/ui-workshop'
@@ -54,6 +61,14 @@ const schemaTypes: ObjectSchemaType[] = [
     fields: [],
     __experimental_search: [],
   },
+  {
+    jsonType: 'object',
+    name: 'videos',
+    title: 'Videos',
+    icon: DocumentVideoIcon,
+    fields: [],
+    __experimental_search: [],
+  },
 ]
 
 const groups: InsertMenuProps['groups'] = [
@@ -71,7 +86,11 @@ const views: InsertMenuProps['views'] = [
 
 export default function FullStory() {
   const iconsEnabled = useSelect('showIcons', {true: true, false: false}, true)
-  const filterEnabled = useSelect('filter', {true: true, false: false}, true)
+  const filterEnabled = useSelect(
+    'filter',
+    {true: true, false: false, undefined: 'undefined'},
+    true,
+  )
   const groupsEnabled = useSelect('groups', {true: true, false: false}, true)
   const viewsEnabled = useSelect('views', {true: true, false: false}, true)
 
@@ -83,7 +102,7 @@ export default function FullStory() {
         <LayerProvider>
           <InsertMenu
             showIcons={iconsEnabled}
-            filter={filterEnabled}
+            filter={filterEnabled === 'undefined' ? undefined : filterEnabled}
             groups={groupsEnabled ? groups : undefined}
             views={viewsEnabled ? views : undefined}
             labels={labels}

--- a/packages/insert-menu/src/__workshop__/full.tsx
+++ b/packages/insert-menu/src/__workshop__/full.tsx
@@ -65,12 +65,12 @@ const views: InsertMenuProps['views'] = [
   {name: 'list'},
   {
     name: 'grid',
-    previewUrl: (_typeName) => '', // `https://prj-page-builder.sanity.build/preview-${typeName}.png`,
+    previewImageUrl: (_typeName) => '', // `https://prj-page-builder.sanity.build/preview-${typeName}.png`,
   },
 ]
 
 export default function FullStory() {
-  const iconsEnabled = useSelect('icons', {true: true, false: false}, true)
+  const iconsEnabled = useSelect('showIcons', {true: true, false: false}, true)
   const filterEnabled = useSelect('filter', {true: true, false: false}, true)
   const groupsEnabled = useSelect('groups', {true: true, false: false}, true)
   const viewsEnabled = useSelect('views', {true: true, false: false}, true)
@@ -82,7 +82,7 @@ export default function FullStory() {
       <Card radius={3} shadow={3}>
         <LayerProvider>
           <InsertMenu
-            icons={iconsEnabled}
+            showIcons={iconsEnabled}
             filter={filterEnabled}
             groups={groupsEnabled ? groups : undefined}
             views={viewsEnabled ? views : undefined}


### PR DESCRIPTION
See each commit for details.

Most noticeable, I've allowed `previewImageUrl` to return `undefined`: d73ea505903b7016db7a8fb3e5b128ce872ac2e2

And allowed filtering to be enabled by default if there are more than 5 schema types in the menu: d5c2c82c746df714c64ebdebafb6bf1eb47b781f