### PR TITLE
fix: remove unnecessary warning

### DIFF
--- a/packages/next-loader/src/client-components/live/SanityLive.tsx
+++ b/packages/next-loader/src/client-components/live/SanityLive.tsx
@@ -29,7 +29,6 @@ export interface SanityLiveProps
     | 'apiVersion'
     | 'useProjectHostname'
     | 'token'
-    | 'ignoreBrowserTokenWarning'
     | 'requestTagPrefix'
   > {
   // handleDraftModeAction: (secret: string) => Promise<void | string>
@@ -51,7 +50,6 @@ export function SanityLive(props: SanityLiveProps): React.JSX.Element | null {
     apiHost,
     apiVersion,
     useProjectHostname,
-    ignoreBrowserTokenWarning,
     token,
     requestTagPrefix,
     // handleDraftModeAction,
@@ -94,21 +92,12 @@ export function SanityLive(props: SanityLiveProps): React.JSX.Element | null {
         apiHost,
         apiVersion,
         useProjectHostname,
-        ignoreBrowserTokenWarning,
+        ignoreBrowserTokenWarning: true,
         token,
         useCdn: false,
         requestTagPrefix,
       }),
-    [
-      apiHost,
-      apiVersion,
-      dataset,
-      ignoreBrowserTokenWarning,
-      projectId,
-      requestTagPrefix,
-      token,
-      useProjectHostname,
-    ],
+    [apiHost, apiVersion, dataset, projectId, requestTagPrefix, token, useProjectHostname],
   )
 
   /**

--- a/packages/next-loader/src/defineLive.tsx
+++ b/packages/next-loader/src/defineLive.tsx
@@ -72,11 +72,6 @@ export interface DefinedSanityLiveProps {
   refreshOnReconnect?: boolean
 
   /**
-   * Once you've checked that the `browserToken` is only Viewer rights or lower, you can set this to `true` to silence browser warnings about the token.
-   * TODO: this warning should only be necessary when `serverToken` and `browserToken` are the same value
-   */
-  ignoreBrowserTokenWarning?: boolean
-  /**
    * Optional request tag for the listener. Use to identify the request in logs.
    *
    * @defaultValue `next-loader.live`
@@ -241,7 +236,6 @@ export function defineLive(config: DefineSanityLiveOptions): {
 
   const SanityLive: React.ComponentType<DefinedSanityLiveProps> = async function SanityLive(props) {
     const {
-      ignoreBrowserTokenWarning = serverToken !== browserToken,
       // handleDraftModeAction = handleDraftModeActionMissing
       refreshOnMount,
       refreshOnFocus,
@@ -274,7 +268,6 @@ export function defineLive(config: DefineSanityLiveOptions): {
         requestTagPrefix={requestTagPrefix}
         tag={tag}
         token={typeof browserToken === 'string' && isDraftModeEnabled ? browserToken : undefined}
-        ignoreBrowserTokenWarning={ignoreBrowserTokenWarning}
         draftModeEnabled={isDraftModeEnabled}
         // handleDraftModeAction={handleDraftModeAction}
         draftModePerspective={


### PR DESCRIPTION
The browser token warning in `@sanity/client` is confusing in userland:
```
You have configured Sanity client to use a token in the browser. This may cause unintentional security issues. See https://www.sanity.io/help/js-client-browser-token for more information and how to hide this warning.
```
As setting `browserToken` in `defineLive` does exactly what it implies, setting a token for the browser. The warning itself isn't actionable and thus it's removed here.