### PR TITLE
fix(insert-menu): set `placement` property of tooltip

### DIFF
--- a/packages/insert-menu/src/InsertMenu.tsx
+++ b/packages/insert-menu/src/InsertMenu.tsx
@@ -232,7 +232,7 @@ function ViewToggle(props: ViewToggleProps) {
   return (
     <Tooltip
       content={<Text size={1}>{props.labels[viewToggleTooltip[nextView.name]]}</Text>}
-      placeholder="top"
+      placement="top"
       portal
     >
       <Button


### PR DESCRIPTION
Fixes a typo in the `placement` property of the tooltip.