### PR TITLE
Image fix

### DIFF
--- a/apps/page-builder-demo/src/components/image/Image.tsx
+++ b/apps/page-builder-demo/src/components/image/Image.tsx
@@ -6,13 +6,17 @@ export function Image(
   props: {
     value: {
       _type: 'image'
-      asset: {_type: 'reference'}
+      asset?: {_type: 'reference'; _ref?: string}
     }
     width?: number
     height?: number
   } & Omit<HTMLProps<HTMLImageElement>, 'src' | 'value' | 'width' | 'height'>,
 ) {
   const {value, width = 800, height = 800, ...rest} = props
+
+  if (!value?.asset?._ref) {
+    return null
+  }
 
   return (
     // @ts-expect-error - NextImage is not typed correctly


### PR DESCRIPTION
A small defensive layer against badly behaving patchers (me).

## The bug
If an image was missing asset, or asset._ref then the demo crashes.

Ie `{_type: 'image'}` ,or `{_type: 'image', asset: {_type: 'reference'}}`.

Most of the time "this should never happen", but here it happens due to the way I'm creating documents on the Create side.

I think you can reproduce this in the studio using images in arrays, where adding an image will create a placeholder `{_type: 'image'}` when the dialog is opened (this was at least how it worked in the past, might be fixed since my glory days).

The error can currently be observed in the wild here:
https://visual-editing-page-builder-demo-git-canary.sanity.dev/pages/create-presentation

![image](https://github.com/user-attachments/assets/5bdb8236-8cff-47bf-9c04-649bd9772c42)

## The fix
Moar defensive layers (ie nullchecks) before using imageBuilder.
ImageBuilder is notoriously bad at dealing with missing asset props in a preview setting.

On this branch, it should be fixed:
https://visual-editing-page-builder-demo-git-image-fix.sanity.dev/pages/create-presentation

![image](https://github.com/user-attachments/assets/e6b6e689-2141-41ca-80ad-ba7f53a8ec20)

## Todo

I did not figure out how to run things locally, so this was kind of a blind fix.
Probably a good idea to have this kind of check anywhere where imageBuilder is used.

On the Create side we should probably make sure to purge any objects that just have a _type field and nothing else after error corrections. (what happend here is that an image is set with asset and all, but the upload fails, so the asset is unset, leaving the dangling {_type: 'image'}
