### PR TITLE
feat(validatePreviewUrl): add studioPreviewPerspective

### DIFF
--- a/packages/preview-url-secret/src/parsePreviewUrl.test.ts
+++ b/packages/preview-url-secret/src/parsePreviewUrl.test.ts
@@ -1,5 +1,9 @@
 import {expect, test} from 'vitest'
-import {urlSearchParamPreviewPathname, urlSearchParamPreviewSecret} from './constants'
+import {
+  urlSearchParamPreviewPathname,
+  urlSearchParamPreviewPerspective,
+  urlSearchParamPreviewSecret,
+} from './constants'
 import {parsePreviewUrl} from './parsePreviewUrl'
 
 test('handles absolute URLs', () => {
@@ -9,6 +13,7 @@ test('handles absolute URLs', () => {
   expect(parsePreviewUrl(unsafe.toString())).toEqual({
     redirectTo: '/preview?foo=bar',
     secret: 'abc123',
+    studioPreviewPerspective: null,
   })
 })
 
@@ -16,9 +21,11 @@ test('handles relative URLs', () => {
   const unsafe = new URL('/api/draft', 'http://localhost')
   unsafe.searchParams.set(urlSearchParamPreviewSecret, 'abc123')
   unsafe.searchParams.set(urlSearchParamPreviewPathname, '/preview?foo=bar')
+  unsafe.searchParams.set(urlSearchParamPreviewPerspective, 'published')
   expect(parsePreviewUrl(`${unsafe.pathname}${unsafe.search}`)).toEqual({
     redirectTo: '/preview?foo=bar',
     secret: 'abc123',
+    studioPreviewPerspective: 'published',
   })
 })
 
@@ -29,6 +36,7 @@ test('includes hash', () => {
   expect(parsePreviewUrl(unsafe.toString())).toEqual({
     redirectTo: '/preview?foo=bar#heading1',
     secret: 'abc123',
+    studioPreviewPerspective: null,
   })
 })
 
@@ -42,5 +50,6 @@ test('strips origin from redirect', () => {
   expect(parsePreviewUrl(unsafe.toString())).toEqual({
     redirectTo: '/preview?foo=bar',
     secret: 'abc123',
+    studioPreviewPerspective: null,
   })
 })

--- a/packages/preview-url-secret/src/parsePreviewUrl.ts
+++ b/packages/preview-url-secret/src/parsePreviewUrl.ts
@@ -1,4 +1,8 @@
-import {urlSearchParamPreviewPathname, urlSearchParamPreviewSecret} from './constants'
+import {
+  urlSearchParamPreviewPathname,
+  urlSearchParamPreviewPerspective,
+  urlSearchParamPreviewSecret,
+} from './constants'
 import type {ParsedPreviewUrl} from './types'
 
 /**
@@ -10,11 +14,12 @@ export function parsePreviewUrl(unsafeUrl: string): ParsedPreviewUrl {
   if (!secret) {
     throw new Error('Missing secret')
   }
+  const studioPreviewPerspective = url.searchParams.get(urlSearchParamPreviewPerspective)
   let redirectTo = undefined
   const unsafeRedirectTo = url.searchParams.get(urlSearchParamPreviewPathname)
   if (unsafeRedirectTo) {
     const {pathname, search, hash} = new URL(unsafeRedirectTo, 'http://localhost')
     redirectTo = `${pathname}${search}${hash}`
   }
-  return {secret, redirectTo}
+  return {secret, redirectTo, studioPreviewPerspective}
 }

--- a/packages/preview-url-secret/src/types.ts
+++ b/packages/preview-url-secret/src/types.ts
@@ -49,12 +49,19 @@ export interface PreviewUrlValidateUrlResult {
    * If the URL is valid, and the studio URL is known and valid, then its origin will be here
    */
   studioOrigin?: string
+  /**
+   * The initial perspective the Studio was using when starting to load the preview.
+   * It can change over time and should also be handled with `postMessage` listeners.
+   * The value can be arbitrary and has to be validated to make sure it's a valid perspective.
+   */
+  studioPreviewPerspective?: string | null
 }
 
 /** @internal */
 export interface ParsedPreviewUrl {
   secret: string
   redirectTo?: string
+  studioPreviewPerspective: string | null
 }
 
 /** @public */

--- a/packages/preview-url-secret/src/validatePreviewUrl.ts
+++ b/packages/preview-url-secret/src/validatePreviewUrl.ts
@@ -37,6 +37,7 @@ export async function validatePreviewUrl(
     disableCacheNoStore,
   )
   const redirectTo = isValid ? parsedPreviewUrl.redirectTo : undefined
+  const studioPreviewPerspective = isValid ? parsedPreviewUrl.studioPreviewPerspective : undefined
   let studioOrigin: string | undefined
   if (isValid) {
     try {
@@ -52,7 +53,7 @@ export async function validatePreviewUrl(
     }
   }
 
-  return {isValid, redirectTo, studioOrigin}
+  return {isValid, redirectTo, studioOrigin, studioPreviewPerspective}
 }
 
 export type {PreviewUrlValidateUrlResult, SanityClientLike}


### PR DESCRIPTION
Adds `studioPreviewPerspective` to the `validatePreviewUrl` handler.

This will be used by `next-sanity` to support the perspective switcher:
<img width="241" alt="image" src="https://github.com/user-attachments/assets/14870c5b-1928-4ede-b8ca-55d06d515c30">

We currently only pick up on what perspective the studio is using after domReady, when `@sanity/comlink` is connected and presentation tool tells `@sanity/next-loader` what the perspective is.
This leads to the unfortunate scenario:
1. Presentation Tool is open and has perspective set to `Published`.
2. A new vercel deployment happened, and draft mode is now disabled automatically, leading to the connection lost error over preview iframe. The Studio search params has `&perspective=published` in the URL.
3. The user does a full page reload to reset, since `&perspective=published` is in the URL then the iframe has `&sanity-preview-perspective=published` in its initial URL.
4. Since `validatePreviewUrl` doesn't return this data we're unable to set the perspective cookie with `published` as its initial value.
5. After the redirect, the app pulls in draft content as the preview cookie isn't set.
6. The page is done loading, and now the perspective is detected as published, the app sets the cookie and refreshes in-place with published content.

TL;DR we don't want an initial flash of just draft content. This isn't super important right now, but it's critical for Content Releases and custom perspectives.