### PR TITLE
fix(visual-editing): import svelte types from dist over src

### DIFF
--- a/packages/visual-editing/svelte/types.ts
+++ b/packages/visual-editing/svelte/types.ts
@@ -1,6 +1,6 @@
 import type {SanityClient} from '@sanity/client'
 
-import type {HistoryRefresh, VisualEditingOptions} from '../src/types'
+import type {HistoryRefresh, VisualEditingOptions} from '../dist'
 
 /** @public */
 export interface VisualEditingProps {


### PR DESCRIPTION
Related to https://github.com/sanity-io/sanity-template-sveltekit-clean/issues/40.

Currently we import types from the sibling `/src` directory, which results in errors as `@repo/` imports cannot be resolved.