### PR TITLE
fix(schema-extract): handle `title` sometimes being a React node

### DIFF
--- a/packages/@repo/sanity-schema/src/page-builder-demo/index.tsx
+++ b/packages/@repo/sanity-schema/src/page-builder-demo/index.tsx
@@ -30,7 +30,9 @@ const productType = defineType({
     defineField({
       type: 'array',
       name: 'media',
-      title: 'Media',
+      // @ts-expect-error this is actually allowed at runtime
+      title: <>Media</>,
+      // title: 'Media',
       of: [
         {
           type: 'image',

--- a/packages/presentation/src/overlays/schema/extract.ts
+++ b/packages/presentation/src/overlays/schema/extract.ts
@@ -250,7 +250,7 @@ export function extractSchema(workspace: Workspace, theme: ThemeContextValue): S
       return {
         type: 'document',
         name: schemaType.name,
-        title: schemaType.title,
+        title: typeof schemaType.title === 'string' ? schemaType.title : undefined,
         icon: extractIcon(schemaType),
         fields: {
           ...documentDefaultFields(schemaType.name),
@@ -287,7 +287,7 @@ export function extractSchema(workspace: Workspace, theme: ThemeContextValue): S
 
     return {
       name: schemaType.name,
-      title: schemaType.title,
+      title: typeof schemaType.title === 'string' ? schemaType.title : undefined,
       type: 'type',
       value,
     }
@@ -307,7 +307,7 @@ export function extractSchema(workspace: Workspace, theme: ThemeContextValue): S
       fields[field.name] = {
         type: 'objectField',
         name: field.name,
-        title: field.type.title,
+        title: typeof field.type.title === 'string' ? field.type.title : undefined,
         value,
         optional: isFieldRequired(field) === false,
       }
@@ -423,7 +423,7 @@ export function extractSchema(workspace: Workspace, theme: ThemeContextValue): S
         type: 'unionOption',
         icon: extractIcon(item),
         name: item.name,
-        title: item.title,
+        title: typeof item.title === 'string' ? item.title : undefined,
         value: field,
       } satisfies SchemaUnionOption
       if (field.type === 'inline') {
@@ -464,7 +464,7 @@ export function extractSchema(workspace: Workspace, theme: ThemeContextValue): S
       of: {
         type: 'arrayItem',
         name,
-        title,
+        title: typeof title === 'string' ? title : undefined,
         value,
       },
     }


### PR DESCRIPTION
This one is a [bit tricky to reproduce on this repo](https://github.com/sanity-io/visual-editing/pull/2002/commits/8968474aaa1395caece33a03f6553631f4dd50ec), since it's also breaking `sanity schema extract` which we use for TypeGen:

```
      name: 'media',
      // @ts-expect-error this is actually allowed at runtime
      title: <>Media</>,
```
Having JSX in a `title` anywhere in the schema will cause a crash that causes the comlink connection to be lost:

<img width="403" alt="Uncaught error" src="https://github.com/user-attachments/assets/bac2c990-ce92-424b-a5b6-9fd89c8cc12f">

It's currently happening if you go to the [Test Studio](https://test-studio.sanity.dev/presentation/presentation/simpleBlock/eed1de44-4731-48f5-ab77-ea50a82dfef9?preview=%2Fpreview%2Findex.html) over at the `sanity` monorepo.

