### PR TITLE
fix: stop inlining rxjs and `@sanity/comlink`

### DIFF
--- a/apps/next-with-i18n/app/(website)/[locale]/[...path]/page.tsx
+++ b/apps/next-with-i18n/app/(website)/[locale]/[...path]/page.tsx
@@ -2,10 +2,11 @@ import { Page } from '@/components/Page'
 import { loadPage } from '@/data/sanity'
 
 export default async function DynamicRoute({
-  params: { path, locale },
+  params,
 }: {
-  params: { path: string[]; locale: string }
+  params: Promise<{ path: string[]; locale: string }>
 }) {
+  const { path, locale } = await params
   const pathname = `/${path.join('/')}`
   const data = await loadPage(pathname, locale)
 

--- a/apps/next-with-i18n/app/(website)/[locale]/layout.tsx
+++ b/apps/next-with-i18n/app/(website)/[locale]/layout.tsx
@@ -18,21 +18,22 @@ const sans = Inter({
 })
 
 export default async function RootLayout({
-  params: { locale },
+  params,
   children,
 }: {
-  params: { locale: string }
+  params: Promise<{ locale: string }>
   children: React.ReactNode
 }) {
+  const { locale } = await params
   return (
     <html lang={locale} className={sans.variable}>
       <body>
         {children}
-        {draftMode().isEnabled && (
+        {(await draftMode()).isEnabled && (
           <VisualEditing
             refresh={async (payload) => {
               'use server'
-              if (!draftMode().isEnabled) {
+              if (!(await draftMode()).isEnabled) {
                 console.debug(
                   'Skipped manual refresh because draft mode is not enabled',
                 )

--- a/apps/next-with-i18n/app/(website)/[locale]/page.tsx
+++ b/apps/next-with-i18n/app/(website)/[locale]/page.tsx
@@ -2,10 +2,11 @@ import { Page } from '@/components/Page'
 import { loadPage } from '@/data/sanity'
 
 export default async function IndexRoute({
-  params: { locale },
+  params,
 }: {
-  params: { locale: string }
+  params: Promise<{ locale: string }>
 }) {
+  const { locale } = await params
   const data = await loadPage('/', locale)
 
   return <Page data={data} />

--- a/apps/next-with-i18n/app/api/disable-draft/route.ts
+++ b/apps/next-with-i18n/app/api/disable-draft/route.ts
@@ -1,8 +1,8 @@
 import { draftMode } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
 
-export function GET(request: NextRequest) {
-  draftMode().disable()
+export async function GET(request: NextRequest) {
+  ;(await draftMode()).disable()
   const url = new URL(request.nextUrl)
   return NextResponse.redirect(new URL('/', url.origin))
 }

--- a/apps/next-with-i18n/app/api/draft/route.ts
+++ b/apps/next-with-i18n/app/api/draft/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: Request) {
     return new Response('Invalid secret', { status: 401 })
   }
 
-  draftMode().enable()
+  ;(await draftMode()).enable()
 
   redirect(redirectTo)
 }

--- a/apps/next-with-i18n/data/sanity/loadQuery.ts
+++ b/apps/next-with-i18n/data/sanity/loadQuery.ts
@@ -16,7 +16,7 @@ export async function loadQuery<QueryResponse>({
   query: string
   params?: QueryParams
 }): Promise<QueryResponse> {
-  const isDraftMode = draftMode().isEnabled
+  const isDraftMode = (await draftMode()).isEnabled
   const token = config.sanity.token
 
   if (isDraftMode && !token) {

--- a/apps/next/src/app/api/draft-mode/disable/route.ts
+++ b/apps/next/src/app/api/draft-mode/disable/route.ts
@@ -1,8 +1,8 @@
 import {draftMode} from 'next/headers'
 import {NextRequest, NextResponse} from 'next/server'
 
-export function GET(request: NextRequest) {
-  draftMode().disable()
+export async function GET(request: NextRequest) {
+  ;(await draftMode()).disable()
   const url = new URL(request.nextUrl)
   return NextResponse.redirect(new URL('/pages-router/shoes', url.origin))
 }

--- a/apps/next/src/app/compat/layout.tsx
+++ b/apps/next/src/app/compat/layout.tsx
@@ -14,10 +14,10 @@ export default async function RootLayout({children}: {children: React.ReactNode}
     <html lang="en">
       <body>
         {children}
-        {draftMode().isEnabled && <VisualEditing />}
+        {(await draftMode()).isEnabled && <VisualEditing />}
         <a className="fixed bottom-1 left-1 block rounded bg-slate-900 px-2 py-1 text-xs text-slate-100">
           app-router:{' '}
-          {draftMode().isEnabled
+          {(await draftMode()).isEnabled
             ? 'draftMode'
             : process.env.NEXT_PUBLIC_VERCEL_ENV || 'development'}
           {', '}

--- a/apps/next/src/app/compat/page.tsx
+++ b/apps/next/src/app/compat/page.tsx
@@ -16,8 +16,8 @@ export default async function ShoesPage() {
     {},
     {
       filterResponse: false,
-      perspective: draftMode().isEnabled ? 'previewDrafts' : 'published',
-      useCdn: draftMode().isEnabled ? false : true,
+      perspective: (await draftMode()).isEnabled ? 'previewDrafts' : 'published',
+      useCdn: (await draftMode()).isEnabled ? false : true,
       cache: 'no-store',
     },
   )

--- a/apps/next/src/app/only-visual-editing/layout.tsx
+++ b/apps/next/src/app/only-visual-editing/layout.tsx
@@ -16,11 +16,11 @@ export default async function RootLayout({children}: {children: React.ReactNode}
       <body>
         {children}
         <VercelToolbar />
-        {draftMode().isEnabled && (
+        {(await draftMode()).isEnabled && (
           <VisualEditing
             refresh={async (payload) => {
               'use server'
-              if (!draftMode().isEnabled) {
+              if (!(await draftMode()).isEnabled) {
                 console.error('Draft Mode is not enabled, ignoring refresh')
                 return
               }
@@ -42,7 +42,7 @@ export default async function RootLayout({children}: {children: React.ReactNode}
         )}
         <a className="fixed bottom-1 left-1 block rounded bg-slate-900 px-2 py-1 text-xs text-slate-100">
           app-router:{' '}
-          {draftMode().isEnabled
+          {(await draftMode()).isEnabled
             ? 'draftMode'
             : process.env.NEXT_PUBLIC_VERCEL_ENV || 'development'}
           {', '}

--- a/apps/next/src/app/only-visual-editing/page.tsx
+++ b/apps/next/src/app/only-visual-editing/page.tsx
@@ -16,8 +16,8 @@ export default async function ShoesPage() {
     {},
     {
       filterResponse: false,
-      perspective: draftMode().isEnabled ? 'previewDrafts' : 'published',
-      useCdn: draftMode().isEnabled ? false : true,
+      perspective: (await draftMode()).isEnabled ? 'previewDrafts' : 'published',
+      useCdn: (await draftMode()).isEnabled ? false : true,
       next: {revalidate: false, tags: ['shoe']},
     },
   )

--- a/apps/next/src/app/shoes/[slug]/page.tsx
+++ b/apps/next/src/app/shoes/[slug]/page.tsx
@@ -5,15 +5,15 @@ import {loadQuery} from '../sanity.ssr'
 import ShoePageClient from './page.client'
 
 type Props = {
-  params: {slug: string}
+  params: Promise<{slug: string}>
 }
 
 export default async function ShoePage(props: Props) {
-  const {params} = props
+  const params = await props.params
   const initial = loadQuery<ShoeResult>(shoe, params, {
-    perspective: draftMode().isEnabled ? 'previewDrafts' : 'published',
+    perspective: (await draftMode()).isEnabled ? 'previewDrafts' : 'published',
     next: {
-      revalidate: draftMode().isEnabled ? 0 : false,
+      revalidate: (await draftMode()).isEnabled ? 0 : false,
       tags: [`shoe:${params.slug}`],
     },
   })

--- a/apps/next/src/app/shoes/layout.tsx
+++ b/apps/next/src/app/shoes/layout.tsx
@@ -11,10 +11,10 @@ export default async function RootLayout({children}: {children: React.ReactNode}
     <html lang="en">
       <body>
         {children}
-        {draftMode().isEnabled && <LiveVisualEditing />}
+        {(await draftMode()).isEnabled && <LiveVisualEditing />}
         <a className="fixed bottom-1 left-1 block rounded bg-slate-900 px-2 py-1 text-xs text-slate-100">
           app-router:{' '}
-          {draftMode().isEnabled
+          {(await draftMode()).isEnabled
             ? 'draftMode'
             : process.env.NEXT_PUBLIC_VERCEL_ENV || 'development'}
           {', '}

--- a/apps/next/src/app/shoes/page.tsx
+++ b/apps/next/src/app/shoes/page.tsx
@@ -9,8 +9,8 @@ export default async function ShoesPage() {
     shoesList,
     {},
     {
-      perspective: draftMode().isEnabled ? 'previewDrafts' : 'published',
-      next: {revalidate: draftMode().isEnabled ? 0 : false, tags: ['shoe']},
+      perspective: (await draftMode()).isEnabled ? 'previewDrafts' : 'published',
+      next: {revalidate: (await draftMode()).isEnabled ? 0 : false, tags: ['shoe']},
     },
   )
   return <ShoesPageClient initial={initial} />

--- a/apps/next/src/app/shoes/sanity.ssr.ts
+++ b/apps/next/src/app/shoes/sanity.ssr.ts
@@ -15,9 +15,10 @@ setServerClient(
 )
 
 // Automatically handle draft mode
-export const loadQuery = ((query, params = {}, options = {}) => {
-  const isDraftMode = draftMode().isEnabled
-  const perspective = options.perspective || draftMode().isEnabled ? 'previewDrafts' : 'published'
+export const loadQuery = (async (query, params = {}, options = {}) => {
+  const isDraftMode = (await draftMode()).isEnabled
+  const perspective =
+    options.perspective || (await draftMode()).isEnabled ? 'previewDrafts' : 'published'
   return _loadQuery(query, params, {
     ...options,
     perspective,

--- a/apps/page-builder-demo/src/app/layout.tsx
+++ b/apps/page-builder-demo/src/app/layout.tsx
@@ -50,9 +50,9 @@ export default async function RootLayout({children}: {children: React.ReactNode}
   return (
     <html lang="en" className={`${mono.variable} ${sans.variable} ${serif.variable}`}>
       <body className="bg-white text-black dark:bg-black dark:text-white">
-        {draftMode().isEnabled && <AlertBanner />}
+        {(await draftMode()).isEnabled && <AlertBanner />}
         <AppLayout data={data}>{children}</AppLayout>
-        {draftMode().isEnabled && <VisualEditing />}
+        {(await draftMode()).isEnabled && <VisualEditing />}
         <SanityLive />
       </body>
     </html>

--- a/apps/page-builder-demo/src/app/pages/[slug]/page.tsx
+++ b/apps/page-builder-demo/src/app/pages/[slug]/page.tsx
@@ -47,8 +47,8 @@ export async function generateStaticParams() {
   return data
 }
 
-export default async function PagesPage({params}: {params: {slug: string}}) {
-  const {data} = await sanityFetch({query: pageQuery, params})
+export default async function PagesPage({params}: {params: Promise<{slug: string}>}) {
+  const {data} = await sanityFetch({query: pageQuery, params: await params})
   if (!data) {
     notFound()
   }

--- a/apps/page-builder-demo/src/app/product/[slug]/page.tsx
+++ b/apps/page-builder-demo/src/app/product/[slug]/page.tsx
@@ -34,9 +34,12 @@ export async function generateStaticParams() {
 
 const productPageQuery = defineQuery(`*[_type == "product" && slug.current == $slug][0]`)
 
-export default async function ProductPage({params}: {params: {slug: string}}) {
+export default async function ProductPage({params}: {params: Promise<{slug: string}>}) {
   // @TODO fix typegen vs manual types issues
-  const {data} = (await sanityFetch({query: productPageQuery, params})) as unknown as {
+  const {data} = (await sanityFetch({
+    query: productPageQuery,
+    params: await params,
+  })) as unknown as {
     data: ProductData | null
   }
 

--- a/apps/page-builder-demo/src/app/project/[slug]/page.tsx
+++ b/apps/page-builder-demo/src/app/project/[slug]/page.tsx
@@ -25,9 +25,12 @@ export async function generateStaticParams() {
 
 const projectPageQuery = defineQuery(`*[_type == "project" && slug.current == $slug][0]`)
 
-export default async function ProjectPage({params}: {params: {slug: string}}) {
+export default async function ProjectPage({params}: {params: Promise<{slug: string}>}) {
   // @TODO fix typegen vs manual types issues
-  const {data} = (await sanityFetch({query: projectPageQuery, params})) as unknown as {
+  const {data} = (await sanityFetch({
+    query: projectPageQuery,
+    params: await params,
+  })) as unknown as {
     data: ProjectData | null
   }
 

--- a/packages/core-loader/package.json
+++ b/packages/core-loader/package.json
@@ -67,13 +67,15 @@
     ],
     "root": true
   },
+  "dependencies": {
+    "@sanity/comlink": "workspace:*"
+  },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/package.config": "workspace:*",
     "@repo/prettier-config": "workspace:*",
     "@repo/visual-editing-helpers": "workspace:*",
     "@sanity/client": "^6.22.2",
-    "@sanity/comlink": "workspace:*",
     "@sanity/pkg-utils": "6.11.4",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",

--- a/packages/preview-kit-compat/package.json
+++ b/packages/preview-kit-compat/package.json
@@ -46,13 +46,15 @@
     ],
     "root": true
   },
+  "dependencies": {
+    "@sanity/comlink": "workspace:*"
+  },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/package.config": "workspace:*",
     "@repo/prettier-config": "workspace:*",
     "@repo/visual-editing-helpers": "workspace:*",
     "@sanity/client": "^6.22.2",
-    "@sanity/comlink": "workspace:*",
     "@sanity/pkg-utils": "6.11.4",
     "@types/react": "^18.3.11",
     "eslint": "^8.57.1",

--- a/packages/visual-editing-helpers/package.json
+++ b/packages/visual-editing-helpers/package.json
@@ -77,6 +77,7 @@
   },
   "peerDependencies": {
     "@sanity/client": "^6.22.2",
+    "@sanity/comlink": "workspace:*",
     "react": "^18.2.0",
     "valibot": "0.31.1"
   },

--- a/packages/visual-editing/package.config.ts
+++ b/packages/visual-editing/package.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     'process.env.NODE_ENV': 'production',
   },
   rollup: {
+    ...baseConfig.rollup,
     treeshake: {
       preset: 'smallest',
       manualPureFunctions: ['createElement', 'forwardRef', 'memo', 'styled'],

--- a/packages/visual-editing/package.json
+++ b/packages/visual-editing/package.json
@@ -109,9 +109,11 @@
     "root": true
   },
   "dependencies": {
+    "@sanity/comlink": "workspace:*",
     "@sanity/mutate": "0.10.1-canary.4",
     "@sanity/preview-url-secret": "workspace:*",
     "@vercel/stega": "0.1.2",
+    "rxjs": "^7.8.1",
     "scroll-into-view-if-needed": "^3.1.0",
     "use-effect-event": "^1.0.2",
     "valibot": "0.31.1",
@@ -124,7 +126,6 @@
     "@repo/visual-editing-helpers": "workspace:*",
     "@sanity/client": "^6.22.2",
     "@sanity/color": "^3.0.6",
-    "@sanity/comlink": "workspace:*",
     "@sanity/demo": "^2.0.0",
     "@sanity/pkg-utils": "6.11.4",
     "@sanity/ui": "2.8.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
         version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.3.3)(typescript@5.6.3)
       '@astrojs/react':
         specifier: ^3.6.2
-        version: 3.6.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0))
+        version: 3.6.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0))
       '@astrojs/tailwind':
         specifier: ^5.1.2
         version: 5.1.2(astro@4.16.6(@types/node@22.5.5)(rollup@4.24.0)(terser@5.33.0)(typescript@5.6.3))(tailwindcss@3.4.14)
@@ -434,13 +434,13 @@ importers:
     devDependencies:
       '@nuxt/devtools':
         specifier: ^1.6.0
-        version: 1.6.0(rollup@4.24.0)(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0))(vue@3.5.6(typescript@5.6.3))(webpack-sources@3.2.3)
+        version: 1.6.0(rollup@4.24.0)(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0))(vue@3.5.6(typescript@5.6.3))(webpack-sources@3.2.3)
       '@repo/prettier-config':
         specifier: workspace:*
         version: link:../../packages/@repo/prettier-config
       nuxt:
         specifier: ^3.13.2
-        version: 3.13.2(@parcel/watcher@2.4.1)(@types/node@22.5.5)(eslint@8.57.1)(ioredis@5.4.1)(magicast@0.3.5)(meow@9.0.0)(optionator@0.9.4)(rollup@4.24.0)(terser@5.33.0)(typescript@5.6.3)(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0))(webpack-sources@3.2.3)
+        version: 3.13.2(@parcel/watcher@2.4.1)(@types/node@22.5.5)(eslint@8.57.1)(ioredis@5.4.1)(magicast@0.3.5)(meow@9.0.0)(optionator@0.9.4)(rollup@4.24.0)(terser@5.33.0)(typescript@5.6.3)(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0))(webpack-sources@3.2.3)
 
   apps/page-builder-demo:
     dependencies:
@@ -1033,6 +1033,10 @@ importers:
         version: 5.0.1(typescript@5.6.3)(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0))
 
   packages/core-loader:
+    dependencies:
+      '@sanity/comlink':
+        specifier: workspace:*
+        version: link:../comlink
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -1049,9 +1053,6 @@ importers:
       '@sanity/client':
         specifier: ^6.22.2
         version: 6.22.2(debug@4.3.7)
-      '@sanity/comlink':
-        specifier: workspace:*
-        version: link:../comlink
       '@sanity/pkg-utils':
         specifier: 6.11.4
         version: 6.11.4(@types/babel__core@7.20.5)(@types/node@22.5.5)(typescript@5.6.3)
@@ -1285,6 +1286,10 @@ importers:
         version: 2.1.3(@types/node@22.5.5)(happy-dom@15.7.4)(jsdom@23.2.0)(terser@5.33.0)
 
   packages/preview-kit-compat:
+    dependencies:
+      '@sanity/comlink':
+        specifier: workspace:*
+        version: link:../comlink
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -1301,9 +1306,6 @@ importers:
       '@sanity/client':
         specifier: ^6.22.2
         version: 6.22.2(debug@4.3.7)
-      '@sanity/comlink':
-        specifier: workspace:*
-        version: link:../comlink
       '@sanity/pkg-utils':
         specifier: 6.11.4
         version: 6.11.4(@types/babel__core@7.20.5)(@types/node@22.5.5)(typescript@5.6.3)
@@ -1460,6 +1462,9 @@ importers:
 
   packages/visual-editing:
     dependencies:
+      '@sanity/comlink':
+        specifier: workspace:*
+        version: link:../comlink
       '@sanity/mutate':
         specifier: 0.10.1-canary.4
         version: 0.10.1-canary.4(xstate@5.18.2)
@@ -1472,6 +1477,9 @@ importers:
       next:
         specifier: '>= 13 || >=14.3.0-canary.0 <14.3.0 || >=15.0.0-rc'
         version: 15.0.0(@babel/core@7.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.1
       scroll-into-view-if-needed:
         specifier: ^3.1.0
         version: 3.1.0
@@ -1503,9 +1511,6 @@ importers:
       '@sanity/color':
         specifier: ^3.0.6
         version: 3.0.6
-      '@sanity/comlink':
-        specifier: workspace:*
-        version: link:../comlink
       '@sanity/demo':
         specifier: ^2.0.0
         version: 2.0.0(@sanity/color@3.0.6)(tailwindcss@3.4.14)
@@ -3645,9 +3650,6 @@ packages:
   '@next/bundle-analyzer@15.0.0-canary.202':
     resolution: {integrity: sha512-vFU/rKi0CssYxraK1U9LHDyTfljEZ09c9+8wwjc9QpTPZUKWfvKc9khR5mZUAqy13LV42InlK80d8HWuUvka/Q==}
 
-  '@next/env@14.2.15':
-    resolution: {integrity: sha512-S1qaj25Wru2dUpcIZMjxeMVSwkt8BK4dmWHHiBuRstcIyOsMapqT4A4jSB6onvqeygkSSmOkyny9VVx8JIGamQ==}
-
   '@next/env@15.0.0':
     resolution: {integrity: sha512-Mcv8ZVmEgTO3bePiH/eJ7zHqQEs2gCqZ0UId2RxHmDDc7Pw6ngfSrOFlxG8XDpaex+n2G+TKPsQAf28MO+88Gw==}
 
@@ -3660,12 +3662,6 @@ packages:
   '@next/eslint-plugin-next@15.0.0-canary.202':
     resolution: {integrity: sha512-6hYNANvsG6bBVjfAR6vtG16lqbzWoINapOfgzLJBIR4JxRcp4dc5Rcmg7HCG4par/l7DB/3FMle5z/PLOgYsBQ==}
 
-  '@next/swc-darwin-arm64@14.2.15':
-    resolution: {integrity: sha512-Rvh7KU9hOUBnZ9TJ28n2Oa7dD9cvDBKua9IKx7cfQQ0GoYUwg9ig31O2oMwH3wm+pE3IkAQ67ZobPfEgurPZIA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@next/swc-darwin-arm64@15.0.0':
     resolution: {integrity: sha512-Gjgs3N7cFa40a9QT9AEHnuGKq69/bvIOn0SLGDV+ordq07QOP4k1GDOVedMHEjVeqy1HBLkL8rXnNTuMZIv79A==}
     engines: {node: '>= 10'}
@@ -3676,12 +3672,6 @@ packages:
     resolution: {integrity: sha512-/FlDaVZfT7Ds8HgSmTTMb3HJ0xVuIEzcWnV8TXmQTZmD/r6GXz05Lu2r2r22TVKn3uPyoAvpXXzxs7Bb/KPWxw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@next/swc-darwin-x64@14.2.15':
-    resolution: {integrity: sha512-5TGyjFcf8ampZP3e+FyCax5zFVHi+Oe7sZyaKOngsqyaNEpOgkKB3sqmymkZfowy3ufGA/tUgDPPxpQx931lHg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
     os: [darwin]
 
   '@next/swc-darwin-x64@15.0.0':
@@ -3696,12 +3686,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@14.2.15':
-    resolution: {integrity: sha512-3Bwv4oc08ONiQ3FiOLKT72Q+ndEMyLNsc/D3qnLMbtUYTQAmkx9E/JRu0DBpHxNddBmNT5hxz1mYBphJ3mfrrw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
   '@next/swc-linux-arm64-gnu@15.0.0':
     resolution: {integrity: sha512-sbCoEpuWUBpYoLSgYrk0CkBv8RFv4ZlPxbwqRHr/BWDBJppTBtF53EvsntlfzQJ9fosYX12xnS6ltxYYwsMBjg==}
     engines: {node: '>= 10'}
@@ -3710,12 +3694,6 @@ packages:
 
   '@next/swc-linux-arm64-gnu@15.0.0-canary.202':
     resolution: {integrity: sha512-FurVSrGYRSYWLo60W0rpKT5Ro55bT1zK4sj+kt47hJuSJibvN0GYiF10r9ymy+frY/wOPBPCJ1PAA+NgHU98uA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@next/swc-linux-arm64-musl@14.2.15':
-    resolution: {integrity: sha512-k5xf/tg1FBv/M4CMd8S+JL3uV9BnnRmoe7F+GWC3DxkTCD9aewFRH1s5rJ1zkzDa+Do4zyN8qD0N8c84Hu96FQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -3732,12 +3710,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@14.2.15':
-    resolution: {integrity: sha512-kE6q38hbrRbKEkkVn62reLXhThLRh6/TvgSP56GkFNhU22TbIrQDEMrO7j0IcQHcew2wfykq8lZyHFabz0oBrA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
   '@next/swc-linux-x64-gnu@15.0.0':
     resolution: {integrity: sha512-r5Smd03PfxrGKMewdRf2RVNA1CU5l2rRlvZLQYZSv7FUsXD5bKEcOZ/6/98aqRwL7diXOwD8TCWJk1NbhATQHg==}
     engines: {node: '>= 10'}
@@ -3746,12 +3718,6 @@ packages:
 
   '@next/swc-linux-x64-gnu@15.0.0-canary.202':
     resolution: {integrity: sha512-Gsx3YUNGu84CBz7BjpAkaJYrQyKn/ws6LEzqp77/9QnAd/cTNifqwmpOUCZFgT1KLQt9DLwbNv3tM41ulZih2Q==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@next/swc-linux-x64-musl@14.2.15':
-    resolution: {integrity: sha512-PZ5YE9ouy/IdO7QVJeIcyLn/Rc4ml9M2G4y3kCM9MNf1YKvFY4heg3pVa/jQbMro+tP6yc4G2o9LjAz1zxD7tQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -3768,12 +3734,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@14.2.15':
-    resolution: {integrity: sha512-2raR16703kBvYEQD9HNLyb0/394yfqzmIeyp2nDzcPV4yPjqNUG3ohX6jX00WryXz6s1FXpVhsCo3i+g4RUX+g==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
   '@next/swc-win32-arm64-msvc@15.0.0':
     resolution: {integrity: sha512-ZOd7c/Lz1lv7qP/KzR513XEa7QzW5/P0AH3A5eR1+Z/KmDOvMucht0AozccPc0TqhdV1xaXmC0Fdx0hoNzk6ng==}
     engines: {node: '>= 10'}
@@ -3784,18 +3744,6 @@ packages:
     resolution: {integrity: sha512-tlYXaAmz9bDlc3164q1pMZk69Imctd5EFsMaWmbKpIPkLuUI5RqggEv9FPTfUm9O42qq1uk75lWDGcpkU70jiw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
-    os: [win32]
-
-  '@next/swc-win32-ia32-msvc@14.2.15':
-    resolution: {integrity: sha512-fyTE8cklgkyR1p03kJa5zXEaZ9El+kDNM5A+66+8evQS5e/6v0Gk28LqA0Jet8gKSOyP+OTm/tJHzMlGdQerdQ==}
-    engines: {node: '>= 10'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@next/swc-win32-x64-msvc@14.2.15':
-    resolution: {integrity: sha512-SzqGbsLsP9OwKNUG9nekShTwhj6JSB9ZLMWQ8g1gG6hdE5gQLncbnbymrwy2yVmH9nikSLYRYxYMFu78Ggp7/g==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
     os: [win32]
 
   '@next/swc-win32-x64-msvc@15.0.0':
@@ -4957,9 +4905,6 @@ packages:
 
   '@swc/helpers@0.5.13':
     resolution: {integrity: sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==}
-
-  '@swc/helpers@0.5.5':
-    resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
 
   '@tailwindcss/typography@0.5.15':
     resolution: {integrity: sha512-AqhlCXl+8grUz8uqExv5OTtgpjuVIwFTSXTrh8y9/pw6q2ek7fJ+Y8ZEVw7EB2DCcuCOtEjf9w3+J3rzts01uA==}
@@ -10013,24 +9958,6 @@ packages:
       sanity: 3.61.0
       styled-components: ^6.1
 
-  next@14.2.15:
-    resolution: {integrity: sha512-h9ctmOokpoDphRvMGnwOJAedT6zKhwqyZML9mDtspgf4Rh3Pn7UTYKqePNoDvhsWBAO5GoPNYshnAUGIazVGmw==}
-    engines: {node: '>=18.17.0'}
-    hasBin: true
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-      '@playwright/test': ^1.41.2
-      react: ^18.2.0
-      react-dom: ^18.2.0
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@playwright/test':
-        optional: true
-      sass:
-        optional: true
-
   next@15.0.0:
     resolution: {integrity: sha512-/ivqF6gCShXpKwY9hfrIQYh8YMge8L3W+w1oRLv/POmK4MOQnh+FscZ8a0fRFTSQWE+2z9ctNYvELD9vP2FV+A==}
     engines: {node: '>=18.18.0'}
@@ -12268,19 +12195,6 @@ packages:
       react: '>= 16.8.0'
       react-dom: '>= 16.8.0'
 
-  styled-jsx@5.1.1:
-    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
-    engines: {node: '>= 12.0.0'}
-    peerDependencies:
-      '@babel/core': '*'
-      babel-plugin-macros: '*'
-      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      babel-plugin-macros:
-        optional: true
-
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -13826,11 +13740,11 @@ snapshots:
     dependencies:
       prismjs: 1.29.0
 
-  '@astrojs/react@3.6.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0))':
+  '@astrojs/react@3.6.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0))':
     dependencies:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
-      '@vitejs/plugin-react': 4.3.1(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0))
+      '@vitejs/plugin-react': 4.3.1(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       ultrahtml: 1.5.3
@@ -15754,8 +15668,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@next/env@14.2.15': {}
-
   '@next/env@15.0.0': {}
 
   '@next/env@15.0.0-canary.202': {}
@@ -15768,16 +15680,10 @@ snapshots:
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@14.2.15':
-    optional: true
-
   '@next/swc-darwin-arm64@15.0.0':
     optional: true
 
   '@next/swc-darwin-arm64@15.0.0-canary.202':
-    optional: true
-
-  '@next/swc-darwin-x64@14.2.15':
     optional: true
 
   '@next/swc-darwin-x64@15.0.0':
@@ -15786,16 +15692,10 @@ snapshots:
   '@next/swc-darwin-x64@15.0.0-canary.202':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@14.2.15':
-    optional: true
-
   '@next/swc-linux-arm64-gnu@15.0.0':
     optional: true
 
   '@next/swc-linux-arm64-gnu@15.0.0-canary.202':
-    optional: true
-
-  '@next/swc-linux-arm64-musl@14.2.15':
     optional: true
 
   '@next/swc-linux-arm64-musl@15.0.0':
@@ -15804,16 +15704,10 @@ snapshots:
   '@next/swc-linux-arm64-musl@15.0.0-canary.202':
     optional: true
 
-  '@next/swc-linux-x64-gnu@14.2.15':
-    optional: true
-
   '@next/swc-linux-x64-gnu@15.0.0':
     optional: true
 
   '@next/swc-linux-x64-gnu@15.0.0-canary.202':
-    optional: true
-
-  '@next/swc-linux-x64-musl@14.2.15':
     optional: true
 
   '@next/swc-linux-x64-musl@15.0.0':
@@ -15822,19 +15716,10 @@ snapshots:
   '@next/swc-linux-x64-musl@15.0.0-canary.202':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@14.2.15':
-    optional: true
-
   '@next/swc-win32-arm64-msvc@15.0.0':
     optional: true
 
   '@next/swc-win32-arm64-msvc@15.0.0-canary.202':
-    optional: true
-
-  '@next/swc-win32-ia32-msvc@14.2.15':
-    optional: true
-
-  '@next/swc-win32-x64-msvc@14.2.15':
     optional: true
 
   '@next/swc-win32-x64-msvc@15.0.0':
@@ -15986,12 +15871,12 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@1.6.0(magicast@0.3.5)(rollup@4.24.0)(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0))(webpack-sources@3.2.3)':
+  '@nuxt/devtools-kit@1.6.0(magicast@0.3.5)(rollup@4.24.0)(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0))(webpack-sources@3.2.3)':
     dependencies:
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.24.0)(webpack-sources@3.2.3)
       '@nuxt/schema': 3.13.2(rollup@4.24.0)(webpack-sources@3.2.3)
       execa: 7.2.0
-      vite: 5.4.9(@types/node@22.5.5)(terser@5.33.0)
+      vite: 4.5.3(@types/node@22.5.5)(terser@5.33.0)
     transitivePeerDependencies:
       - magicast
       - rollup
@@ -16011,13 +15896,13 @@ snapshots:
       rc9: 2.1.2
       semver: 7.6.3
 
-  '@nuxt/devtools@1.6.0(rollup@4.24.0)(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0))(vue@3.5.6(typescript@5.6.3))(webpack-sources@3.2.3)':
+  '@nuxt/devtools@1.6.0(rollup@4.24.0)(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0))(vue@3.5.6(typescript@5.6.3))(webpack-sources@3.2.3)':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.6.0(magicast@0.3.5)(rollup@4.24.0)(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0))(webpack-sources@3.2.3)
+      '@nuxt/devtools-kit': 1.6.0(magicast@0.3.5)(rollup@4.24.0)(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0))(webpack-sources@3.2.3)
       '@nuxt/devtools-wizard': 1.6.0
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.24.0)(webpack-sources@3.2.3)
-      '@vue/devtools-core': 7.4.4(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0))(vue@3.5.6(typescript@5.6.3))
+      '@vue/devtools-core': 7.4.4(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0))(vue@3.5.6(typescript@5.6.3))
       '@vue/devtools-kit': 7.4.4
       birpc: 0.2.17
       consola: 3.2.3
@@ -16046,9 +15931,9 @@ snapshots:
       sirv: 2.0.4
       tinyglobby: 0.2.6
       unimport: 3.12.0(rollup@4.24.0)(webpack-sources@3.2.3)
-      vite: 5.4.9(@types/node@22.5.5)(terser@5.33.0)
-      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.24.0)(webpack-sources@3.2.3))(rollup@4.24.0)(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0))
-      vite-plugin-vue-inspector: 5.1.3(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0))
+      vite: 4.5.3(@types/node@22.5.5)(terser@5.33.0)
+      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.24.0)(webpack-sources@3.2.3))(rollup@4.24.0)(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0))
+      vite-plugin-vue-inspector: 5.1.3(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0))
       which: 3.0.1
       ws: 8.18.0
     transitivePeerDependencies:
@@ -16332,7 +16217,27 @@ snapshots:
 
   '@polka/url@1.0.0-next.25': {}
 
-  '@portabletext/editor@1.1.4(@sanity/block-tools@3.61.0(debug@4.3.7))(@sanity/schema@3.61.0(debug@4.3.7))(@sanity/types@3.61.0(debug@4.3.7))(@sanity/util@3.61.0(debug@4.3.7))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@portabletext/editor@1.1.4(@sanity/block-tools@3.61.0(debug@4.3.7))(@sanity/schema@3.61.0(debug@4.3.7))(@sanity/types@3.61.0(debug@4.3.7))(@sanity/util@3.61.0(debug@4.3.7))(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)(rxjs@7.8.1)(styled-components@6.1.13(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614))':
+    dependencies:
+      '@portabletext/patches': 1.1.0
+      '@sanity/block-tools': 3.61.0(debug@4.3.7)
+      '@sanity/schema': 3.61.0(debug@4.3.7)
+      '@sanity/types': 3.61.0(debug@4.3.7)
+      '@sanity/util': 3.61.0(debug@4.3.7)
+      debug: 4.3.7
+      is-hotkey-esm: 1.0.0
+      lodash: 4.17.21
+      react: 19.0.0-rc-fb9a90fa48-20240614
+      rxjs: 7.8.1
+      slate: 0.103.0
+      slate-react: 0.110.1(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)(slate@0.103.0)
+      styled-components: 6.1.13(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)
+      xstate: 5.18.2
+    transitivePeerDependencies:
+      - react-dom
+      - supports-color
+
+  '@portabletext/editor@1.1.4(@sanity/block-tools@3.61.0(debug@4.3.7))(@sanity/schema@3.61.0(debug@4.3.7))(@sanity/types@3.61.0)(@sanity/util@3.61.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@portabletext/patches': 1.1.0
       '@sanity/block-tools': 3.61.0(debug@4.3.7)
@@ -17112,7 +17017,7 @@ snapshots:
       react-copy-to-clipboard: 5.1.0(react@19.0.0-rc-fb9a90fa48-20240614)
       react-dom: 19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614)
 
-  '@sanity/insert-menu@1.0.9(@sanity/types@3.61.0(debug@4.3.7))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@sanity/insert-menu@1.0.9(@sanity/types@3.61.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@sanity/icons': 3.4.0(react@18.3.1)
       '@sanity/types': 3.61.0(debug@4.3.7)
@@ -17991,11 +17896,6 @@ snapshots:
 
   '@swc/helpers@0.5.13':
     dependencies:
-      tslib: 2.8.0
-
-  '@swc/helpers@0.5.5':
-    dependencies:
-      '@swc/counter': 0.1.3
       tslib: 2.8.0
 
   '@tailwindcss/typography@0.5.15(tailwindcss@3.4.14)':
@@ -19144,14 +19044,14 @@ snapshots:
 
   '@vue/devtools-api@6.6.4': {}
 
-  '@vue/devtools-core@7.4.4(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0))(vue@3.5.6(typescript@5.6.3))':
+  '@vue/devtools-core@7.4.4(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0))(vue@3.5.6(typescript@5.6.3))':
     dependencies:
       '@vue/devtools-kit': 7.4.4
       '@vue/devtools-shared': 7.4.4
       mitt: 3.0.1
       nanoid: 3.3.7
       pathe: 1.1.2
-      vite-hot-client: 0.2.3(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0))
+      vite-hot-client: 0.2.3(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0))
       vue: 3.5.6(typescript@5.6.3)
     transitivePeerDependencies:
       - vite
@@ -24705,31 +24605,6 @@ snapshots:
       sanity: 3.61.0(@types/node@20.16.5)(@types/react@18.3.11)(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)(styled-components@6.1.13(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614))(terser@5.33.0)
       styled-components: 6.1.13(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)
 
-  next@14.2.15(@babel/core@7.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@next/env': 14.2.15
-      '@swc/helpers': 0.5.5
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001667
-      graceful-fs: 4.2.11
-      postcss: 8.4.31
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.25.8)(react@18.3.1)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.15
-      '@next/swc-darwin-x64': 14.2.15
-      '@next/swc-linux-arm64-gnu': 14.2.15
-      '@next/swc-linux-arm64-musl': 14.2.15
-      '@next/swc-linux-x64-gnu': 14.2.15
-      '@next/swc-linux-x64-musl': 14.2.15
-      '@next/swc-win32-arm64-msvc': 14.2.15
-      '@next/swc-win32-ia32-msvc': 14.2.15
-      '@next/swc-win32-x64-msvc': 14.2.15
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
   next@15.0.0(@babel/core@7.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 15.0.0
@@ -24765,31 +24640,6 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 19.0.0-rc-fb9a90fa48-20240614(react@18.3.1)
-      styled-jsx: 5.1.6(@babel/core@7.25.8)(react@18.3.1)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 15.0.0
-      '@next/swc-darwin-x64': 15.0.0
-      '@next/swc-linux-arm64-gnu': 15.0.0
-      '@next/swc-linux-arm64-musl': 15.0.0
-      '@next/swc-linux-x64-gnu': 15.0.0
-      '@next/swc-linux-x64-musl': 15.0.0
-      '@next/swc-win32-arm64-msvc': 15.0.0
-      '@next/swc-win32-x64-msvc': 15.0.0
-      sharp: 0.33.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
-  next@15.0.0(@babel/core@7.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@next/env': 15.0.0
-      '@swc/counter': 0.1.3
-      '@swc/helpers': 0.5.13
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001667
-      postcss: 8.4.31
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.6(@babel/core@7.25.8)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.0.0
@@ -25095,10 +24945,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@22.5.5)(eslint@8.57.1)(ioredis@5.4.1)(magicast@0.3.5)(meow@9.0.0)(optionator@0.9.4)(rollup@4.24.0)(terser@5.33.0)(typescript@5.6.3)(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0))(webpack-sources@3.2.3):
+  nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@22.5.5)(eslint@8.57.1)(ioredis@5.4.1)(magicast@0.3.5)(meow@9.0.0)(optionator@0.9.4)(rollup@4.24.0)(terser@5.33.0)(typescript@5.6.3)(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0))(webpack-sources@3.2.3):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.6.0(rollup@4.24.0)(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0))(vue@3.5.6(typescript@5.6.3))(webpack-sources@3.2.3)
+      '@nuxt/devtools': 1.6.0(rollup@4.24.0)(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0))(vue@3.5.6(typescript@5.6.3))(webpack-sources@3.2.3)
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.24.0)(webpack-sources@3.2.3)
       '@nuxt/schema': 3.13.2(rollup@4.24.0)(webpack-sources@3.2.3)
       '@nuxt/telemetry': 2.6.0(magicast@0.3.5)(rollup@4.24.0)(webpack-sources@3.2.3)
@@ -27068,7 +26918,7 @@ snapshots:
       '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@dnd-kit/utilities': 3.2.2(react@18.3.1)
       '@juggle/resize-observer': 3.4.0
-      '@portabletext/editor': 1.1.4(@sanity/block-tools@3.61.0(debug@4.3.7))(@sanity/schema@3.61.0(debug@4.3.7))(@sanity/types@3.61.0(debug@4.3.7))(@sanity/util@3.61.0(debug@4.3.7))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@portabletext/editor': 1.1.4(@sanity/block-tools@3.61.0(debug@4.3.7))(@sanity/schema@3.61.0(debug@4.3.7))(@sanity/types@3.61.0)(@sanity/util@3.61.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@portabletext/react': 3.1.0(react@18.3.1)
       '@rexxars/react-json-inspector': 8.0.1(react@18.3.1)
       '@sanity/asset-utils': 2.0.6
@@ -27084,7 +26934,7 @@ snapshots:
       '@sanity/icons': 3.4.0(react@18.3.1)
       '@sanity/image-url': 1.0.2
       '@sanity/import': 3.37.5
-      '@sanity/insert-menu': 1.0.9(@sanity/types@3.61.0(debug@4.3.7))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@sanity/insert-menu': 1.0.9(@sanity/types@3.61.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/logos': 2.1.13(@sanity/color@3.0.6)(react@18.3.1)
       '@sanity/migrate': 3.61.0
       '@sanity/mutator': 3.61.0
@@ -27204,7 +27054,7 @@ snapshots:
       '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@dnd-kit/utilities': 3.2.2(react@18.3.1)
       '@juggle/resize-observer': 3.4.0
-      '@portabletext/editor': 1.1.4(@sanity/block-tools@3.61.0(debug@4.3.7))(@sanity/schema@3.61.0(debug@4.3.7))(@sanity/types@3.61.0(debug@4.3.7))(@sanity/util@3.61.0(debug@4.3.7))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@portabletext/editor': 1.1.4(@sanity/block-tools@3.61.0(debug@4.3.7))(@sanity/schema@3.61.0(debug@4.3.7))(@sanity/types@3.61.0)(@sanity/util@3.61.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rxjs@7.8.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@portabletext/react': 3.1.0(react@18.3.1)
       '@rexxars/react-json-inspector': 8.0.1(react@18.3.1)
       '@sanity/asset-utils': 2.0.6
@@ -27220,7 +27070,7 @@ snapshots:
       '@sanity/icons': 3.4.0(react@18.3.1)
       '@sanity/image-url': 1.0.2
       '@sanity/import': 3.37.5
-      '@sanity/insert-menu': 1.0.9(@sanity/types@3.61.0(debug@4.3.7))(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@sanity/insert-menu': 1.0.9(@sanity/types@3.61.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@sanity/logos': 2.1.13(@sanity/color@3.0.6)(react@18.3.1)
       '@sanity/migrate': 3.61.0
       '@sanity/mutator': 3.61.0
@@ -27476,7 +27326,7 @@ snapshots:
       '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.1.0(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)
       '@dnd-kit/utilities': 3.2.2(react@19.0.0-rc-fb9a90fa48-20240614)
       '@juggle/resize-observer': 3.4.0
-      '@portabletext/editor': 1.1.4(@sanity/block-tools@3.61.0(debug@4.3.7))(@sanity/schema@3.61.0(debug@4.3.7))(@sanity/types@3.61.0)(@sanity/util@3.61.0)(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)(rxjs@7.8.1)(styled-components@6.1.13(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614))
+      '@portabletext/editor': 1.1.4(@sanity/block-tools@3.61.0(debug@4.3.7))(@sanity/schema@3.61.0(debug@4.3.7))(@sanity/types@3.61.0(debug@4.3.7))(@sanity/util@3.61.0(debug@4.3.7))(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)(rxjs@7.8.1)(styled-components@6.1.13(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614))
       '@portabletext/react': 3.1.0(react@19.0.0-rc-fb9a90fa48-20240614)
       '@rexxars/react-json-inspector': 8.0.1(react@19.0.0-rc-fb9a90fa48-20240614)
       '@sanity/asset-utils': 2.0.6
@@ -28215,13 +28065,6 @@ snapshots:
       shallowequal: 1.1.0
       stylis: 4.3.2
       tslib: 2.6.2
-
-  styled-jsx@5.1.1(@babel/core@7.25.8)(react@18.3.1):
-    dependencies:
-      client-only: 0.0.1
-      react: 18.3.1
-    optionalDependencies:
-      '@babel/core': 7.25.8
 
   styled-jsx@5.1.6(@babel/core@7.25.8)(react@18.3.1):
     dependencies:
@@ -29220,9 +29063,9 @@ snapshots:
       '@types/unist': 3.0.2
       vfile-message: 4.0.2
 
-  vite-hot-client@0.2.3(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0)):
+  vite-hot-client@0.2.3(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0)):
     dependencies:
-      vite: 5.4.9(@types/node@22.5.5)(terser@5.33.0)
+      vite: 4.5.3(@types/node@22.5.5)(terser@5.33.0)
 
   vite-node@1.6.0(@types/node@22.5.5)(terser@5.33.0):
     dependencies:
@@ -29282,7 +29125,7 @@ snapshots:
       optionator: 0.9.4
       typescript: 5.6.3
 
-  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.24.0)(webpack-sources@3.2.3))(rollup@4.24.0)(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0)):
+  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.24.0)(webpack-sources@3.2.3))(rollup@4.24.0)(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.2(rollup@4.24.0)
@@ -29293,14 +29136,14 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.0
       sirv: 2.0.4
-      vite: 5.4.9(@types/node@22.5.5)(terser@5.33.0)
+      vite: 4.5.3(@types/node@22.5.5)(terser@5.33.0)
     optionalDependencies:
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.24.0)(webpack-sources@3.2.3)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-vue-inspector@5.1.3(vite@5.4.9(@types/node@22.5.5)(terser@5.33.0)):
+  vite-plugin-vue-inspector@5.1.3(vite@4.5.3(@types/node@22.5.5)(terser@5.33.0)):
     dependencies:
       '@babel/core': 7.25.8
       '@babel/plugin-proposal-decorators': 7.24.7(@babel/core@7.25.8)
@@ -29311,7 +29154,7 @@ snapshots:
       '@vue/compiler-dom': 3.5.6
       kolorist: 1.8.0
       magic-string: 0.30.12
-      vite: 5.4.9(@types/node@22.5.5)(terser@5.33.0)
+      vite: 4.5.3(@types/node@22.5.5)(terser@5.33.0)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
We've had some massive bundle bloat due to accidental inlining:
- https://bundlephobia.com/package/@sanity/preview-kit-compat@1.5.9 vs https://bundlephobia.com/package/@sanity/preview-kit-compat@1.5.7
- https://bundlephobia.com/package/@sanity/visual-editing@2.2.1 vs https://bundlephobia.com/package/@sanity/visual-editing@2.1.10