### PR TITLE
fix(presentation): add iframe pointer events to prevent interference with resizing drag handler

### DIFF
--- a/packages/presentation/src/panels/PanelResizer.tsx
+++ b/packages/presentation/src/panels/PanelResizer.tsx
@@ -107,11 +107,35 @@ export const PanelResizer: FunctionComponent<{
   useEffect(() => {
     if (!isDragging || disabled) return
 
+    // Set styles to prevent text selection and force an ew-resize cursor whilst
+    // dragging. Return a reset callback so we can revert to any values that
+    // might have been present before dragging started.
+    function setDocumentStyles() {
+      const bodyStyle = document.body.style
+      const documentStyle = document.documentElement.style
+
+      const {cursor} = documentStyle
+      const {userSelect} = bodyStyle
+
+      documentStyle.cursor = 'ew-resize'
+      bodyStyle.userSelect = 'none'
+
+      return () => {
+        if (cursor) documentStyle.cursor = cursor
+        else documentStyle.removeProperty('cursor')
+
+        if (userSelect) bodyStyle.userSelect = userSelect
+        else bodyStyle.removeProperty('user-select')
+      }
+    }
+
+    const resetDocumentStyles = setDocumentStyles()
     window.addEventListener('mousemove', onDrag)
     window.addEventListener('mouseup', onDragStop)
     window.addEventListener('contextmenu', onDragStop)
 
     return () => {
+      resetDocumentStyles()
       window.removeEventListener('mousemove', onDrag)
       window.removeEventListener('mouseup', onDragStop)
       window.removeEventListener('contextmenu', onDragStop)

--- a/packages/presentation/src/panels/PanelResizer.tsx
+++ b/packages/presentation/src/panels/PanelResizer.tsx
@@ -109,10 +109,12 @@ export const PanelResizer: FunctionComponent<{
 
     window.addEventListener('mousemove', onDrag)
     window.addEventListener('mouseup', onDragStop)
+    window.addEventListener('contextmenu', onDragStop)
 
     return () => {
       window.removeEventListener('mousemove', onDrag)
       window.removeEventListener('mouseup', onDragStop)
+      window.removeEventListener('contextmenu', onDragStop)
     }
   }, [disabled, isDragging, onDrag, onDragStop])
 

--- a/packages/presentation/src/preview/IFrame.tsx
+++ b/packages/presentation/src/preview/IFrame.tsx
@@ -1,9 +1,47 @@
-import {motion} from 'framer-motion'
+import {Box} from '@sanity/ui'
+import {motion, type VariantLabels, type Variants} from 'framer-motion'
+import {forwardRef, type ReactEventHandler} from 'react'
 import {styled} from 'styled-components'
 
-export const IFrame = motion(styled.iframe`
-  border: 0;
+const IFrameElement = motion(styled.iframe`
+  box-shadow: 0 0 0 1px var(--card-border-color);
+  border-top: 1px solid transparent;
+  border-bottom: 0;
+  border-right: 0;
+  border-left: 0;
   max-height: 100%;
   width: 100%;
-  display: block;
 `)
+
+const IFrameOverlay = styled(Box)`
+  position: absolute;
+  inset: 0;
+  background: transparent;
+`
+
+interface IFrameProps {
+  animate: VariantLabels
+  initial: VariantLabels
+  onLoad: ReactEventHandler<HTMLIFrameElement>
+  preventClick: boolean
+  src: string
+  variants: Variants
+}
+
+export const IFrame = forwardRef<HTMLIFrameElement, IFrameProps>(function IFrame(props, ref) {
+  const {animate, initial, onLoad, preventClick, src, variants} = props
+
+  return (
+    <>
+      <IFrameElement
+        animate={animate}
+        initial={initial}
+        onLoad={onLoad}
+        ref={ref}
+        src={src}
+        variants={variants}
+      />
+      {preventClick && <IFrameOverlay />}
+    </>
+  )
+})

--- a/packages/presentation/src/preview/PreviewFrame.tsx
+++ b/packages/presentation/src/preview/PreviewFrame.tsx
@@ -240,6 +240,22 @@ export const PreviewFrame = forwardRef<HTMLIFrameElement, PreviewFrameProps>(
       }
     }, [ref])
 
+    const preventIframeInteraction = useMemo(() => {
+      return (
+        (loading || (overlaysConnection === 'connecting' && iframe.status !== 'refreshing')) &&
+        !continueAnyway
+      )
+    }, [continueAnyway, iframe.status, loading, overlaysConnection])
+
+    const iframeAnimations = useMemo(() => {
+      return [
+        preventIframeInteraction ? 'background' : 'active',
+        loading ? 'reloading' : 'idle',
+        viewport,
+        showOverlaysConnectionStatus && !continueAnyway ? 'timedOut' : '',
+      ]
+    }, [continueAnyway, loading, preventIframeInteraction, showOverlaysConnectionStatus, viewport])
+
     return (
       <MotionConfig transition={prefersReducedMotion ? {duration: 0} : undefined}>
         <TooltipDelayGroupProvider delay={1000}>
@@ -679,31 +695,13 @@ export const PreviewFrame = forwardRef<HTMLIFrameElement, PreviewFrameProps>(
                 ) : null}
               </AnimatePresence>
               <IFrame
-                ref={ref}
-                style={{
-                  pointerEvents:
-                    (loading ||
-                      (overlaysConnection === 'connecting' && iframe.status !== 'refreshing')) &&
-                    !continueAnyway
-                      ? 'none'
-                      : 'auto',
-                  boxShadow: '0 0 0 1px var(--card-border-color)',
-                  borderTop: '1px solid transparent',
-                }}
-                src={initialUrl.toString()}
+                animate={iframeAnimations}
                 initial={['background']}
-                variants={iframeVariants}
-                animate={[
-                  (loading ||
-                    (overlaysConnection === 'connecting' && iframe.status !== 'refreshing')) &&
-                  !continueAnyway
-                    ? 'background'
-                    : 'active',
-                  loading ? 'reloading' : 'idle',
-                  viewport,
-                  showOverlaysConnectionStatus && !continueAnyway ? 'timedOut' : '',
-                ]}
                 onLoad={onIFrameLoad}
+                preventClick={preventIframeInteraction}
+                ref={ref}
+                src={initialUrl.toString()}
+                variants={iframeVariants}
               />
             </Flex>
           </Card>


### PR DESCRIPTION
### Overview

We prevent users interacting with iframe content whilst the iframe is loading or whilst a connection is being established to  the Presentation tool.

Currently, this is done using `pointer-events: none;` on the iframe itself. However this means panel resizing does not play nicely at all (see Linear ticket for video), as I assume it prevents `mousemove` events as a user's cursor hovers over the iframe.

This PR attempts similar behaviour by replacing `pointer-events: none;` with a transparent absolutely positioned div, preventing interaction with the iframe but allowing the `mousemove` events we need to handle resizing.

Also some minor refactoring to tidy up the iframe component.

### Test

Drag the divider between iframe and document pane in Presentation tool on main and then this branch. Your dragging experience should be markedly improved.