### PR TITLE
fix(presentation): preserve tool state across intent link navigations

### DIFF
--- a/packages/presentation/src/getIntentState.ts
+++ b/packages/presentation/src/getIntentState.ts
@@ -1,8 +1,14 @@
 import {uuid} from '@sanity/uuid'
-import {type SearchParam} from 'sanity/router'
+import {type RouterState, type SearchParam} from 'sanity/router'
 
 import {encodeJsonParams, getPublishedId} from './internals'
-import type {PresentationStateParams} from './types'
+import type {PresentationSearchParams, PresentationStateParams} from './types'
+
+const preservedSearchParamKeys: Array<keyof PresentationSearchParams> = [
+  'preview',
+  'perspective',
+  'viewport',
+]
 
 /**
  * @internal
@@ -10,7 +16,7 @@ import type {PresentationStateParams} from './types'
 export function getIntentState(
   intent: string,
   params: Record<string, string>,
-  _routerState: undefined,
+  routerState: RouterState | undefined,
   payload: unknown,
 ):
   | (PresentationStateParams & {_searchParams: SearchParam[]})
@@ -18,27 +24,37 @@ export function getIntentState(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const {id, mode, path, presentation, type, ...searchParams} = params
 
+  const preservedSearchParams = (routerState?._searchParams || [])
+    // @todo Casting https://github.com/microsoft/TypeScript/issues/14520
+    .filter(([key]) => preservedSearchParamKeys.includes(key as keyof PresentationSearchParams))
+    .reduce((acc, [key, value]) => ({...acc, [key]: value}), {} as Record<string, string>)
+
+  const _searchParams = {
+    ...preservedSearchParams,
+    ...searchParams,
+  }
+
   if (intent === 'edit' && id) {
     return {
       type: type || '*',
       id: getPublishedId(id),
       path,
-      _searchParams: Object.entries(searchParams),
+      _searchParams: Object.entries(_searchParams),
     }
   }
 
   if (intent === 'create') {
-    searchParams['preview'] =
-      searchParams['preview'] || new URLSearchParams(window.location.search).get('preview') || '/'
+    _searchParams['preview'] =
+      _searchParams['preview'] || new URLSearchParams(window.location.search).get('preview') || '/'
 
     if (payload && typeof payload === 'object') {
-      searchParams['templateParams'] = encodeJsonParams(payload as Record<string, unknown>)
+      _searchParams['templateParams'] = encodeJsonParams(payload as Record<string, unknown>)
     }
 
     return {
       type: type || '*',
       id: id || uuid(),
-      _searchParams: Object.entries(searchParams),
+      _searchParams: Object.entries(_searchParams),
     }
   }
   return {intent, params, payload}


### PR DESCRIPTION
### Summary

This pull request addresses the handling of router state when navigating via intent links in the Presentation tool.

Currently, the Presentation tool does not maintain search parameter-specific state when handling intent links. This can lead to unintended side effects, such as resetting the preview URL and changing the viewport size when intent links are used to navigate within the tool.

### Proposed Solution
The solution involves updating the `getIntentState` method to preserve the search parameters related to the Presentation tool's state (as defined in the [PresentationSearchParams](https://github.com/sanity-io/visual-editing/blob/main/packages/presentation/src/types.ts#L173-L177) interface), rather than requiring them to be explicitly defined when constructing an intent link.

### Testing and Validation
In our test environment, we have an experimental navigator component that uses intent links to create new documents in-situ. You'll notice a narrow/mobile viewport size will not be maintained when using these links because the relevant parameter is not explicitly set. On this branch, that state will be maintained.

Feedback is appreciated to confirm if this approach aligns with the expected behaviour of intent links. Is preserving these parameters the correct approach? Should the handling of intent links be tool/parameter specific, or is there a general expectation for how they should behave?