### PR TITLE
feat(drag-and-drop): v0 UI

### DIFF
--- a/apps/page-builder-demo/src/components/page/Page.tsx
+++ b/apps/page-builder-demo/src/components/page/Page.tsx
@@ -19,6 +19,7 @@ export function Page(props: {data: WrappedValue<PageData>}) {
         type: data._type,
         path: 'sections',
       })}
+      data-sanity-drag-group="sections"
     >
       {isArray(data.sections) &&
         data.sections.map((section) => {

--- a/apps/page-builder-demo/src/components/page/Page.tsx
+++ b/apps/page-builder-demo/src/components/page/Page.tsx
@@ -19,7 +19,6 @@ export function Page(props: {data: WrappedValue<PageData>}) {
         type: data._type,
         path: 'sections',
       })}
-      data-sanity-drag-group="sections"
     >
       {isArray(data.sections) &&
         data.sections.map((section) => {

--- a/apps/page-builder-demo/src/components/page/sections/FeatureHighlight.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/FeatureHighlight.tsx
@@ -22,6 +22,7 @@ export function FeatureHighlight(props: {
       })}
       className="p-4 sm:p-5 md:p-6"
       variant={section.style?.variant?.value as any}
+      data-sanity-draggable
     >
       <div className="-m-4 sm:-m-5 md:-m-6">
         {section.image?.asset && (
@@ -44,6 +45,14 @@ export function FeatureHighlight(props: {
             <sanity.span>{section.description}</sanity.span>
           </p>
         )}
+        <div>
+          {section.ctas &&
+            section.ctas.map((cta, i) => (
+              <sanity.button key={i} data-sanity-draggable>
+                {cta.title}
+              </sanity.button>
+            ))}
+        </div>
       </div>
 
       {section.product && (

--- a/apps/page-builder-demo/src/components/page/sections/FeatureHighlight.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/FeatureHighlight.tsx
@@ -45,10 +45,14 @@ export function FeatureHighlight(props: {
             <sanity.span>{section.description}</sanity.span>
           </p>
         )}
-        <div>
+        <div className="flex gap-3">
           {section.ctas &&
             section.ctas.map((cta, i) => (
-              <sanity.button key={i} data-sanity-draggable>
+              <sanity.button
+                className="mt-5 border border-current p-3"
+                key={i}
+                data-sanity-draggable
+              >
                 {cta.title}
               </sanity.button>
             ))}

--- a/apps/page-builder-demo/src/components/page/sections/FeaturedProducts.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/FeaturedProducts.tsx
@@ -22,24 +22,29 @@ export function FeaturedProducts(props: {
       })}
       className="overflow-hidden"
       variant={section.style?.variant?.value as any}
+      data-sanity-draggable
     >
       <div className="flex w-full flex-nowrap gap-2 overflow-auto p-4 sm:p-5 md:p-6">
         <h1 className="w-96 flex-none p-5 text-2xl font-bold">
           <sanity.span>{section.headline}</sanity.span>
         </h1>
 
-        {section.products?.map?.((product) => (
-          <Link
-            className="block w-96 flex-none border border-white p-5 hover:border-gray-100 dark:border-black dark:hover:border-gray-800"
-            href={`/product/${product.slug?.current?.value}`}
-            key={product._key}
-          >
-            <h2>
-              <sanity.span>{product.title}</sanity.span>
-            </h2>
-            <div>{product.media?.asset && <Image alt="" value={unwrapData(product.media)} />}</div>
-          </Link>
-        ))}
+        <div>
+          {section.products?.map?.((product) => (
+            <Link
+              className="block w-96 flex-none border border-white p-5 hover:border-gray-100 dark:border-black dark:hover:border-gray-800"
+              href={`/product/${product.slug?.current?.value}`}
+              key={product._key}
+            >
+              <h2>
+                <sanity.span>{product.title}</sanity.span>
+              </h2>
+              <div>
+                {product.media?.asset && <Image alt="" value={unwrapData(product.media)} />}
+              </div>
+            </Link>
+          ))}
+        </div>
       </div>
     </PageSection>
   )

--- a/apps/page-builder-demo/src/components/page/sections/Hero.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/Hero.tsx
@@ -20,6 +20,7 @@ export function Hero(props: {
       })}
       className="px-4 py-6 text-center sm:px-5 sm:py-7 md:px-7 md:py-9"
       variant={section.style?.variant?.value as any}
+      data-sanity-draggable
     >
       {section.headline ? (
         <h1 className="text-3xl font-extrabold sm:text-5xl md:text-7xl">

--- a/apps/page-builder-demo/src/components/page/sections/Intro.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/Intro.tsx
@@ -20,6 +20,7 @@ export function Intro(props: {
       })}
       className="p-4 sm:p-5 md:p-6"
       variant={section.style?.variant?.value as any}
+      data-sanity-draggable
     >
       {section.headline ? (
         <h1 className="text-2xl font-extrabold sm:text-3xl md:text-4xl">

--- a/apps/page-builder-demo/src/components/page/sections/Section.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/Section.tsx
@@ -19,6 +19,7 @@ export function Section(props: {
         type: page._type,
         path: `sections[_key=="${section._key}"]`,
       })}
+      data-sanity-draggable
     >
       {section.headline ? (
         <h1 className="text-3xl font-extrabold sm:text-5xl md:text-7xl">

--- a/apps/page-builder-demo/src/components/page/types.ts
+++ b/apps/page-builder-demo/src/components/page/types.ts
@@ -47,6 +47,7 @@ export interface FeatureHighlightSectionData {
     media?: SanityImageValue
   }
   style?: SectionStyleData
+  ctas: Array<{title: string; href: string; _key: string}>
 }
 
 export interface PageSectionData {

--- a/packages/visual-editing/src/controller.ts
+++ b/packages/visual-editing/src/controller.ts
@@ -145,21 +145,23 @@ export function createOverlayController({
 
         if (event.currentTarget !== hoverStack.at(-1)) return
 
+        const targetIsDraggable = element.getAttribute('data-sanity-draggable')
+
+        if (!targetIsDraggable) return
+
         const targetSanityData = elementsMap.get(element)?.sanity
 
         if (!targetSanityData || !isSanityNode(targetSanityData)) return
 
-        const closestDragGroup = element.closest('[data-sanity-drag-group]')
-
         const group = [...elementSet].reduce<OverlayElement[]>((acc, el) => {
           const elData = elementsMap.get(el)
+          const elIsDraggable = el.getAttribute('data-sanity-draggable')
 
           if (
             elData &&
+            elIsDraggable &&
             isSanityNode(elData.sanity) &&
-            sanityNodesExistInSameArray(targetSanityData, elData.sanity) &&
-            closestDragGroup &&
-            closestDragGroup.contains(el)
+            sanityNodesExistInSameArray(targetSanityData, elData.sanity)
           ) {
             acc.push(elData)
           }

--- a/packages/visual-editing/src/controller.ts
+++ b/packages/visual-editing/src/controller.ts
@@ -165,7 +165,7 @@ export function createOverlayController({
 
         if (group.length <= 1) return
 
-        handleOverlayDrag(group, handler)
+        handleOverlayDrag(event as MouseEvent, group, handler)
       },
       mousemove(event) {
         eventHandlers.mouseenter(event)

--- a/packages/visual-editing/src/controller.ts
+++ b/packages/visual-editing/src/controller.ts
@@ -149,13 +149,17 @@ export function createOverlayController({
 
         if (!targetSanityData || !isSanityNode(targetSanityData)) return
 
+        const closestDragGroup = element.closest('[data-sanity-drag-group]')
+
         const group = [...elementSet].reduce<OverlayElement[]>((acc, el) => {
           const elData = elementsMap.get(el)
 
           if (
             elData &&
             isSanityNode(elData.sanity) &&
-            sanityNodesExistInSameArray(targetSanityData, elData.sanity)
+            sanityNodesExistInSameArray(targetSanityData, elData.sanity) &&
+            closestDragGroup &&
+            closestDragGroup.contains(el)
           ) {
             acc.push(elData)
           }

--- a/packages/visual-editing/src/controller.ts
+++ b/packages/visual-editing/src/controller.ts
@@ -165,7 +165,7 @@ export function createOverlayController({
 
         if (group.length <= 1) return
 
-        handleOverlayDrag(event as MouseEvent, group, handler)
+        handleOverlayDrag(event as MouseEvent, element, group, handler)
       },
       mousemove(event) {
         eventHandlers.mouseenter(event)

--- a/packages/visual-editing/src/index.ts
+++ b/packages/visual-editing/src/index.ts
@@ -2,6 +2,7 @@ export {createOverlayController} from './controller'
 export type {
   DisableVisualEditing,
   DragInsertPosition,
+  DragSkeleton,
   ElementFocusedState,
   ElementState,
   HistoryAdapter,

--- a/packages/visual-editing/src/index.ts
+++ b/packages/visual-editing/src/index.ts
@@ -1,6 +1,7 @@
 export {createOverlayController} from './controller'
 export type {
   DisableVisualEditing,
+  DragInsertPosition,
   ElementFocusedState,
   ElementState,
   HistoryAdapter,
@@ -14,6 +15,10 @@ export type {
   OverlayMsgActivate,
   OverlayMsgBlur,
   OverlayMsgDeactivate,
+  OverlayMsgDragEnd,
+  OverlayMsgDragStart,
+  OverlayMsgDragUpdateCursorPosition,
+  OverlayMsgDragUpdateInsertPosition,
   OverlayMsgElement,
   OverlayMsgElementActivate,
   OverlayMsgElementClick,
@@ -24,8 +29,6 @@ export type {
   OverlayMsgElementUnregister,
   OverlayMsgElementUpdate,
   OverlayMsgElementUpdateRect,
-  OverlayMsgUpdateDragCursorPosition,
-  OverlayMsgUpdateDragInsertPosition,
   OverlayOptions,
   OverlayRect,
   SanityNode,

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -56,6 +56,21 @@ export type DragInsertPosition = {
   right?: {rect: OverlayRect; sanity: SanityNode} | null
 } | null
 
+/** @public */
+export type DragSkeleton = {
+  w: number
+  h: number
+  offsetX: number
+  offsetY: number
+  childRects: {
+    x: number
+    y: number
+    w: number
+    h: number
+    tagName: string
+  }[]
+}
+
 /**
  * Base controller dispatched message
  * @typeParam T - Type of message
@@ -127,11 +142,12 @@ export type OverlayMsgDragUpdateInsertPosition = Msg<'overlay/dragUpdateInsertPo
 export type OverlayMsgDragUpdateCursorPosition = Msg<'overlay/dragUpdateCursorPosition'> & {
   x: number
   y: number
-  targetRect: OverlayRect
 }
 
 /** @public */
-export type OverlayMsgDragStart = Msg<'overlay/dragStart'>
+export type OverlayMsgDragStart = Msg<'overlay/dragStart'> & {
+  skeleton: DragSkeleton
+}
 
 /** @public */
 export type OverlayMsgDragEnd = Msg<'overlay/dragEnd'>

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -150,7 +150,9 @@ export type OverlayMsgDragStart = Msg<'overlay/dragStart'> & {
 }
 
 /** @public */
-export type OverlayMsgDragEnd = Msg<'overlay/dragEnd'>
+export type OverlayMsgDragEnd = Msg<'overlay/dragEnd'> & {
+  insertPosition: DragInsertPosition
+}
 
 /**
  * Controller dispatched messages

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -41,12 +41,20 @@ export interface Point2D {
 }
 
 /** @internal */
-export interface DragInsertPosition {
+export interface DragInsertPositionRects {
   top?: OverlayRect | null
   left?: OverlayRect | null
   bottom?: OverlayRect | null
   right?: OverlayRect | null
 }
+
+/** @public */
+export type DragInsertPosition = {
+  top?: {rect: OverlayRect; sanity: SanityNode} | null
+  left?: {rect: OverlayRect; sanity: SanityNode} | null
+  bottom?: {rect: OverlayRect; sanity: SanityNode} | null
+  right?: {rect: OverlayRect; sanity: SanityNode} | null
+} | null
 
 /**
  * Base controller dispatched message
@@ -111,20 +119,22 @@ export type OverlayMsgElementUpdateRect = OverlayMsgElement<'updateRect'> & {
 }
 
 /** @public */
-export type OverlayMsgUpdateDragInsertPosition = Msg<'overlay/updateDragInsertPosition'> & {
-  insertPosition: {
-    top?: {rect: OverlayRect; sanity: SanityNode} | null
-    left?: {rect: OverlayRect; sanity: SanityNode} | null
-    bottom?: {rect: OverlayRect; sanity: SanityNode} | null
-    right?: {rect: OverlayRect; sanity: SanityNode} | null
-  } | null
+export type OverlayMsgDragUpdateInsertPosition = Msg<'overlay/dragUpdateInsertPosition'> & {
+  insertPosition: DragInsertPosition | null
 }
 
 /** @public */
-export type OverlayMsgUpdateDragCursorPosition = Msg<'overlay/updateDragCursorPosition'> & {
+export type OverlayMsgDragUpdateCursorPosition = Msg<'overlay/dragUpdateCursorPosition'> & {
   x: number
   y: number
+  targetRect: OverlayRect
 }
+
+/** @public */
+export type OverlayMsgDragStart = Msg<'overlay/dragStart'>
+
+/** @public */
+export type OverlayMsgDragEnd = Msg<'overlay/dragEnd'>
 
 /**
  * Controller dispatched messages
@@ -143,8 +153,10 @@ export type OverlayMsg =
   | OverlayMsgElementUnregister
   | OverlayMsgElementUpdate
   | OverlayMsgElementUpdateRect
-  | OverlayMsgUpdateDragInsertPosition
-  | OverlayMsgUpdateDragCursorPosition
+  | OverlayMsgDragStart
+  | OverlayMsgDragEnd
+  | OverlayMsgDragUpdateInsertPosition
+  | OverlayMsgDragUpdateCursorPosition
 
 /**
  * Callback function used for handling dispatched controller messages

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -147,6 +147,7 @@ export type OverlayMsgDragUpdateCursorPosition = Msg<'overlay/dragUpdateCursorPo
 /** @public */
 export type OverlayMsgDragStart = Msg<'overlay/dragStart'> & {
   skeleton: DragSkeleton
+  flow: 'horizontal' | 'vertical'
 }
 
 /** @public */

--- a/packages/visual-editing/src/ui/OverlayDragInsertMarker.tsx
+++ b/packages/visual-editing/src/ui/OverlayDragInsertMarker.tsx
@@ -3,7 +3,7 @@ import type {FunctionComponent} from 'react'
 import type {DragInsertPosition} from '../types'
 
 const markerThickness = 2
-const markerGap = 4
+const markerGap = 0
 
 function lerp(v0: number, v1: number, t: number) {
   return v0 * (1 - t) + v1 * t
@@ -75,7 +75,7 @@ export const OverlayDragInsertMarker: FunctionComponent<{
         transform: `translate(${x}px, ${y}px)`,
         width,
         height,
-        background: 'color-mix(in srgb, #556bfc 75%, transparent)',
+        background: 'color-mix(in srgb, #556bfc 95%, transparent)',
         pointerEvents: 'none',
       }}
     ></div>

--- a/packages/visual-editing/src/ui/OverlayDragInsertMarker.tsx
+++ b/packages/visual-editing/src/ui/OverlayDragInsertMarker.tsx
@@ -2,6 +2,9 @@ import type {FunctionComponent} from 'react'
 
 import type {DragInsertPosition} from '../types'
 
+const markerThickness = 2
+const markerGap = 4
+
 function lerp(v0: number, v1: number, t: number) {
   return v0 * (1 - t) + v1 * t
 }
@@ -21,22 +24,22 @@ export const OverlayDragInsertMarker: FunctionComponent<{
   if (flow === 'horizontal') {
     const {left, right} = dragInsertPosition
 
-    width = 4
+    width = markerThickness
 
     if (right && left) {
       const startX = left.rect.x + left.rect.w
       const endX = right.rect.x
 
-      x = lerp(startX, endX, 0.5) - 2
+      x = lerp(startX, endX, 0.5) - markerThickness / 2
       y = left.rect.y
 
       height = Math.min(right.rect.h, left.rect.h)
     } else if (right && !left) {
-      x = right.rect.x - 4 - 4
+      x = right.rect.x - markerThickness - markerGap
       y = right.rect.y
       height = right.rect.h
     } else if (left && !right) {
-      x = left.rect.x + left.rect.w + 4
+      x = left.rect.x + left.rect.w + markerGap
       y = left.rect.y
       height = left.rect.h
     }
@@ -47,21 +50,21 @@ export const OverlayDragInsertMarker: FunctionComponent<{
       const startY = top.rect.y + top.rect.h
       const endY = bottom.rect.y
 
-      height = 4
+      height = markerThickness
 
       x = top.rect.x
-      y = lerp(startY, endY, 0.5) - 2
+      y = lerp(startY, endY, 0.5) - markerThickness / 2
       width = Math.min(bottom.rect.w, top.rect.w)
     } else if (bottom && !top) {
       x = bottom.rect.x
-      y = bottom.rect.y - 4
+      y = bottom.rect.y - markerGap
       width = bottom.rect.w
-      height = 4
+      height = markerThickness
     } else if (top && !bottom) {
       x = top.rect.x
-      y = top.rect.y + top.rect.h + 4
+      y = top.rect.y + top.rect.h + markerGap
       width = top.rect.w
-      height = 4
+      height = markerThickness
     }
   }
 

--- a/packages/visual-editing/src/ui/OverlayDragInsertMarker.tsx
+++ b/packages/visual-editing/src/ui/OverlayDragInsertMarker.tsx
@@ -1,0 +1,80 @@
+import type {FunctionComponent} from 'react'
+
+import type {DragInsertPosition} from '../types'
+
+function lerp(v0: number, v1: number, t: number) {
+  return v0 * (1 - t) + v1 * t
+}
+
+export const OverlayDragInsertMarker: FunctionComponent<{
+  dragInsertPosition: DragInsertPosition
+}> = ({dragInsertPosition}) => {
+  if (dragInsertPosition === null) return
+
+  const flow = dragInsertPosition?.left || dragInsertPosition?.right ? 'horizontal' : 'vertical'
+
+  let x = 0
+  let y = 0
+  let width = 0
+  let height = 0
+
+  if (flow === 'horizontal') {
+    const {left, right} = dragInsertPosition
+
+    width = 4
+
+    if (right && left) {
+      const startX = left.rect.x + left.rect.w
+      const endX = right.rect.x
+
+      x = lerp(startX, endX, 0.5) - 2
+      y = left.rect.y
+
+      height = Math.min(right.rect.h, left.rect.h)
+    } else if (right && !left) {
+      x = right.rect.x - 4 - 4
+      y = right.rect.y
+      height = right.rect.h
+    } else if (left && !right) {
+      x = left.rect.x + left.rect.w + 4
+      y = left.rect.y
+      height = left.rect.h
+    }
+  } else {
+    const {bottom, top} = dragInsertPosition
+
+    if (bottom && top) {
+      const startY = top.rect.y + top.rect.h
+      const endY = bottom.rect.y
+
+      height = 4
+
+      x = top.rect.x
+      y = lerp(startY, endY, 0.5) - 2
+      width = Math.min(bottom.rect.w, top.rect.w)
+    } else if (bottom && !top) {
+      x = bottom.rect.x
+      y = bottom.rect.y - 4 - 4
+      width = bottom.rect.w
+      height = 4
+    } else if (top && !bottom) {
+      x = top.rect.x
+      y = top.rect.y + top.rect.h + 4
+      width = top.rect.w
+      height = 4
+    }
+  }
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        transform: `translate(${x}px, ${y}px)`,
+        width,
+        height,
+        background: '#596ffc',
+        pointerEvents: 'none',
+      }}
+    ></div>
+  )
+}

--- a/packages/visual-editing/src/ui/OverlayDragInsertMarker.tsx
+++ b/packages/visual-editing/src/ui/OverlayDragInsertMarker.tsx
@@ -54,7 +54,7 @@ export const OverlayDragInsertMarker: FunctionComponent<{
       width = Math.min(bottom.rect.w, top.rect.w)
     } else if (bottom && !top) {
       x = bottom.rect.x
-      y = bottom.rect.y - 4 - 4
+      y = bottom.rect.y - 4
       width = bottom.rect.w
       height = 4
     } else if (top && !bottom) {
@@ -72,7 +72,7 @@ export const OverlayDragInsertMarker: FunctionComponent<{
         transform: `translate(${x}px, ${y}px)`,
         width,
         height,
-        background: '#596ffc',
+        background: 'color-mix(in srgb, #556bfc 75%, transparent)',
         pointerEvents: 'none',
       }}
     ></div>

--- a/packages/visual-editing/src/ui/OverlayDragPreview.tsx
+++ b/packages/visual-editing/src/ui/OverlayDragPreview.tsx
@@ -3,6 +3,7 @@ import type {FunctionComponent} from 'react'
 import type {DragSkeleton} from '../types'
 
 export const OverlayDragPreview: FunctionComponent<{skeleton: DragSkeleton}> = ({skeleton}) => {
+  if (skeleton.w < 48 || skeleton.h < 48) return ''
   return (
     <div
       style={{
@@ -10,15 +11,13 @@ export const OverlayDragPreview: FunctionComponent<{skeleton: DragSkeleton}> = (
         background: 'light-dark(#f6f6f8, #13141b)',
         pointerEvents: 'none',
         transformOrigin: `${skeleton.offsetX}px ${skeleton.offsetY}px`,
-        transform: `translate(calc(var(--drag-preview-x)), calc(var(--drag-preview-y))) scale(0.5)`,
+        transform: `translate(calc(var(--drag-preview-x)), calc(var(--drag-preview-y)))`,
         width: `${skeleton.w}px`,
         height: `${skeleton.h}px`,
         zIndex: 1,
         backdropFilter: 'blur(8px)',
         border: '1px solid light-dark(#ffffff, #383d51)',
         colorScheme: 'light dark',
-        padding: '16px',
-        borderRadius: '8px',
       }}
     >
       <div style={{position: 'relative', width: '100%', height: '100%'}}>

--- a/packages/visual-editing/src/ui/OverlayDragPreview.tsx
+++ b/packages/visual-editing/src/ui/OverlayDragPreview.tsx
@@ -18,6 +18,7 @@ export const OverlayDragPreview: FunctionComponent<{skeleton: DragSkeleton}> = (
         border: '1px solid light-dark(#ffffff, #383d51)',
         colorScheme: 'light dark',
         padding: '16px',
+        borderRadius: '8px',
       }}
     >
       <div style={{position: 'relative', width: '100%', height: '100%'}}>

--- a/packages/visual-editing/src/ui/OverlayDragPreview.tsx
+++ b/packages/visual-editing/src/ui/OverlayDragPreview.tsx
@@ -1,19 +1,54 @@
 import type {FunctionComponent} from 'react'
 
-export const OverlayDragPreview: FunctionComponent = () => {
+import type {DragSkeleton} from '../types'
+
+export const OverlayDragPreview: FunctionComponent<{skeleton: DragSkeleton}> = ({skeleton}) => {
   return (
     <div
       style={{
         position: 'fixed',
-        background: 'color-mix(in lch, #e3e4e8 75%, transparent)',
+        background: 'light-dark(#f6f6f8, #13141b)',
         pointerEvents: 'none',
-        transformOrigin: '0 0',
-        transform: `translate(var(--drag-preview-x), var(--drag-preview-y))`,
-        width: 'var(--drag-preview-w)',
-        height: 'var(--drag-preview-h)',
+        transformOrigin: `${skeleton.offsetX}px ${skeleton.offsetY}px`,
+        transform: `translate(calc(var(--drag-preview-x)), calc(var(--drag-preview-y))) scale(0.5)`,
+        width: `${skeleton.w}px`,
+        height: `${skeleton.h}px`,
         zIndex: 1,
-        backdropFilter: 'blur(1px)',
+        backdropFilter: 'blur(8px)',
+        border: '1px solid light-dark(#ffffff, #383d51)',
+        colorScheme: 'light dark',
+        padding: '16px',
       }}
-    ></div>
+    >
+      <div style={{position: 'relative', width: '100%', height: '100%'}}>
+        <svg style={{position: 'absolute'}} viewBox={`0 0 ${skeleton.w} ${skeleton.h}`}>
+          {skeleton.childRects.map((r, i) => (
+            <rect
+              key={i}
+              x={r.x}
+              y={r.y}
+              width={r.w}
+              height={r.h}
+              fill="light-dark(#e3e4e8, #1b1d27)"
+              stroke="light-dark(#ffffff, #383d51)"
+              strokeWidth="1"
+            ></rect>
+          ))}
+        </svg>
+        <svg
+          style={{position: 'absolute', top: '24px', left: '24px', width: '48px'}}
+          viewBox="0 0 25 25"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M9.5 8C10.3284 8 11 7.32843 11 6.5C11 5.67157 10.3284 5 9.5 5C8.67157 5 8 5.67157 8 6.5C8 7.32843 8.67157 8 9.5 8ZM9.5 14C10.3284 14 11 13.3284 11 12.5C11 11.6716 10.3284 11 9.5 11C8.67157 11 8 11.6716 8 12.5C8 13.3284 8.67157 14 9.5 14ZM11 18.5C11 19.3284 10.3284 20 9.5 20C8.67157 20 8 19.3284 8 18.5C8 17.6716 8.67157 17 9.5 17C10.3284 17 11 17.6716 11 18.5ZM15.5 8C16.3284 8 17 7.32843 17 6.5C17 5.67157 16.3284 5 15.5 5C14.6716 5 14 5.67157 14 6.5C14 7.32843 14.6716 8 15.5 8ZM17 12.5C17 13.3284 16.3284 14 15.5 14C14.6716 14 14 13.3284 14 12.5C14 11.6716 14.6716 11 15.5 11C16.3284 11 17 11.6716 17 12.5ZM15.5 20C16.3284 20 17 19.3284 17 18.5C17 17.6716 16.3284 17 15.5 17C14.6716 17 14 17.6716 14 18.5C14 19.3284 14.6716 20 15.5 20Z"
+            fill="light-dark(#727892, #515870)"
+          />
+        </svg>
+      </div>
+    </div>
   )
 }

--- a/packages/visual-editing/src/ui/OverlayDragPreview.tsx
+++ b/packages/visual-editing/src/ui/OverlayDragPreview.tsx
@@ -1,0 +1,19 @@
+import type {FunctionComponent} from 'react'
+
+export const OverlayDragPreview: FunctionComponent = () => {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        background: 'color-mix(in lch, #e3e4e8 75%, transparent)',
+        pointerEvents: 'none',
+        transformOrigin: '0 0',
+        transform: `translate(var(--drag-preview-x), var(--drag-preview-y))`,
+        width: 'var(--drag-preview-w)',
+        height: 'var(--drag-preview-h)',
+        zIndex: 1,
+        backdropFilter: 'blur(1px)',
+      }}
+    ></div>
+  )
+}

--- a/packages/visual-editing/src/ui/OverlayDragPreview.tsx
+++ b/packages/visual-editing/src/ui/OverlayDragPreview.tsx
@@ -1,6 +1,69 @@
 import type {FunctionComponent} from 'react'
+import {styled} from 'styled-components'
 
 import type {DragSkeleton} from '../types'
+
+const Root = styled.div<{
+  $width: number
+  $height: number
+  $offsetX: number
+  $offsetY: number
+  $scaleFactor: number
+}>`
+  --drag-preview-bg: #f6f6f8;
+  --drag-preview-border: #ffffff;
+  --drag-preview-opacity: 0.875;
+  --drag-preview-skeleton-fill: #e3e4e8;
+  --drag-preview-skeleton-stroke: #ffffff;
+  --drag-preview-handle-fill: #727892;
+
+  @media (prefers-color-scheme: dark) {
+    --drag-preview-bg: #13141b;
+    --drag-preview-border: #383d51;
+    --drag-preview-skeleton-fill: #1b1d27;
+    --drag-preview-skeleton-stroke: #383d51;
+    --drag-preview-handle-fill: #515870;
+  }
+
+  position: fixed;
+  background: var(--drag-preview-bg);
+  pointer-events: none;
+  transform-origin: 0 0;
+  transform: ${({$offsetX, $offsetY, $scaleFactor}) =>
+    `translate(calc(var(--drag-preview-x) + ${$offsetX}px), calc(var(--drag-preview-y) + ${$offsetY}px)) scale(${$scaleFactor})`};
+  width: ${({$width}) => `${$width}px`};
+  height: ${({$height}) => `${$height}px`};
+  z-index: 9999999;
+  border: 1px solid var(--drag-preview-border);
+  opacity: var(--drag-preview-opacity);
+
+  .drag-preview-content-wrapper {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    container-type: inline-size;
+  }
+
+  .drag-preview-skeleton {
+    position: absolute;
+    inset: 0;
+
+    rect {
+      fill: var(--drag-preview-skeleton-fill);
+      stroke: var(--drag-preview-skeleton-stroke);
+      opacity: var(--drag-preview-opacity);
+      stroke-width: 1;
+    }
+  }
+
+  .drag-preview-handle {
+    position: absolute;
+    top: 4cqmin;
+    left: 4cqmin;
+    width: 6cqmin;
+    fill: var(--drag-preview-handle-fill);
+  }
+`
 
 export const OverlayDragPreview: FunctionComponent<{skeleton: DragSkeleton}> = ({skeleton}) => {
   const minSkeletonWidth = 100
@@ -16,56 +79,27 @@ export const OverlayDragPreview: FunctionComponent<{skeleton: DragSkeleton}> = (
   const offsetY = skeleton.offsetY * scaleFactor
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        background: 'light-dark(#f6f6f8, #13141b)',
-        pointerEvents: 'none',
-        transformOrigin: `0 0`,
-        transform: `translate(calc(var(--drag-preview-x) + ${offsetX}px), calc(var(--drag-preview-y) + ${offsetY}px)) scale(${scaleFactor})`,
-        width: `${skeleton.w}px`,
-        height: `${skeleton.h}px`,
-        zIndex: 1,
-        backdropFilter: 'blur(8px)',
-        border: '1px solid light-dark(#ffffff, #383d51)',
-        colorScheme: 'light dark',
-      }}
+    <Root
+      $width={skeleton.w}
+      $height={skeleton.h}
+      $offsetX={offsetX}
+      $offsetY={offsetY}
+      $scaleFactor={scaleFactor}
     >
-      <div
-        style={{position: 'relative', width: '100%', height: '100%', containerType: 'inline-size'}}
-      >
+      <div className="drag-preview-content-wrapper">
         {showSkeleton && (
           <>
-            <svg style={{position: 'absolute'}} viewBox={`0 0 ${skeleton.w} ${skeleton.h}`}>
+            <svg className="drag-preview-skeleton" viewBox={`0 0 ${skeleton.w} ${skeleton.h}`}>
               {skeleton.childRects.map((r, i) => (
-                <rect
-                  key={i}
-                  x={r.x}
-                  y={r.y}
-                  width={r.w}
-                  height={r.h}
-                  fill="light-dark(#e3e4e8, #1b1d27)"
-                  stroke="light-dark(#ffffff, #383d51)"
-                  strokeWidth="1"
-                ></rect>
+                <rect key={i} x={r.x} y={r.y} width={r.w} height={r.h}></rect>
               ))}
             </svg>
-            <svg
-              style={{position: 'absolute', top: '4cqmin', left: '4cqmin', width: '6cqmin'}}
-              viewBox="0 0 25 25"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M9.5 8C10.3284 8 11 7.32843 11 6.5C11 5.67157 10.3284 5 9.5 5C8.67157 5 8 5.67157 8 6.5C8 7.32843 8.67157 8 9.5 8ZM9.5 14C10.3284 14 11 13.3284 11 12.5C11 11.6716 10.3284 11 9.5 11C8.67157 11 8 11.6716 8 12.5C8 13.3284 8.67157 14 9.5 14ZM11 18.5C11 19.3284 10.3284 20 9.5 20C8.67157 20 8 19.3284 8 18.5C8 17.6716 8.67157 17 9.5 17C10.3284 17 11 17.6716 11 18.5ZM15.5 8C16.3284 8 17 7.32843 17 6.5C17 5.67157 16.3284 5 15.5 5C14.6716 5 14 5.67157 14 6.5C14 7.32843 14.6716 8 15.5 8ZM17 12.5C17 13.3284 16.3284 14 15.5 14C14.6716 14 14 13.3284 14 12.5C14 11.6716 14.6716 11 15.5 11C16.3284 11 17 11.6716 17 12.5ZM15.5 20C16.3284 20 17 19.3284 17 18.5C17 17.6716 16.3284 17 15.5 17C14.6716 17 14 17.6716 14 18.5C14 19.3284 14.6716 20 15.5 20Z"
-                fill="light-dark(#727892, #515870)"
-              />
+            <svg className="drag-preview-handle" viewBox="0 0 25 25">
+              <path d="M9.5 8a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3ZM9.5 14a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3ZM11 18.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0ZM15.5 8a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3ZM17 12.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0ZM15.5 20a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z" />
             </svg>
           </>
         )}
       </div>
-    </div>
+    </Root>
   )
 }

--- a/packages/visual-editing/src/ui/OverlayDragPreview.tsx
+++ b/packages/visual-editing/src/ui/OverlayDragPreview.tsx
@@ -3,15 +3,26 @@ import type {FunctionComponent} from 'react'
 import type {DragSkeleton} from '../types'
 
 export const OverlayDragPreview: FunctionComponent<{skeleton: DragSkeleton}> = ({skeleton}) => {
-  if (skeleton.w < 48 || skeleton.h < 48) return ''
+  const minSkeletonWidth = 100
+  const minSkeletonHeight = 100
+
+  const maxSkeletonWidth = window.innerWidth / 2
+  const scaleFactor = skeleton.w > maxSkeletonWidth ? maxSkeletonWidth / skeleton.w : 1
+
+  const showSkeleton =
+    skeleton.w * scaleFactor >= minSkeletonWidth && skeleton.h * scaleFactor >= minSkeletonHeight
+
+  const offsetX = skeleton.offsetX * scaleFactor
+  const offsetY = skeleton.offsetY * scaleFactor
+
   return (
     <div
       style={{
         position: 'fixed',
         background: 'light-dark(#f6f6f8, #13141b)',
         pointerEvents: 'none',
-        transformOrigin: `${skeleton.offsetX}px ${skeleton.offsetY}px`,
-        transform: `translate(calc(var(--drag-preview-x)), calc(var(--drag-preview-y)))`,
+        transformOrigin: `0 0`,
+        transform: `translate(calc(var(--drag-preview-x) + ${offsetX}px), calc(var(--drag-preview-y) + ${offsetY}px)) scale(${scaleFactor})`,
         width: `${skeleton.w}px`,
         height: `${skeleton.h}px`,
         zIndex: 1,
@@ -20,34 +31,40 @@ export const OverlayDragPreview: FunctionComponent<{skeleton: DragSkeleton}> = (
         colorScheme: 'light dark',
       }}
     >
-      <div style={{position: 'relative', width: '100%', height: '100%'}}>
-        <svg style={{position: 'absolute'}} viewBox={`0 0 ${skeleton.w} ${skeleton.h}`}>
-          {skeleton.childRects.map((r, i) => (
-            <rect
-              key={i}
-              x={r.x}
-              y={r.y}
-              width={r.w}
-              height={r.h}
-              fill="light-dark(#e3e4e8, #1b1d27)"
-              stroke="light-dark(#ffffff, #383d51)"
-              strokeWidth="1"
-            ></rect>
-          ))}
-        </svg>
-        <svg
-          style={{position: 'absolute', top: '24px', left: '24px', width: '48px'}}
-          viewBox="0 0 25 25"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            fillRule="evenodd"
-            clipRule="evenodd"
-            d="M9.5 8C10.3284 8 11 7.32843 11 6.5C11 5.67157 10.3284 5 9.5 5C8.67157 5 8 5.67157 8 6.5C8 7.32843 8.67157 8 9.5 8ZM9.5 14C10.3284 14 11 13.3284 11 12.5C11 11.6716 10.3284 11 9.5 11C8.67157 11 8 11.6716 8 12.5C8 13.3284 8.67157 14 9.5 14ZM11 18.5C11 19.3284 10.3284 20 9.5 20C8.67157 20 8 19.3284 8 18.5C8 17.6716 8.67157 17 9.5 17C10.3284 17 11 17.6716 11 18.5ZM15.5 8C16.3284 8 17 7.32843 17 6.5C17 5.67157 16.3284 5 15.5 5C14.6716 5 14 5.67157 14 6.5C14 7.32843 14.6716 8 15.5 8ZM17 12.5C17 13.3284 16.3284 14 15.5 14C14.6716 14 14 13.3284 14 12.5C14 11.6716 14.6716 11 15.5 11C16.3284 11 17 11.6716 17 12.5ZM15.5 20C16.3284 20 17 19.3284 17 18.5C17 17.6716 16.3284 17 15.5 17C14.6716 17 14 17.6716 14 18.5C14 19.3284 14.6716 20 15.5 20Z"
-            fill="light-dark(#727892, #515870)"
-          />
-        </svg>
+      <div
+        style={{position: 'relative', width: '100%', height: '100%', containerType: 'inline-size'}}
+      >
+        {showSkeleton && (
+          <>
+            <svg style={{position: 'absolute'}} viewBox={`0 0 ${skeleton.w} ${skeleton.h}`}>
+              {skeleton.childRects.map((r, i) => (
+                <rect
+                  key={i}
+                  x={r.x}
+                  y={r.y}
+                  width={r.w}
+                  height={r.h}
+                  fill="light-dark(#e3e4e8, #1b1d27)"
+                  stroke="light-dark(#ffffff, #383d51)"
+                  strokeWidth="1"
+                ></rect>
+              ))}
+            </svg>
+            <svg
+              style={{position: 'absolute', top: '4cqmin', left: '4cqmin', width: '6cqmin'}}
+              viewBox="0 0 25 25"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M9.5 8C10.3284 8 11 7.32843 11 6.5C11 5.67157 10.3284 5 9.5 5C8.67157 5 8 5.67157 8 6.5C8 7.32843 8.67157 8 9.5 8ZM9.5 14C10.3284 14 11 13.3284 11 12.5C11 11.6716 10.3284 11 9.5 11C8.67157 11 8 11.6716 8 12.5C8 13.3284 8.67157 14 9.5 14ZM11 18.5C11 19.3284 10.3284 20 9.5 20C8.67157 20 8 19.3284 8 18.5C8 17.6716 8.67157 17 9.5 17C10.3284 17 11 17.6716 11 18.5ZM15.5 8C16.3284 8 17 7.32843 17 6.5C17 5.67157 16.3284 5 15.5 5C14.6716 5 14 5.67157 14 6.5C14 7.32843 14.6716 8 15.5 8ZM17 12.5C17 13.3284 16.3284 14 15.5 14C14.6716 14 14 13.3284 14 12.5C14 11.6716 14.6716 11 15.5 11C16.3284 11 17 11.6716 17 12.5ZM15.5 20C16.3284 20 17 19.3284 17 18.5C17 17.6716 16.3284 17 15.5 17C14.6716 17 14 17.6716 14 18.5C14 19.3284 14.6716 20 15.5 20Z"
+                fill="light-dark(#727892, #515870)"
+              />
+            </svg>
+          </>
+        )}
       </div>
     </div>
   )

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -176,7 +176,11 @@ export const Overlays: FunctionComponent<{
       } else if (message.type === 'overlay/deactivate') {
         channel.send('overlay/toggle', {enabled: false})
       } else if (message.type === 'overlay/dragStart') {
-        document.body.style.cursor = 'ns-resize'
+        if (message.flow === 'vertical') {
+          document.body.style.cursor = 'ns-resize'
+        } else {
+          document.body.style.cursor = 'ew-resize'
+        }
       } else if (message.type === 'overlay/dragEnd') {
         document.body.style.cursor = 'auto'
       } else if (message.type === 'overlay/dragUpdateCursorPosition') {

--- a/packages/visual-editing/src/ui/overlayStateReducer.ts
+++ b/packages/visual-editing/src/ui/overlayStateReducer.ts
@@ -1,7 +1,7 @@
 import type {PresentationMsg} from '@repo/visual-editing-helpers'
 import type {ClientPerspective} from '@sanity/client'
 
-import type {ElementState, OverlayMsg} from '../types'
+import type {DragInsertPosition, ElementState, OverlayMsg} from '../types'
 import {elementsReducer} from './elementsReducer'
 
 export interface OverlayState {
@@ -9,6 +9,8 @@ export interface OverlayState {
   elements: ElementState[]
   wasMaybeCollapsed: boolean
   perspective: ClientPerspective
+  isDragging: boolean
+  dragInsertPosition: DragInsertPosition
 }
 
 export function overlayStateReducer(
@@ -18,6 +20,8 @@ export function overlayStateReducer(
   let focusPath = state.focusPath
   let wasMaybeCollapsed = false
   let perspective = state.perspective
+  let isDragging = state.isDragging
+  let dragInsertPosition = state.dragInsertPosition
 
   if (message.type === 'presentation/focus') {
     const prevFocusPath = state.focusPath
@@ -33,9 +37,21 @@ export function overlayStateReducer(
     perspective = message.data.perspective
   }
 
+  if (message.type === 'overlay/dragUpdateInsertPosition') {
+    dragInsertPosition = message.insertPosition
+  }
+
+  if (message.type === 'overlay/dragStart') {
+    isDragging = true
+  } else if (message.type === 'overlay/dragEnd') {
+    isDragging = false
+  }
+
   return {
     ...state,
     elements: elementsReducer(state.elements, message),
+    dragInsertPosition,
+    isDragging,
     focusPath,
     perspective,
     wasMaybeCollapsed,

--- a/packages/visual-editing/src/ui/overlayStateReducer.ts
+++ b/packages/visual-editing/src/ui/overlayStateReducer.ts
@@ -1,7 +1,7 @@
 import type {PresentationMsg} from '@repo/visual-editing-helpers'
 import type {ClientPerspective} from '@sanity/client'
 
-import type {DragInsertPosition, ElementState, OverlayMsg} from '../types'
+import type {DragInsertPosition, DragSkeleton, ElementState, OverlayMsg} from '../types'
 import {elementsReducer} from './elementsReducer'
 
 export interface OverlayState {
@@ -11,6 +11,7 @@ export interface OverlayState {
   perspective: ClientPerspective
   isDragging: boolean
   dragInsertPosition: DragInsertPosition
+  dragSkeleton: DragSkeleton | null
 }
 
 export function overlayStateReducer(
@@ -22,6 +23,7 @@ export function overlayStateReducer(
   let perspective = state.perspective
   let isDragging = state.isDragging
   let dragInsertPosition = state.dragInsertPosition
+  let dragSkeleton = state.dragSkeleton
 
   if (message.type === 'presentation/focus') {
     const prevFocusPath = state.focusPath
@@ -43,7 +45,10 @@ export function overlayStateReducer(
 
   if (message.type === 'overlay/dragStart') {
     isDragging = true
-  } else if (message.type === 'overlay/dragEnd') {
+    dragSkeleton = message.skeleton
+  }
+
+  if (message.type === 'overlay/dragEnd') {
     isDragging = false
   }
 
@@ -51,6 +56,7 @@ export function overlayStateReducer(
     ...state,
     elements: elementsReducer(state.elements, message),
     dragInsertPosition,
+    dragSkeleton,
     isDragging,
     focusPath,
     perspective,

--- a/packages/visual-editing/src/util/drag-and-drop.md
+++ b/packages/visual-editing/src/util/drag-and-drop.md
@@ -1,0 +1,94 @@
+# Sanity Presentation Drag and Drop Pseudo-docs
+
+To create an draggable group of UI elements:
+
+## Define schema
+
+First, define an `array` field in your schema, for example:
+
+```js
+defineField({
+  type: 'array',
+  name: 'ctas',
+  title: 'CTAs',
+  of: [
+    {
+      type: 'object',
+      name: 'cta',
+      title: 'CTA',
+      fields: [
+        defineField({
+          type: 'string',
+          name: 'title',
+          title: 'Title',
+        }),
+      ],
+    },
+  ],
+}),
+```
+
+Next, render your content:
+
+```js
+ctas.map((cta, i) => <button>{cta.title}</button>)
+```
+
+From here, there are a few routes to take.
+
+---
+
+## Draggable groups for automatic Stega overlays
+
+When stega is enabled in your sanity client, an overlay will be created for the `<button>` element. The sanity `path` for that overlay will be something like: `ctas[_key="1234"].title`.
+
+To allow the buttons within the array to be dragged and reordered, assign a `data-sanity-draggable` to each `<button>` element:
+
+```js
+ctas.map((cta, i) => <button data-sanity-draggable>{cta.title}</button>)
+```
+
+When each `<button>` overlay is dragged, we ignore the last part of the `path` that references the string that has stega encoding. For example: `ctas[_key="1234"].title` becomes `ctas[_key="1234"]`.
+
+The path `ctas[_key="1234"]` tells us that the dragged item belongs to the `ctas[]` array. Now we know which elements to check against when calculating drop insert positions 🎉
+
+**Note:** when working with automatic Stega overlays, the stega-encoded string must be a direct child of the `data-sanity-draggable` element. For example:
+
+```js
+// 🚫
+ctas.map((cta, i) => (
+  <button data-sanity-draggable>
+    <div>{cta.title}</div>
+  </button>
+))
+```
+
+Here, the overlay will be created for the `<div>`, rather than the `<button>` that has the `data-sanity-draggable` data attribute. Drag and drop will not work.
+
+---
+
+## Draggable groups for custom overlays
+
+For more complex use cases, such as a `card` that has mutliple text fields, or to allow a non-stega-able field to be dragged, we can pair `data-sanity-draggable` with the the `data-sanity` attribute. For example:
+
+```js
+{
+  cards.map((card) => (
+    // any area of this card that does not contain a stega-encoded string will be draggable
+    <article
+      data-sanity={dataAttribute({
+        id: parentDocument._id,
+        type: parentDocument._type,
+        path: `sections[_key=="${section._key}"].cards[_key=="${card._key}"]`,
+      })}
+      style={{padding: '2rem'}}
+      data-sanity-draggable
+    >
+      // this is stega encoded, and will open the text field on click. drag events will not fire
+      from this element
+      <h2>{card.title}</h2>
+      ...
+    </article>
+  ))
+}
+```

--- a/packages/visual-editing/src/util/drag-and-drop.md
+++ b/packages/visual-editing/src/util/drag-and-drop.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> Drag and Drop is an experimental feature. This documentation serves as a rough guide, and it's contents are subject to change.
+
 # Sanity Presentation Drag and Drop Pseudo-docs
 
 To create an draggable group of UI elements:

--- a/packages/visual-editing/src/util/dragAndDrop.ts
+++ b/packages/visual-editing/src/util/dragAndDrop.ts
@@ -325,6 +325,7 @@ export function handleOverlayDrag(
       handler({
         type: 'overlay/dragStart',
         skeleton,
+        flow,
       })
 
       dragSequenceStarted = true

--- a/packages/visual-editing/src/util/dragAndDrop.ts
+++ b/packages/visual-editing/src/util/dragAndDrop.ts
@@ -271,7 +271,7 @@ function calcMousePos(e: MouseEvent) {
 function buildPreviewSkeleton(e: MouseEvent, element: ElementNode) {
   const bounds = getRect(element)
   const children = [
-    ...element.querySelectorAll(':where(h1, h2, h3, h4, p, a, img, span):not(:has(*))'),
+    ...element.querySelectorAll(':where(h1, h2, h3, h4, p, a, img, span, button):not(:has(*))'),
   ]
   const mousePos = calcMousePos(e)
 

--- a/packages/visual-editing/src/util/findSanityNodes.ts
+++ b/packages/visual-editing/src/util/findSanityNodes.ts
@@ -177,7 +177,7 @@ export function findSanityNodes(
   return elements
 }
 
-export function getSanityNodeArrayPath(path: string): string {
+export function getSanityNodeClosestArrayPath(path: string): string {
   const lastDotIndex = path.lastIndexOf('.')
   const lastPathItem = path.substring(lastDotIndex, path.length)
 
@@ -198,5 +198,8 @@ export function sanityNodesExistInSameArray(
   sanityNode1: SanityNode,
   sanityNode2: SanityNode,
 ): boolean {
-  return getSanityNodeArrayPath(sanityNode1.path) === getSanityNodeArrayPath(sanityNode2.path)
+  return (
+    getSanityNodeClosestArrayPath(sanityNode1.path) ===
+    getSanityNodeClosestArrayPath(sanityNode2.path)
+  )
 }

--- a/packages/visual-editing/src/util/findSanityNodes.ts
+++ b/packages/visual-editing/src/util/findSanityNodes.ts
@@ -177,12 +177,21 @@ export function findSanityNodes(
   return elements
 }
 
-export function getSanityNodeArrayPath(sanityPath: string): string {
-  const split = sanityPath.split('.')
+export function getSanityNodeArrayPath(path: string): string {
+  const lastDotIndex = path.lastIndexOf('.')
+  const lastPathItem = path.substring(lastDotIndex, path.length)
 
-  return split
-    .map((p, index) => (index === split.length - 1 ? p.replace(/\[.*?\]/g, '[]') : p))
-    .join('.')
+  const lastPathItemIsArray = lastPathItem.includes('[')
+
+  if (!lastPathItemIsArray) {
+    path = path.substring(0, lastDotIndex)
+  }
+
+  const split = path.split('.')
+
+  split[split.length - 1] = split[split.length - 1].replace(/\[.*?\]/g, '[]')
+
+  return split.join('.')
 }
 
 export function sanityNodesExistInSameArray(


### PR DESCRIPTION
**This PR:** 

- Implements "Drag Previews" for dragged elements. Drag previews render an abstract representation of the dragged element when possible, and default to a simple rectangle for small elements. 
- Adds the ability to opt in to drag and drop using the `data-sanity-draggable` HTML attribute.
- Improves drag insert position calculation, allowing for larger "hit" areas. 
- Adds an "Insert Marker" preview for drag sequences. This is a simple blue bar that appears on element top/bottom for vertical drag groups, or left/right for horizontal drag groups.
- Commits a simple `dnd.md` document to help provide insight into how drag and drop works. This can be refined over time, and help inform our actual documentation.
- Updates the Page Builder demo to allow `FeatureHighlight` to render an array of `CTAs` — this is helpful for demo-ing horizontal drag and drop on simple text nodes.
- Ensures drag sequences start only after a small drag delta on overlay elements.

@rdunk I have not included your `useDragEvents` functionality in this PR, as I thought it may make sense for you to add it after the fact, but let me know if that isn't correct! 

**Next Steps:** 

This PR does not include the mutation logic for reordering, it simply emits events. We need to integrate with Rupert/Cody's work 🚀 

**⚠️ Before Merging ⚠️:** 

- Update commit message to `chore()`