### PR TITLE
fix(visual-editing): Don't show "Open in Studio" offscreen when at top of screen

### DIFF
--- a/packages/visual-editing/src/ui/ElementOverlay.tsx
+++ b/packages/visual-editing/src/ui/ElementOverlay.tsx
@@ -53,7 +53,6 @@ const Root = styled(Card)`
 `
 
 const Actions = styled(Flex)`
-  bottom: 100%;
   cursor: pointer;
   pointer-events: none;
   position: absolute;
@@ -137,6 +136,17 @@ export const ElementOverlay = memo(function ElementOverlay(props: {
     [rect],
   )
 
+  const actionStyle = useMemo(() => {
+    // If the element is close to the top of the screen, we want to show the actions below it
+    const isNearTop = rect.y < 20
+    return {
+      top: isNearTop ? '100%' : 0,
+      bottom: isNearTop ? 0 : '100%',
+      paddingTop: isNearTop ? 4 : 0,
+      paddingBottom: isNearTop ? 0 : 4,
+    }
+  }, [rect])
+
   const href = 'path' in sanity ? createIntentLink(sanity) : sanity.href
 
   return (
@@ -147,7 +157,7 @@ export const ElementOverlay = memo(function ElementOverlay(props: {
       style={style}
     >
       {showActions && hovered ? (
-        <Actions gap={1} paddingBottom={1}>
+        <Actions gap={1} style={actionStyle}>
           <Link href={href} />
         </Actions>
       ) : null}


### PR DESCRIPTION
For things like navbars or logos that might appear on the top of the screen, the overlay could be cut off. This moves the "Open in Studio" below the element in that case.

## Before:
<img width="449" alt="Screenshot 2024-09-25 at 3 10 21 PM" src="https://github.com/user-attachments/assets/71cc7846-2ab5-41bb-95e3-909212860795">

## After:
<img width="451" alt="Screenshot 2024-09-25 at 3 11 35 PM" src="https://github.com/user-attachments/assets/98303fa7-07ff-48f0-a0bb-081762ddb3f7">

