### PR TITLE
chore: create env var template for test studio

### DIFF
--- a/apps/studio/.env.local
+++ b/apps/studio/.env.local
@@ -1,0 +1,18 @@
+# If you are opening a PR you can paste these variables into: https://vercel.com/sanity-sandbox/visual-editing-studio/settings/environment-variables
+# and then use "Preview (Select custom branch)" and batch add vars so that changes in the Studio side, and app side, can be tested together:
+SANITY_STUDIO_ASTRO_PREVIEW_URL=""
+SANITY_STUDIO_NEXT_APP_ROUTER_PREVIEW_URL=""
+SANITY_STUDIO_NEXT_PAGES_ROUTER_PREVIEW_URL=""
+SANITY_STUDIO_NUXT_PREVIEW_URL=""
+SANITY_STUDIO_PAGE_BUILDER_DEMO_PREVIEW_URL=""
+SANITY_STUDIO_REMIX_PREVIEW_URL=""
+SANITY_STUDIO_SVELTE_PREVIEW_URL=""
+
+# If these are not specified, and a Linear branch URL not used, then the Studio will connect to production deployment with the values below are used:
+# SANITY_STUDIO_ASTRO_PREVIEW_URL="https://visual-editing-astro-git-preview.sanity.dev/shoes"
+# SANITY_STUDIO_NEXT_APP_ROUTER_PREVIEW_URL="https://visual-editing-next.sanity.dev/shoes"
+# SANITY_STUDIO_NEXT_PAGES_ROUTER_PREVIEW_URL="https://visual-editing-next.sanity.build/pages-router/shoes"
+# SANITY_STUDIO_NUXT_PREVIEW_URL="https://visual-editing-nuxt.sanity.build/shoes"
+# SANITY_STUDIO_PAGE_BUILDER_DEMO_PREVIEW_URL="https://visual-editing-page-builder-demo.sanity.build"
+# SANITY_STUDIO_REMIX_PREVIEW_URL="https://visual-editing-remix.sanity.build/shoes"
+# SANITY_STUDIO_SVELTE_PREVIEW_URL="https://visual-editing-svelte.sanity.build/shoes"


### PR DESCRIPTION
Helps the maintainer burden until we properly support origin patterns and array of strings for `presentationTool({previewUrl: {origin: ['*.sanity.dev', '*.sanity.build']}})`