### PR TITLE
chore: improve vscode monorepo onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,7 +135,6 @@ package-lock.json
 .idea/
 .vercel
 .turbo
-.vscode
 dist-svelte
 .svelte-kit
 tsconfig.vitest-temp.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "Nixon.env-cmd-file-syntax",
     "sanity-io.vscode-sanity",
     "joshbolduc.story-explorer",
     "bradlc.vscode-tailwindcss",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,13 @@
+{
+  "recommendations": [
+    "Nixon.env-cmd-file-syntax",
+    "sanity-io.vscode-sanity",
+    "joshbolduc.story-explorer",
+    "bradlc.vscode-tailwindcss",
+    "mattpocock.ts-error-translator",
+    "Vercel.turbo-vsc",
+    "vitest.explorer",
+    "styled-components.vscode-styled-components",
+    "statelyai.stately-vscode"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
The `settings.json` file ensures folks don't have to deal with making sure TypeScript loads correctly.

And the `extensions.json` will show a prompt in VS Code based editors:
<img width="474" alt="image" src="https://github.com/user-attachments/assets/f8d5cbe6-a197-418c-9b99-9cee77a79cb9">

I have a **_lot_** of extensions I like, but I wanted to make sure the recommendations are only the most useful ones, especially for the tooling we use in this monorepo:::

<img width="343" alt="image" src="https://github.com/user-attachments/assets/8857a20b-e0ac-4238-a348-e1fddab3638e">

They are the kind of extensions that folks often don't know to look for, but are huge timesavers.