### PR TITLE
chore: fix storybook build command

### DIFF
--- a/packages/visual-editing/turbo.json
+++ b/packages/visual-editing/turbo.json
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "build-storybook": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["build"]
     },
     "storybook": {
       "persistent": false


### PR DESCRIPTION
We have to do a bit of a workaround in the project settings atm:

<img width="893" alt="image" src="https://github.com/user-attachments/assets/d1a1986a-aa2c-4d86-a94f-77cfe4022789">

This PR lets us set it back to just `turbo run build-storybook` 🥳 