### PR TITLE
fix(presentation): prevent displaying main document on explicit document navigation

### DIFF
--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -118,6 +118,7 @@ export default function PresentationTool(props: {
 
   const {
     navigate: _navigate,
+    navigationHistory,
     params,
     searchParams,
     structureParams,
@@ -147,11 +148,12 @@ export default function PresentationTool(props: {
   const dataset = useDataset()
 
   const mainDocumentState = useMainDocument({
-    resolvers: props.tool.options?.resolve?.mainDocuments,
-    previewUrl: props.tool.options?.previewUrl,
-    path: params.preview,
     // Prevent flash of content by using immediate navigation
     navigate: _navigate,
+    navigationHistory,
+    path: params.preview,
+    previewUrl: props.tool.options?.previewUrl,
+    resolvers: props.tool.options?.resolve?.mainDocuments,
   })
 
   const [overlaysConnection, setOverlaysConnection] = useState<ChannelStatus>('connecting')

--- a/packages/presentation/src/useParams.ts
+++ b/packages/presentation/src/useParams.ts
@@ -1,4 +1,4 @@
-import {type MutableRefObject, useCallback, useEffect, useMemo, useRef} from 'react'
+import {type MutableRefObject, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import type {RouterContextValue, RouterState, SearchParam} from 'sanity/router'
 
 import {getPublishedId} from './internals'
@@ -37,6 +37,7 @@ export function useParams({
   frameStateRef: MutableRefObject<FrameState>
 }): {
   navigate: PresentationNavigate
+  navigationHistory: RouterState[]
   params: PresentationParams
   searchParams: PresentationSearchParams
   structureParams: StructureDocumentPaneParams
@@ -113,6 +114,8 @@ export function useParams({
     routerStateRef.current = routerState
   }, [routerState])
 
+  const [navigationHistory, setNavigationHistory] = useState<RouterState[]>([routerState])
+
   const navigate = useCallback<PresentationNavigate>(
     (nextState, nextSearchState = {}, forceReplace) => {
       // Force navigation to use published IDs only
@@ -152,6 +155,7 @@ export function useParams({
 
       const replace = forceReplace ?? searchState.preview === frameStateRef.current.url
 
+      setNavigationHistory((prev) => [...prev, state])
       routerNavigate(state, {replace})
     },
     [routerNavigate, frameStateRef],
@@ -159,6 +163,7 @@ export function useParams({
 
   return {
     navigate,
+    navigationHistory,
     params,
     searchParams,
     structureParams,


### PR DESCRIPTION
### Overview

This one has been reported by a few different people.

Currently the main document resolver is far too keen in automatically navigating users to the main document for a given path:

A main document is resolved (or not) for the current preview path after each, and on the initial, navigation. This means that if a user follows a link which contains a path which resolves a main document, but a document id that does not match it, the main document will override that specified.

This PR fixes this by comparing the previous two router states (i.e. the previous navigation event) before forcing a main document navigation. If the previous navigation did not trigger a document change, or in other words the path changed but the document did not, then we can safely show the main document.

### Test


🔴 [Navigating on main](https://visual-editing-studio.sanity.build/page-builder-demo/presentation/product/462efcc6-3c8b-47c6-8474-5544e1a4acde?preview=/) will show a flash of the document whose ID corresponds to that in the URL, and then show the main document.

🟢 [Navigating on this branch](https://visual-editing-studio-git-crx-795.sanity.build/page-builder-demo/presentation/product/462efcc6-3c8b-47c6-8474-5544e1a4acde?preview=%2F) will correctly display the document whose ID corresponds to that in the URL.