### PR TITLE
fix(svelte-loader): add svelte export condition

### DIFF
--- a/packages/svelte-loader/package.json
+++ b/packages/svelte-loader/package.json
@@ -18,6 +18,7 @@
     ".": {
       "source": "./src/index.ts",
       "import": "./dist/index.js",
+      "svelte": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
Adds missing `svelte` specific export condition