### PR TITLE
chore: speedup `sanity dev`

### DIFF
--- a/apps/studio/sanity.cli.ts
+++ b/apps/studio/sanity.cli.ts
@@ -5,6 +5,11 @@ export default defineCliConfig({
   vite: (config) => {
     return {
       ...config,
+      define: {
+        ...config.define,
+        // Speed up styled-components in dev mode: https://github.com/sanity-io/sanity/pull/7440
+        'process.env.SC_DISABLE_SPEEDY': JSON.stringify('false'),
+      },
       resolve: {
         ...config.resolve,
         alias: {


### PR DESCRIPTION
This speeds up `styled-components` for `sanity dev` when running the visual editing test studio locally on http://localhost:3333.

More info https://github.com/sanity-io/sanity/pull/7440