### PR TITLE
revert: `createCompatibilityActors` not needed (#2017)

### DIFF
--- a/packages/next-loader/src/client-components/live/PresentationComlink.tsx
+++ b/packages/next-loader/src/client-components/live/PresentationComlink.tsx
@@ -1,4 +1,8 @@
-import type {LoaderControllerMsg, LoaderNodeMsg} from '@repo/visual-editing-helpers'
+import {
+  createCompatibilityActors,
+  type LoaderControllerMsg,
+  type LoaderNodeMsg,
+} from '@repo/visual-editing-helpers'
 import type {ClientPerspective} from '@sanity/client'
 import {
   createNode,
@@ -50,7 +54,9 @@ function PresentationComlink(props: {
         name: 'loaders',
         connectTo: 'presentation',
       },
-      createNodeMachine<LoaderControllerMsg, LoaderNodeMsg>(),
+      createNodeMachine<LoaderControllerMsg, LoaderNodeMsg>().provide({
+        actors: createCompatibilityActors<LoaderNodeMsg>(),
+      }),
     )
 
     // comlink.onStatus((status) => {


### PR DESCRIPTION
This reverts commit 0bdfcc44551ce407e979fe46f82b303214449b56.