### PR TITLE
fix(visual-editing): improve overlay mutation handling

### DIFF
--- a/packages/visual-editing/src/controller.ts
+++ b/packages/visual-editing/src/controller.ts
@@ -88,15 +88,13 @@ export function createOverlayController({
    * Executed when element enters the viewport
    * Enables an element’s event handlers
    */
-  function activateElement({id, elements, handlers, sanity}: OverlayElement) {
+  function activateElement({id, elements, handlers}: OverlayElement) {
     const {element, measureElement} = elements
     addEventHandlers(element, handlers)
     ro.observe(measureElement)
     handler({
       type: 'element/activate',
       id,
-      rect: getRect(element),
-      sanity,
     })
   }
 
@@ -130,11 +128,14 @@ export function createOverlayController({
             event.preventDefault()
             event.stopPropagation()
           }
-          handler({
-            type: 'element/click',
-            id,
-            sanity,
-          })
+          const sanity = elementsMap.get(element)?.sanity
+          if (sanity) {
+            handler({
+              type: 'element/click',
+              id,
+              sanity,
+            })
+          }
         }
       },
       mousedown(event) {
@@ -232,12 +233,14 @@ export function createOverlayController({
   }
 
   function updateElement({elements, sanity}: ResolvedElement) {
-    const overlayElement = elementsMap.get(elements.element)
+    const {element} = elements
+    const overlayElement = elementsMap.get(element)
     if (overlayElement) {
+      elementsMap.set(element, {...overlayElement, sanity})
       handler({
         type: 'element/update',
         id: overlayElement.id,
-        rect: getRect(elements.element),
+        rect: getRect(element),
         sanity: sanity,
       })
     }

--- a/packages/visual-editing/src/index.ts
+++ b/packages/visual-editing/src/index.ts
@@ -22,6 +22,7 @@ export type {
   OverlayMsgElementMouseLeave,
   OverlayMsgElementRegister,
   OverlayMsgElementUnregister,
+  OverlayMsgElementUpdate,
   OverlayMsgElementUpdateRect,
   OverlayOptions,
   OverlayRect,

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -78,6 +78,12 @@ export type OverlayMsgElementRegister = OverlayMsgElement<'register'> & {
 }
 
 /** @public */
+export type OverlayMsgElementUpdate = OverlayMsgElement<'update'> & {
+  sanity: SanityNode | SanityStegaNode
+  rect: OverlayRect
+}
+
+/** @public */
 export type OverlayMsgElementUnregister = OverlayMsgElement<'unregister'>
 
 /** @public */
@@ -100,6 +106,7 @@ export type OverlayMsg =
   | OverlayMsgElementMouseLeave
   | OverlayMsgElementRegister
   | OverlayMsgElementUnregister
+  | OverlayMsgElementUpdate
   | OverlayMsgElementUpdateRect
 
 /**

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -41,10 +41,7 @@ export interface OverlayMsgElement<T extends string> extends Msg<`element/${T}`>
 }
 
 /** @public */
-export type OverlayMsgElementActivate = OverlayMsgElement<'activate'> & {
-  sanity: SanityNode | SanityStegaNode
-  rect: OverlayRect
-}
+export type OverlayMsgElementActivate = OverlayMsgElement<'activate'>
 
 /** @public */
 export type OverlayMsgBlur = Msg<'overlay/blur'>

--- a/packages/visual-editing/src/ui/elementsReducer.ts
+++ b/packages/visual-editing/src/ui/elementsReducer.ts
@@ -34,6 +34,14 @@ export const elementsReducer = (
         }
         return e
       })
+    case 'element/update': {
+      return elements.map((e) => {
+        if (e.id === message.id) {
+          return {...e, sanity: message.sanity, rect: message.rect}
+        }
+        return e
+      })
+    }
     case 'element/unregister':
       return elements.filter((e) => e.id !== message.id)
     case 'element/deactivate':


### PR DESCRIPTION
This adds a method for updating an existing element detected by the overlay controller, rather than having to de-and-re-register it to track updates.

It also adds support for handling text mutations, which means changes in stega encoded strings will be picked up (they weren't before!)

It seems to make things much more predictable: no more randomly missing overlays!