### PR TITLE
chore(drag-and-drop): minimap stability, drag enablement

### DIFF
--- a/apps/page-builder-demo/src/app/dnd/page.tsx
+++ b/apps/page-builder-demo/src/app/dnd/page.tsx
@@ -87,7 +87,7 @@ export default async function Page() {
                       path: `children[_key=="${child._key}"].children[_key=="${child1._key}"]`,
                     }).toString()}
                     className="mt-4 border border-solid border-white p-3"
-                    key={child._key}
+                    key={child1._key}
                   >
                     {stegaClean(child1.title)}
                     <div className="flew-row flex gap-3">
@@ -100,7 +100,7 @@ export default async function Page() {
                               path: `children[_key=="${child._key}"].children[_key=="${child1._key}"].children[_key=="${child2._key}"]`,
                             }).toString()}
                             className="mt-4 border border-solid border-white p-3"
-                            key={child._key}
+                            key={child2._key}
                           >
                             {stegaClean(child2.title)}
                           </div>

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -437,6 +437,7 @@ export const Overlays: FunctionComponent<{
                     ({id, element, focused, hovered, rect, sanity, dragDisabled}) => {
                       const draggable =
                         !dragDisabled &&
+                        !!element.getAttribute('data-sanity') &&
                         elements.some((e) =>
                           'id' in e.sanity && 'id' in sanity
                             ? sanityNodesExistInSameArray(e.sanity, sanity) &&

--- a/packages/visual-editing/src/util/findSanityNodes.ts
+++ b/packages/visual-editing/src/util/findSanityNodes.ts
@@ -214,6 +214,8 @@ export function resolveDragAndDropGroup(
   elementSet: Set<ElementNode>,
   elementsMap: WeakMap<ElementNode, OverlayElement>,
 ): null | OverlayElement[] {
+  if (!element.getAttribute('data-sanity')) return null
+
   if (element.getAttribute('data-sanity-drag-disable')) return null
 
   if (!sanity || !isSanityNode(sanity) || !isSanityArrayPath(sanity.path)) return null
@@ -224,6 +226,7 @@ export function resolveDragAndDropGroup(
     const elData = elementsMap.get(el)
     const elDragDisabled = el.getAttribute('data-sanity-drag-disable')
     const elDragGroup = el.getAttribute('data-sanity-drag-group')
+    const elHasSanityAttribution = el.getAttribute('data-sanity') !== null
 
     const sharedDragGroup = targetDragGroup !== null ? targetDragGroup === elDragGroup : true
 
@@ -232,7 +235,8 @@ export function resolveDragAndDropGroup(
       !elDragDisabled &&
       isSanityNode(elData.sanity) &&
       sanityNodesExistInSameArray(sanity, elData.sanity) &&
-      sharedDragGroup
+      sharedDragGroup &&
+      elHasSanityAttribution
     ) {
       acc.push(elData)
     }


### PR DESCRIPTION
- Fixes a bug where certain `overflow` and `height` values on the document root allow scrolling while the minimap is open 
- Only enables drag and drop where `data-sanity` attribution is explicitly applied. Right now we have some issues mutating primitive arrays, and it feels generally safer (and in line with the docs) to require this.