### PR TITLE
fix(comlink): handle heartbeat compatibility correctly

### DIFF
--- a/packages/core-loader/README.md
+++ b/packages/core-loader/README.md
@@ -12,3 +12,4 @@ npm install @sanity/core-loader @sanity/client
 [gzip-badge]: https://img.shields.io/bundlephobia/minzip/@sanity/core-loader?label=gzip%20size&style=flat-square
 [size-badge]: https://img.shields.io/bundlephobia/min/@sanity/core-loader?label=size&style=flat-square
 [bundlephobia]: https://bundlephobia.com/package/@sanity/core-loader
+

--- a/packages/next-loader/README.md
+++ b/packages/next-loader/README.md
@@ -12,3 +12,4 @@
 [gzip-badge]: https://img.shields.io/bundlephobia/minzip/@sanity/next-loader?label=gzip%20size&style=flat-square
 [size-badge]: https://img.shields.io/bundlephobia/min/@sanity/next-loader?label=size&style=flat-square
 [bundlephobia]: https://bundlephobia.com/package/@sanity/next-loader
+

--- a/packages/react-loader/README.md
+++ b/packages/react-loader/README.md
@@ -223,3 +223,4 @@ export default function ProductTemplate(props: Props) {
 [gzip-badge]: https://img.shields.io/bundlephobia/minzip/@sanity/react-loader?label=gzip%20size&style=flat-square
 [size-badge]: https://img.shields.io/bundlephobia/min/@sanity/react-loader?label=size&style=flat-square
 [bundlephobia]: https://bundlephobia.com/package/@sanity/react-loader
+

--- a/packages/svelte-loader/README.md
+++ b/packages/svelte-loader/README.md
@@ -257,3 +257,4 @@ Finally, we enable both live mode and overlays in the root layout component.
 [gzip-badge]: https://img.shields.io/bundlephobia/minzip/@sanity/svelte-loader?label=gzip%20size&style=flat-square
 [size-badge]: https://img.shields.io/bundlephobia/min/@sanity/svelte-loader?label=size&style=flat-square
 [bundlephobia]: https://bundlephobia.com/package/@sanity/svelte-loader
+

--- a/packages/visual-editing-helpers/src/comlinkCompatibility.ts
+++ b/packages/visual-editing-helpers/src/comlinkCompatibility.ts
@@ -115,6 +115,10 @@ const convertToChannelsMessage = (message: ProtocolMessage): ProtocolMessage => 
 
   message.type = comlinkToChannelsMap[message.type as ComlinkMessageType] ?? message.type
 
+  if (message.type === 'channel/response' && message.responseTo && !message.data) {
+    message.data = {responseTo: message.responseTo}
+  }
+
   return message
 }
 

--- a/packages/visual-editing/README.md
+++ b/packages/visual-editing/README.md
@@ -454,3 +454,4 @@ enableVisualEditing({
 [remix]: https://remix.run/
 [sveltekit]: https://kit.svelte.dev/
 [server-actions]: https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations
+


### PR DESCRIPTION
After a lot of debugging I noticed that every time `@sanity/presentation@1.16.5` sent a `channel/heartbeat` like this:
```json
    {
        "connectionId": "46d4c484-df9c-4c7f-b633-d1739330567e",
        "domain": "sanity/channels",
        "from": "presentation",
        "id": "b9cf5be9-e64e-4efb-812b-4ace7c98c857",
        "to": "overlays",
        "type": "channel/heartbeat"
    }
```

The connection was lost.
Comparing payloads and versions, `@sanity/visual-editing@2.1.0` responds with:

```json
   {
        "connectionId": "46d4c484-df9c-4c7f-b633-d1739330567e",
        "data": {
            "responseTo": "b9cf5be9-e64e-4efb-812b-4ace7c98c857"
        },
        "domain": "sanity/channels",
        "from": "overlays",
        "id": "b19f2420-e0d2-4156-9d36-982162129df2",
        "to": "presentation",
        "type": "channel/response"
    }
```
And all is well.
While `@sanity/visual-editing@2.2.0` responds with:

```json
   {
        "connectionId": "46d4c484-df9c-4c7f-b633-d1739330567e",
        "domain": "sanity/channels",
        "from": "overlays",
        "id": "msg-68f6d443-70e8-4306-abfb-9f2c6ee043e9",
        "to": "presentation",
        "type": "channel/response",
        "responseTo": "b9cf5be9-e64e-4efb-812b-4ace7c98c857"
   }
```

The only difference I could find where:
```diff
   {
        "connectionId": "46d4c484-df9c-4c7f-b633-d1739330567e",
-        "data": {
-            "responseTo": "b9cf5be9-e64e-4efb-812b-4ace7c98c857"
-        },
        "domain": "sanity/channels",
        "from": "overlays",
        "id": "b19f2420-e0d2-4156-9d36-982162129df2",
        "to": "presentation",
        "type": "channel/response",
+       "responseTo": "b9cf5be9-e64e-4efb-812b-4ace7c98c857"
    }
```

I found the compat layer and tested the fix there, adding back `data.responseTo` if there were no `data` already, and also a `responseTo` present. 
`@sanity/visual-editing@2.2.1-canary.0` can connect to both `@sanity/presentation@1.16.5` and `@sanity/presentation@1.17.1` without issues 😮‍💨 