### PR TITLE
chore(drag-and-drop-opt-out)

### DIFF
--- a/apps/page-builder-demo/src/components/page/sections/FeatureHighlight.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/FeatureHighlight.tsx
@@ -1,4 +1,5 @@
 import {WrappedValue, unwrapData} from '@sanity/react-loader/jsx'
+import {stegaClean} from '@sanity/client/stega'
 import {sanity} from '@sanity/react-loader/jsx'
 import Link from 'next/link'
 
@@ -22,7 +23,6 @@ export function FeatureHighlight(props: {
       })}
       className="p-4 sm:p-5 md:p-6"
       variant={section.style?.variant?.value as any}
-      data-sanity-draggable
     >
       <div className="-m-4 sm:-m-5 md:-m-6">
         {section.image?.asset && (
@@ -48,13 +48,18 @@ export function FeatureHighlight(props: {
         <div className="flex gap-3">
           {section.ctas &&
             section.ctas.map((cta, i) => (
-              <sanity.button
+              <button
+                data-sanity={dataAttribute({
+                  id: data._id,
+                  type: data._type,
+                  path: `sections[_key=="${section._key}"].ctas[_key=="${cta._key}"]`,
+                })}
                 className="mt-5 border border-current p-3"
                 key={i}
-                data-sanity-draggable
+                style={{padding: '2rem'}}
               >
-                {cta.title}
-              </sanity.button>
+                {unwrapData(stegaClean(cta.title))}
+              </button>
             ))}
         </div>
       </div>

--- a/apps/page-builder-demo/src/components/page/sections/FeaturedProducts.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/FeaturedProducts.tsx
@@ -22,7 +22,6 @@ export function FeaturedProducts(props: {
       })}
       className="overflow-hidden"
       variant={section.style?.variant?.value as any}
-      data-sanity-draggable
     >
       <div className="flex w-full flex-nowrap gap-2 overflow-auto p-4 sm:p-5 md:p-6">
         <h1 className="w-96 flex-none p-5 text-2xl font-bold">

--- a/apps/page-builder-demo/src/components/page/sections/Hero.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/Hero.tsx
@@ -20,7 +20,6 @@ export function Hero(props: {
       })}
       className="px-4 py-6 text-center sm:px-5 sm:py-7 md:px-7 md:py-9"
       variant={section.style?.variant?.value as any}
-      data-sanity-draggable
     >
       {section.headline ? (
         <h1 className="text-3xl font-extrabold sm:text-5xl md:text-7xl">

--- a/apps/page-builder-demo/src/components/page/sections/Intro.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/Intro.tsx
@@ -20,7 +20,6 @@ export function Intro(props: {
       })}
       className="p-4 sm:p-5 md:p-6"
       variant={section.style?.variant?.value as any}
-      data-sanity-draggable
     >
       {section.headline ? (
         <h1 className="text-2xl font-extrabold sm:text-3xl md:text-4xl">

--- a/apps/page-builder-demo/src/components/page/sections/Section.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/Section.tsx
@@ -19,7 +19,6 @@ export function Section(props: {
         type: page._type,
         path: `sections[_key=="${section._key}"]`,
       })}
-      data-sanity-draggable
     >
       {section.headline ? (
         <h1 className="text-3xl font-extrabold sm:text-5xl md:text-7xl">

--- a/packages/visual-editing/src/controller.ts
+++ b/packages/visual-editing/src/controller.ts
@@ -9,7 +9,12 @@ import type {
   ResolvedElement,
 } from './types'
 import {handleOverlayDrag} from './util/dragAndDrop'
-import {findSanityNodes, isSanityNode, sanityNodesExistInSameArray} from './util/findSanityNodes'
+import {
+  findSanityNodes,
+  isSanityArrayPath,
+  isSanityNode,
+  sanityNodesExistInSameArray,
+} from './util/findSanityNodes'
 import {getRect} from './util/getRect'
 
 const isElementNode = (target: EventTarget | null): target is ElementNode => {
@@ -145,21 +150,24 @@ export function createOverlayController({
 
         if (event.currentTarget !== hoverStack.at(-1)) return
 
-        const targetIsDraggable = element.getAttribute('data-sanity-draggable')
-
-        if (!targetIsDraggable) return
+        if (element.getAttribute('data-sanity-disable-drag')) return
 
         const targetSanityData = elementsMap.get(element)?.sanity
 
-        if (!targetSanityData || !isSanityNode(targetSanityData)) return
+        if (
+          !targetSanityData ||
+          !isSanityNode(targetSanityData) ||
+          !isSanityArrayPath(targetSanityData.path)
+        )
+          return
 
         const group = [...elementSet].reduce<OverlayElement[]>((acc, el) => {
           const elData = elementsMap.get(el)
-          const elIsDraggable = el.getAttribute('data-sanity-draggable')
+          const elDragDisabled = el.getAttribute('data-sanity-disable-drag')
 
           if (
             elData &&
-            elIsDraggable &&
+            !elDragDisabled &&
             isSanityNode(elData.sanity) &&
             sanityNodesExistInSameArray(targetSanityData, elData.sanity)
           ) {

--- a/packages/visual-editing/src/util/drag-and-drop.md
+++ b/packages/visual-editing/src/util/drag-and-drop.md
@@ -1,11 +1,11 @@
 > [!WARNING]
 > Drag and Drop is an experimental feature. This documentation serves as a rough guide, and it's contents are subject to change.
 
-# Sanity Presentation Drag and Drop Pseudo-docs
+# Drag and Drop
 
 To create an draggable group of UI elements:
 
-## Define schema
+## 1. Define schema
 
 First, define an `array` field in your schema, for example:
 
@@ -31,67 +31,61 @@ defineField({
 }),
 ```
 
-Next, render your content:
+## 2. Render and define paths
+
+Drag and drop will be enabled by default for any element with a direct array `path`.
+
+For example:
 
 ```js
-ctas.map((cta, i) => <button>{cta.title}</button>)
-```
-
-From here, there are a few routes to take.
-
----
-
-## Draggable groups for automatic Stega overlays
-
-When stega is enabled in your sanity client, an overlay will be created for the `<button>` element. The sanity `path` for that overlay will be something like: `ctas[_key="1234"].title`.
-
-To allow the buttons within the array to be dragged and reordered, assign a `data-sanity-draggable` to each `<button>` element:
-
-```js
-ctas.map((cta, i) => <button data-sanity-draggable>{cta.title}</button>)
-```
-
-When each `<button>` overlay is dragged, we ignore the last part of the `path` that references the string that has stega encoding. For example: `ctas[_key="1234"].title` becomes `ctas[_key="1234"]`.
-
-The path `ctas[_key="1234"]` tells us that the dragged item belongs to the `ctas[]` array. Now we know which elements to check against when calculating drop insert positions 🎉
-
-**Note:** when working with automatic Stega overlays, the stega-encoded string must be a direct child of the `data-sanity-draggable` element. For example:
-
-```js
-// 🚫
-ctas.map((cta, i) => (
-  <button data-sanity-draggable>
-    <div>{cta.title}</div>
-  </button>
-))
-```
-
-Here, the overlay will be created for the `<div>`, rather than the `<button>` that has the `data-sanity-draggable` data attribute. Drag and drop will not work.
-
----
-
-## Draggable groups for custom overlays
-
-For more complex use cases, such as a `card` that has mutliple text fields, or to allow a non-stega-able field to be dragged, we can pair `data-sanity-draggable` with the the `data-sanity` attribute. For example:
-
-```js
+// ✅ drag and drop enabled
 {
-  cards.map((card) => (
-    // any area of this card that does not contain a stega-encoded string will be draggable
-    <article
+  ctas.map((cta, i) => (
+    <button
       data-sanity={dataAttribute({
         id: parentDocument._id,
         type: parentDocument._type,
-        path: `sections[_key=="${section._key}"].cards[_key=="${card._key}"]`,
+        path: `sections[_key=="${section._key}"].ctas[_key=="${cta._key}"]`,
       })}
-      style={{padding: '2rem'}}
-      data-sanity-draggable
     >
-      // this is stega encoded, and will open the text field on click. drag events will not fire
-      from this element
-      <h2>{card.title}</h2>
-      ...
-    </article>
+      // prevent stega-encoded string from becoming the overlay target
+      {stegaClean(cta.title)}
+    </button>
   ))
 }
 ```
+
+```js
+// 🚫 drag and drop disabled
+{
+  ctas.map((cta, i) => (
+    <button
+      data-sanity={dataAttribute({
+        id: parentDocument._id,
+        type: parentDocument._type,
+        path: `sections[_key=="${section._key}"].ctas[_key=="${cta._key}"]`,
+      })}
+    >
+      // overlay is created for the path sections[].ctas[].title, drag and drop cannot be enabled
+      {cta.title}
+    </button>
+  ))
+}
+```
+
+You can disable drag and drop on any element using the `data-sanity-disable-drag` data attribute:
+
+```js
+<button data-sanity-disable-drag></button>
+```
+
+_This data attribute can be added to every item in an array, or to specific items._
+
+## Layout and language support
+
+Currently, drag and drop supports horizontal/top-bottom languages. It can infer layout for the following CSS layout types:
+
+- Inline/Inline Block elements
+- Block elements
+- Non `reverse` Flex layouts
+- 1-dimensional CSS Grid layouts

--- a/packages/visual-editing/src/util/findSanityNodes.ts
+++ b/packages/visual-editing/src/util/findSanityNodes.ts
@@ -177,15 +177,15 @@ export function findSanityNodes(
   return elements
 }
 
-export function getSanityNodeClosestArrayPath(path: string): string {
+export function isSanityArrayPath(path: string): boolean {
   const lastDotIndex = path.lastIndexOf('.')
   const lastPathItem = path.substring(lastDotIndex, path.length)
 
-  const lastPathItemIsArray = lastPathItem.includes('[')
+  return lastPathItem.includes('[')
+}
 
-  if (!lastPathItemIsArray) {
-    path = path.substring(0, lastDotIndex)
-  }
+export function getSanityNodeArrayPath(path: string): string | null {
+  if (!isSanityArrayPath(path)) return null
 
   const split = path.split('.')
 
@@ -198,8 +198,7 @@ export function sanityNodesExistInSameArray(
   sanityNode1: SanityNode,
   sanityNode2: SanityNode,
 ): boolean {
-  return (
-    getSanityNodeClosestArrayPath(sanityNode1.path) ===
-    getSanityNodeClosestArrayPath(sanityNode2.path)
-  )
+  if (!isSanityArrayPath(sanityNode1.path) || !isSanityArrayPath(sanityNode2.path)) return false
+
+  return getSanityNodeArrayPath(sanityNode1.path) === getSanityNodeArrayPath(sanityNode2.path)
 }


### PR DESCRIPTION
This PR updates the Drag and Drop API to be opt-out. 

It also simplifies the functionality, enabling drag-and-drop only on elements with an array path. 