### PR TITLE
feat: lower permissions req to Collaborator

### DIFF
--- a/packages/next-loader/src/defineLive.tsx
+++ b/packages/next-loader/src/defineLive.tsx
@@ -97,7 +97,7 @@ export interface DefineSanityLiveOptions {
    */
   client: SanityClient
   /**
-   * Optional. If provided then the token needs to have permissions to query documents with `drafts.` prefixes as well as `sanity-preview-url-secret.` prefixes.
+   * Optional. If provided then the token needs to have permissions to query documents with `drafts.` prefixes in order for `perspective: 'previewDrafts'` to work.
    * This token is not shared with the browser.
    */
   serverToken?: string

--- a/packages/presentation/src/PresentationToolGrantsCheck.tsx
+++ b/packages/presentation/src/PresentationToolGrantsCheck.tsx
@@ -44,7 +44,7 @@ export default function PresentationToolGrantsCheck(props: {
       .checkDocumentPermission('read', {_id: schemaIdSingleton, _type: schemaTypeSingleton})
       .subscribe(setReadAccessSharingPermission)
     const previewUrlSecretPermissionSubscription = grantsStore
-      .checkDocumentPermission('create', {_id: `${schemaIdPrefix}.${uuid()}`, _type: schemaType})
+      .checkDocumentPermission('create', {_id: `drafts.${uuid()}`, _type: schemaType})
       .subscribe(setPreviewUrlSecretPermission)
 
     return () => {

--- a/packages/presentation/src/PresentationToolGrantsCheck.tsx
+++ b/packages/presentation/src/PresentationToolGrantsCheck.tsx
@@ -1,5 +1,4 @@
 import {
-  schemaIdPrefix,
   schemaIdSingleton,
   schemaType,
   schemaTypeSingleton,

--- a/packages/presentation/src/i18n/resources.ts
+++ b/packages/presentation/src/i18n/resources.ts
@@ -106,7 +106,8 @@ export default {
   /** Disables sharing access to those who have the link */
   'share-url.dialog.action.disable-sharing': 'Disable sharing',
   /** Error toast that notifies that URL Preview Secrets can't be generated as the user lacks ACL grants */
-  'preview-url-secret.missing-grants': "URL Preview Secrets can't be generated",
+  'preview-url-secret.missing-grants':
+    "You don't have permission to create URL Preview Secrets. This will likely cause the preview to fail loading.",
   /** The `aria-label` for the button that opens the share menu */
   'preview-frame.share-button.aria-label': 'Share this preview',
   /** The tooltip for the button that opens the share menu */

--- a/packages/preview-url-secret/README.md
+++ b/packages/preview-url-secret/README.md
@@ -33,6 +33,35 @@ export default defineConfig({
 })
 ```
 
+# Permissions model
+
+> [!NOTE]
+> v1 used to require Editor or above to create the secret.
+> v2 lowers the requirement to Collaborator.
+
+In order to create an URL Preview Secret, the user needs to have the rights to create draft documents in the schema.
+By default that means Contributor or above.
+For Enterprise customers with custom roles, it's possible to grant Viewer roles access to create preview secrets.
+
+## Granting access to Viewer roles and below
+
+In your proiect access settings:
+
+1. Create a new Content Resource.
+2. Title it "Preview URL Secrets for Presentation Tool".
+3. Set the filter to: `_type == "sanity.previewUrlSecret" && _id in path("drafts.**")`.
+4. Click "Create content resource".
+5. Create new role.
+6. Title it "Viewer with Presentation Tool access".
+7. Create the role.
+8. Edit the "Content permissions".
+9. For the "Preview URL Secrets for Presentation Tool" and set it to "+ Update and create". The "All documents", "Image assets" and "File assets" should be set to "Read".
+10. Save changes.
+
+To grant a user access to Presentation Tool you simply assign them the new "Viewer with Presentation Tool access" role, instead of "Viewer".
+
+# Usage
+
 ## Next.js App Router
 
 Create an API token with viewer rights, and put it in an environment variable named `SANITY_API_READ_TOKEN`, then create the following API handler:

--- a/packages/preview-url-secret/src/createClientWithConfig.ts
+++ b/packages/preview-url-secret/src/createClientWithConfig.ts
@@ -16,12 +16,11 @@ export function createClientWithConfig(client: SanityClientLike): SanityClientLi
   }
 
   return client.withConfig({
+    perspective: 'raw',
     // Userland might be using an API version that's too old to use perspectives
     apiVersion,
     // We can't use the CDN, the secret is typically validated right after it's created
     useCdn: false,
-    // The documents that hold secrets are never drafts
-    perspective: 'published',
     // Don't waste time returning a source map, we don't need it
     resultSourceMap: false,
     // @ts-expect-error - If stega is enabled, make sure it's disabled

--- a/packages/preview-url-secret/src/createPreviewSecret.ts
+++ b/packages/preview-url-secret/src/createPreviewSecret.ts
@@ -1,13 +1,6 @@
 import type {SanityClient} from '@sanity/client'
 import {uuid} from '@sanity/uuid'
-import {
-  apiVersion,
-  deleteExpiredSecretsQuery,
-  schemaIdPrefix,
-  schemaType,
-  SECRET_TTL,
-  tag,
-} from './constants'
+import {apiVersion, deleteExpiredSecretsQuery, schemaType, SECRET_TTL, tag} from './constants'
 import {generateUrlSecret} from './generateSecret'
 import type {SanityClientLike} from './types'
 
@@ -23,7 +16,7 @@ export async function createPreviewSecret(
 
   try {
     const expiresAt = new Date(Date.now() + 1000 * SECRET_TTL)
-    const _id = `${schemaIdPrefix}.${id}`
+    const _id = `drafts.${id}`
     const newSecret = generateUrlSecret()
     const patch = client.patch(_id).set({secret: newSecret, source, studioUrl, userId})
     await client.transaction().createOrReplace({_id, _type: schemaType}).patch(patch).commit({tag})

--- a/packages/preview-url-secret/src/types.ts
+++ b/packages/preview-url-secret/src/types.ts
@@ -1,3 +1,5 @@
+import type {ClientPerspective} from '@sanity/client'
+
 /** @internal */
 export type PreviewUrlSecretSchemaIdPrefix = `sanity-preview-url-secret`
 
@@ -18,7 +20,7 @@ export type SanityClientLike = {
   withConfig(config: {
     apiVersion?: string
     useCdn?: boolean
-    perspective?: 'published'
+    perspective?: ClientPerspective
     resultSourceMap?: boolean
   }): SanityClientLike
   fetch<


### PR DESCRIPTION
We used to require Editor or above to allow someone to use Presentation Tool when `previewUrl.previewMode.enable` was used, as it creates documents in your dataset with secrets, and used to have a `sanity-preview-url-secret.**` document `_id` prefix.
The `sanity-preview-url-secret.` prefix ensures the documents can't be queried without being Viewer or above. But the downside is that Collaborator roles can only create `drafts.` prefixes.
By moving to `drafts.` Collaborators can now use Presentation Tool 🥳 

Enterprise customers can with custom roles setup access for Viewer roles as well. We always supported this, but didn't document how to set it up. I've updated the README with a step-by-step for how to use it.

Viewers and below also now see a toast message when they can't create preview secrets:

<img width="407" alt="image" src="https://github.com/user-attachments/assets/33c92a6d-2014-4d9a-9e93-b8042b8ca299">
Instead of a crash like we had before.

Applications that don't make use of `previewUrl.previewMode.enable` works just fine with Viewer and above on all price plans.