### PR TITLE
fix(presentation): observe correct preview snapshot perspectives

### DIFF
--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -585,7 +585,11 @@ export default function PresentationTool(props: {
       )}
       {visualEditingComlink && documentsOnPage.length > 0 && (
         <Suspense>
-          <PostMessagePreviewSnapshots comlink={visualEditingComlink} refs={documentsOnPage} />
+          <PostMessagePreviewSnapshots
+            comlink={visualEditingComlink}
+            perspective={perspective}
+            refs={documentsOnPage}
+          />
         </Suspense>
       )}
       {visualEditingComlink && (

--- a/packages/presentation/src/editor/PostMessagePreviewSnapshots.tsx
+++ b/packages/presentation/src/editor/PostMessagePreviewSnapshots.tsx
@@ -1,5 +1,17 @@
+import type {ClientPerspective} from '@sanity/client'
 import {memo, useEffect, useMemo, type FC} from 'react'
-import {combineLatest, debounceTime, Subject, switchMap} from 'rxjs'
+import {
+  combineLatest,
+  debounceTime,
+  merge,
+  NEVER,
+  share,
+  skipWhile,
+  Subject,
+  switchMap,
+  takeUntil,
+} from 'rxjs'
+import {getDraftId, getPublishedId} from 'sanity'
 import {useDocumentPreviewStore, useSchema, type PreviewValue} from '../internals'
 import type {VisualEditingConnection} from '../types'
 
@@ -10,11 +22,12 @@ type Ref = {
 
 export interface PostMessagePreviewsProps {
   comlink: VisualEditingConnection
+  perspective: ClientPerspective
   refs: Ref[]
 }
 
 const PostMessagePreviews: FC<PostMessagePreviewsProps> = (props) => {
-  const {comlink, refs} = props
+  const {comlink, refs, perspective} = props
   const documentPreviewStore = useDocumentPreviewStore()
   const schema = useSchema()
 
@@ -24,12 +37,34 @@ const PostMessagePreviews: FC<PostMessagePreviewsProps> = (props) => {
     return refsSubject.asObservable().pipe(
       switchMap((refs) => {
         return combineLatest(
-          refs.map((ref) => documentPreviewStore.observeForPreview(ref, schema.get(ref._type)!)),
+          refs.map((ref) => {
+            const draftRef = {...ref, _id: getDraftId(ref._id)}
+            const draft$ =
+              perspective === 'previewDrafts'
+                ? documentPreviewStore
+                    .observeForPreview(draftRef, schema.get(draftRef._type)!)
+                    .pipe(
+                      // Share to prevent double subscribe in the merge
+                      share(),
+                      // Don't emit if no snapshot is returned
+                      skipWhile((p) => p.snapshot === null),
+                    )
+                : // Don't emit if not displaying drafts
+                  NEVER
+
+            const publishedRef = {...ref, _id: getPublishedId(ref._id)}
+            const published$ = documentPreviewStore.observeForPreview(
+              publishedRef,
+              schema.get(publishedRef._type)!,
+            )
+
+            return merge(published$.pipe(takeUntil(draft$)), draft$)
+          }),
         )
       }),
       debounceTime(0),
     )
-  }, [documentPreviewStore, refsSubject, schema])
+  }, [documentPreviewStore, refsSubject, schema, perspective])
 
   useEffect(() => {
     const sub = previews$.subscribe((snapshots) => {
@@ -38,7 +73,10 @@ const PostMessagePreviews: FC<PostMessagePreviewsProps> = (props) => {
         data: {
           snapshots: snapshots
             .filter((s) => s.snapshot)
-            .map((s) => s.snapshot as PreviewValue & {_id: string}),
+            .map((s) => {
+              const snapshot = s.snapshot as PreviewValue & {_id: string}
+              return {...snapshot, _id: getPublishedId(snapshot._id)}
+            }),
         },
       })
     })


### PR DESCRIPTION
This should fix missing document labels on overlay elements corresponding to documents without draft versions when in the draft perspective.