### PR TITLE
fix: resolve issues with newly added canary features

### DIFF
--- a/packages/presentation/src/PostMessagePerspective.tsx
+++ b/packages/presentation/src/PostMessagePerspective.tsx
@@ -1,0 +1,31 @@
+import type {ClientPerspective} from '@sanity/client'
+import {memo, useEffect, type FC} from 'react'
+import type {VisualEditingConnection} from './types'
+
+export interface PostMessagePerspectiveProps {
+  comlink: VisualEditingConnection
+  perspective: ClientPerspective
+}
+
+const PostMessagePerspective: FC<PostMessagePerspectiveProps> = (props) => {
+  const {comlink, perspective} = props
+
+  // Return the perspective when requested
+  useEffect(() => {
+    return comlink.on('visual-editing/fetch-perspective', () => ({
+      perspective,
+    }))
+  }, [comlink, perspective])
+
+  // Dispatch a perspective message when the perspective changes
+  useEffect(() => {
+    comlink.post({
+      type: 'presentation/perspective',
+      data: {perspective},
+    })
+  }, [comlink, perspective])
+
+  return null
+}
+
+export default memo(PostMessagePerspective)

--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -204,7 +204,7 @@ export default function PresentationTool(props: {
   useEffect(() => {
     const target = iframeRef.current?.contentWindow
 
-    if (!target) return
+    if (!target || state.iframe.status === 'loading') return
 
     const controller = createController({targetOrigin})
     controller.addTarget(target)
@@ -214,7 +214,7 @@ export default function PresentationTool(props: {
       controller.destroy()
       setController(undefined)
     }
-  }, [targetOrigin])
+  }, [targetOrigin, state.iframe.status])
 
   useEffect(() => {
     const unsubs: Array<() => void> = []

--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -71,6 +71,7 @@ import {useStatus} from './useStatus'
 const LoaderQueries = lazy(() => import('./loader/LoaderQueries'))
 const LiveQueries = lazy(() => import('./loader/LiveQueries'))
 const PostMessageDocuments = lazy(() => import('./overlays/PostMessageDocuments'))
+const PostMessageFeatures = lazy(() => import('./features/PostMessageFeatures'))
 const PostMessageRefreshMutations = lazy(() => import('./editor/PostMessageRefreshMutations'))
 const PostMessagePerspective = lazy(() => import('./PostMessagePerspective'))
 const PostMessagePreviewSnapshots = lazy(() => import('./editor/PostMessagePreviewSnapshots'))
@@ -623,6 +624,11 @@ export default function PresentationTool(props: {
       {visualEditingComlink && (
         <Suspense>
           <PostMessageDocuments comlink={visualEditingComlink} />
+        </Suspense>
+      )}
+      {visualEditingComlink && (
+        <Suspense>
+          <PostMessageFeatures comlink={visualEditingComlink} />
         </Suspense>
       )}
       {visualEditingComlink && (

--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -72,6 +72,7 @@ const LoaderQueries = lazy(() => import('./loader/LoaderQueries'))
 const LiveQueries = lazy(() => import('./loader/LiveQueries'))
 const PostMessageDocuments = lazy(() => import('./overlays/PostMessageDocuments'))
 const PostMessageRefreshMutations = lazy(() => import('./editor/PostMessageRefreshMutations'))
+const PostMessagePerspective = lazy(() => import('./PostMessagePerspective'))
 const PostMessagePreviewSnapshots = lazy(() => import('./editor/PostMessagePreviewSnapshots'))
 const PostMessageSchema = lazy(() => import('./overlays/schema/PostMessageSchema'))
 
@@ -358,14 +359,6 @@ export default function PresentationTool(props: {
     [navigate],
   )
 
-  // Dispatch a perspective message when the perspective changes
-  useEffect(() => {
-    visualEditingComlink?.post({
-      type: 'presentation/perspective',
-      data: {perspective},
-    })
-  }, [perspective, visualEditingComlink])
-
   // Dispatch a focus or blur message when the id or path change
   useEffect(() => {
     if (params.id && params.path) {
@@ -630,6 +623,11 @@ export default function PresentationTool(props: {
       {visualEditingComlink && (
         <Suspense>
           <PostMessageDocuments comlink={visualEditingComlink} />
+        </Suspense>
+      )}
+      {visualEditingComlink && (
+        <Suspense>
+          <PostMessagePerspective comlink={visualEditingComlink} perspective={perspective} />
         </Suspense>
       )}
       {params.id && params.type && (

--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -190,16 +190,13 @@ export default function PresentationTool(props: {
   // const [previewKitConnection, setPreviewKitConnection] = useState<Status>('connecting')
   const [previewKitConnection, setPreviewKitConnection] = useStatus()
 
-  const [popups] = useState<Set<Window>>(() => new Set())
-  const handleOpenPopup = useCallback(
-    (url: string) => {
-      const source = window.open(url, '_blank')
-      if (source) {
-        popups.add(source)
-      }
-    },
-    [popups],
-  )
+  const [popups, setPopups] = useState<Set<Window>>(() => new Set())
+  const handleOpenPopup = useCallback((url: string) => {
+    const source = window.open(url, '_blank')
+    if (source) {
+      setPopups((prev) => new Set(prev).add(source))
+    }
+  }, [])
 
   useEffect(() => {
     const target = iframeRef.current?.contentWindow
@@ -229,7 +226,7 @@ export default function PresentationTool(props: {
     return () => {
       unsubs.forEach((unsub) => unsub())
     }
-  }, [controller, popups, popups.size])
+  }, [controller, popups])
 
   useEffect(() => {
     if (!controller) return

--- a/packages/presentation/src/features/PostMessageFeatures.tsx
+++ b/packages/presentation/src/features/PostMessageFeatures.tsx
@@ -1,0 +1,22 @@
+import {memo, useEffect, type FC} from 'react'
+import type {VisualEditingConnection} from '../types'
+
+export interface PostMessagePreviewsProps {
+  comlink: VisualEditingConnection
+}
+
+const PostMessageFeatures: FC<PostMessagePreviewsProps> = (props) => {
+  const {comlink} = props
+
+  useEffect(() => {
+    return comlink.on('visual-editing/features', () => ({
+      features: {
+        optimistic: true,
+      },
+    }))
+  }, [comlink])
+
+  return null
+}
+
+export default memo(PostMessageFeatures)

--- a/packages/presentation/src/overlays/schema/PostMessageSchema.tsx
+++ b/packages/presentation/src/overlays/schema/PostMessageSchema.tsx
@@ -1,7 +1,7 @@
 import type {UnresolvedPath} from '@repo/visual-editing-helpers'
 import type {ClientPerspective} from '@sanity/client'
 import {useRootTheme} from '@sanity/ui'
-import {memo, useEffect, useMemo} from 'react'
+import {memo, useEffect} from 'react'
 import {API_VERSION} from '../../constants'
 import {useClient, useWorkspace} from '../../internals'
 import type {VisualEditingConnection} from '../../types'
@@ -37,12 +37,18 @@ function PostMessageSchema(props: PostMessageSchemaProps): JSX.Element | null {
 
   const workspace = useWorkspace()
   const theme = useRootTheme()
-  const schema = useMemo(() => extractSchema(workspace, theme), [workspace, theme])
 
   // Send a representation of the schema to the visual editing context
   useEffect(() => {
+    const schema = extractSchema(workspace, theme)
+    /**
+     * @deprecated switch to explict schema fetching (using
+     * 'visual-editing/schema') at next major
+     */
     comlink.post({type: 'presentation/schema', data: {schema}})
-  }, [comlink, schema])
+
+    return comlink.on('visual-editing/schema', () => ({schema}))
+  }, [comlink, theme, workspace])
 
   const client = useClient({apiVersion: API_VERSION})
 

--- a/packages/visual-editing-helpers/src/types/comlink.ts
+++ b/packages/visual-editing-helpers/src/types/comlink.ts
@@ -228,8 +228,11 @@ export type VisualEditingNodeMsg =
       response: any
     }
   | {
-      type: 'visual-editing/listen'
+      type: 'visual-editing/snapshot-welcome'
       data: undefined
+      response: {
+        event: WelcomeEvent
+      }
     }
   | {
       type: 'visual-editing/fetch-perspective'

--- a/packages/visual-editing-helpers/src/types/comlink.ts
+++ b/packages/visual-editing-helpers/src/types/comlink.ts
@@ -232,8 +232,11 @@ export type VisualEditingNodeMsg =
       data: undefined
     }
   | {
-      type: 'visual-editing/unlisten'
+      type: 'visual-editing/fetch-perspective'
       data: undefined
+      response: {
+        perspective: ClientPerspective
+      }
     }
 
 /**

--- a/packages/visual-editing-helpers/src/types/comlink.ts
+++ b/packages/visual-editing-helpers/src/types/comlink.ts
@@ -107,6 +107,10 @@ export type VisualEditingControllerMsg =
         perspective: ClientPerspective
       }
     }
+  /**
+   * @deprecated switch to explict schema fetching (using
+   * 'visual-editing/schema') at next major
+   */
   | {
       type: 'presentation/schema'
       data: {
@@ -180,6 +184,13 @@ export type VisualEditingNodeMsg =
   | {
       type: 'visual-editing/refreshed'
       data: HistoryRefresh
+    }
+  | {
+      type: 'visual-editing/schema'
+      data: undefined
+      response: {
+        schema: SchemaType[]
+      }
     }
   | {
       type: 'visual-editing/schema-union-types'

--- a/packages/visual-editing-helpers/src/types/comlink.ts
+++ b/packages/visual-editing-helpers/src/types/comlink.ts
@@ -238,6 +238,13 @@ export type VisualEditingNodeMsg =
         perspective: ClientPerspective
       }
     }
+  | {
+      type: 'visual-editing/features'
+      data: undefined
+      response: {
+        features: Record<string, boolean>
+      }
+    }
 
 /**
  * @public

--- a/packages/visual-editing/src/controller.ts
+++ b/packages/visual-editing/src/controller.ts
@@ -28,6 +28,7 @@ export function createOverlayController({
   handler,
   overlayElement,
   inFrame,
+  optimisticActorReady,
 }: OverlayOptions): OverlayController {
   let activated = false
   // Map for getting element by ID
@@ -127,7 +128,7 @@ export function createOverlayController({
   }
 
   function setOverlayCursor() {
-    if (!inFrame) return
+    if (!inFrame || !optimisticActorReady) return
 
     const hoveredElement = getHoveredElement()
 
@@ -180,7 +181,7 @@ export function createOverlayController({
         }
       },
       contextmenu(event) {
-        if (!('path' in sanity)) return
+        if (!('path' in sanity) || !inFrame || !optimisticActorReady) return
 
         // This is a temporary check as the context menu only supports array
         // items (for now). We split the path into segments, if a `_key` exists
@@ -214,7 +215,7 @@ export function createOverlayController({
         if (element.getAttribute('data-sanity-drag-disable')) return
 
         // disable dnd in non-studio contexts
-        if (!inFrame) return
+        if (!inFrame || !optimisticActorReady) return
 
         const targetSanityData = elementsMap.get(element)?.sanity
 

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -264,6 +264,7 @@ export interface OverlayOptions {
   handler: OverlayEventHandler
   overlayElement: HTMLElement
   inFrame: boolean
+  optimisticActorReady: boolean
 }
 
 /**

--- a/packages/visual-editing/src/ui/History.tsx
+++ b/packages/visual-editing/src/ui/History.tsx
@@ -1,0 +1,30 @@
+import {useEffect, type FunctionComponent} from 'react'
+import type {HistoryAdapter, VisualEditingNode} from '../types'
+
+/**
+ * @internal
+ */
+export const History: FunctionComponent<{
+  comlink: VisualEditingNode
+  history?: HistoryAdapter
+}> = (props) => {
+  const {comlink, history} = props
+
+  useEffect(() => {
+    return comlink?.on('presentation/navigate', (data) => {
+      history?.update(data)
+    })
+  }, [comlink, history])
+
+  useEffect(() => {
+    if (history) {
+      return history.subscribe((update) => {
+        update.title = update.title || document.title
+        comlink?.post({type: 'visual-editing/navigate', data: update})
+      })
+    }
+    return
+  }, [comlink, history])
+
+  return null
+}

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -162,11 +162,10 @@ const OverlaysController: FunctionComponent<{
 export const Overlays: FunctionComponent<{
   comlink?: VisualEditingNode
   componentResolver?: OverlayComponentResolver
-  history?: HistoryAdapter
   inFrame: boolean
   zIndex?: string | number
 }> = (props) => {
-  const {comlink, componentResolver, inFrame, history, zIndex} = props
+  const {comlink, componentResolver, inFrame, zIndex} = props
 
   const [status, setStatus] = useState<Status>()
 
@@ -215,9 +214,6 @@ export const Overlays: FunctionComponent<{
       comlink?.on('presentation/perspective', (data) => {
         dispatch({type: 'presentation/perspective', data})
       }),
-      comlink?.on('presentation/navigate', (data) => {
-        history?.update(data)
-      }),
       comlink?.on('presentation/toggle-overlay', () => {
         setOverlayEnabled((enabled) => !enabled)
       }),
@@ -227,7 +223,7 @@ export const Overlays: FunctionComponent<{
     ].filter(Boolean)
 
     return () => unsubs.forEach((unsub) => unsub!())
-  }, [comlink, history])
+  }, [comlink])
 
   useReportDocuments(comlink, elements, perspective)
 
@@ -289,16 +285,6 @@ export const Overlays: FunctionComponent<{
       window.removeEventListener('keyup', handleKeyUp)
     }
   }, [setOverlayEnabled])
-
-  useEffect(() => {
-    if (history) {
-      return history.subscribe((update) => {
-        update.title = update.title || document.title
-        comlink?.post({type: 'visual-editing/navigate', data: update})
-      })
-    }
-    return
-  }, [comlink, history])
 
   const [overlaysFlash, setOverlaysFlash] = useState(false)
   const [fadingOut, setFadingOut] = useState(false)

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -32,7 +32,7 @@ import {sanityNodesExistInSameArray} from '../util/findSanityNodes.ts'
 import {useDragEndEvents} from '../util/useDragEvents'
 import {ContextMenu} from './context-menu/ContextMenu'
 import {ElementOverlay} from './ElementOverlay'
-import {useOptimisticActor} from './optimistic-state/useOptimisticActor'
+import {useOptimisticActor, useOptimisticActorReady} from './optimistic-state/useOptimisticActor'
 import {OverlayDragGroupRect} from './OverlayDragGroupRect'
 import {OverlayDragInsertMarker} from './OverlayDragInsertMarker'
 import {OverlayDragPreview} from './OverlayDragPreview'
@@ -166,7 +166,7 @@ export const Overlays: FunctionComponent<{
   inFrame: boolean
   zIndex?: string | number
 }> = (props) => {
-  const {comlink, componentResolver, inFrame, zIndex} = props
+  const {comlink, componentResolver: _componentResolver, inFrame, zIndex} = props
 
   const [status, setStatus] = useState<Status>()
 
@@ -327,6 +327,12 @@ export const Overlays: FunctionComponent<{
     dispatch({type: 'overlay/blur'})
   }, [])
 
+  const optimisticActorReady = useOptimisticActorReady()
+
+  const componentResolver = useMemo(() => {
+    return optimisticActorReady ? _componentResolver : undefined
+  }, [_componentResolver, optimisticActorReady])
+
   return (
     <ThemeProvider scheme={prefersDark ? 'dark' : 'light'} theme={studioTheme} tone="transparent">
       <LayerProvider>
@@ -356,6 +362,7 @@ export const Overlays: FunctionComponent<{
                       const draggable =
                         !dragDisabled &&
                         !!element.getAttribute('data-sanity') &&
+                        optimisticActorReady &&
                         elements.some((e) =>
                           'id' in e.sanity && 'id' in sanity
                             ? sanityNodesExistInSameArray(e.sanity, sanity) &&

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -21,13 +21,12 @@ import {
 } from 'react'
 import {styled} from 'styled-components'
 import type {
-  HistoryAdapter,
   OverlayComponentResolver,
   OverlayEventHandler,
   OverlayMsg,
   VisualEditingNode,
 } from '../types'
-import {getDraftId, getPublishedId} from '../util/documents.ts'
+import {getDraftId, getPublishedId} from '../util/documents'
 import {sanityNodesExistInSameArray} from '../util/findSanityNodes.ts'
 import {useDragEndEvents} from '../util/useDragEvents'
 import {ContextMenu} from './context-menu/ContextMenu'
@@ -144,7 +143,7 @@ const OverlaysController: FunctionComponent<{
     [comlink, dispatch, dispatchDragEndEvent, onDrag],
   )
 
-  const controller = useController(rootElement, overlayEventHandler, !!inFrame)
+  const controller = useController(rootElement, overlayEventHandler, inFrame)
 
   useEffect(() => {
     if (overlayEnabled) {
@@ -339,7 +338,6 @@ export const Overlays: FunctionComponent<{
         <PortalProvider element={rootElement}>
           <SchemaProvider comlink={comlink} elements={elements}>
             <PreviewSnapshotsProvider comlink={comlink}>
-              {/* <OptimisticStateProvider comlink={comlink} documentIds={documentIds}> */}
               <Root
                 data-fading-out={fadingOut ? '' : undefined}
                 data-overlays={overlaysFlash ? '' : undefined}

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -41,6 +41,7 @@ import {overlayStateReducer} from './overlayStateReducer'
 import {PreviewSnapshotsProvider} from './preview/PreviewSnapshotsProvider'
 import {SchemaProvider} from './schema/SchemaProvider'
 import {useController} from './useController'
+import {usePerspectiveSync} from './usePerspectiveSync'
 import {useReportDocuments} from './useReportDocuments'
 
 const Root = styled.div<{
@@ -211,9 +212,6 @@ export const Overlays: FunctionComponent<{
       comlink?.on('presentation/blur', (data) => {
         dispatch({type: 'presentation/blur', data})
       }),
-      comlink?.on('presentation/perspective', (data) => {
-        dispatch({type: 'presentation/perspective', data})
-      }),
       comlink?.on('presentation/toggle-overlay', () => {
         setOverlayEnabled((enabled) => !enabled)
       }),
@@ -224,6 +222,8 @@ export const Overlays: FunctionComponent<{
 
     return () => unsubs.forEach((unsub) => unsub!())
   }, [comlink])
+
+  usePerspectiveSync(comlink, dispatch)
 
   useReportDocuments(comlink, elements, perspective)
 

--- a/packages/visual-editing/src/ui/VisualEditing.tsx
+++ b/packages/visual-editing/src/ui/VisualEditing.tsx
@@ -8,6 +8,7 @@ import {useEffect, useState, type FunctionComponent} from 'react'
 import {createActor} from 'xstate'
 import type {VisualEditingNode, VisualEditingOptions} from '../types'
 import {createDatasetMutator} from './comlink'
+import {History} from './History'
 import {Meta} from './Meta'
 import {setActor} from './optimistic-state/context'
 import {createSharedListener} from './optimistic-state/machines/createSharedListener'
@@ -54,9 +55,9 @@ export const VisualEditing: FunctionComponent<VisualEditingOptions> = (props) =>
         componentResolver={components}
         comlink={comlink}
         inFrame={inFrame}
-        history={history}
         zIndex={zIndex}
       />
+      {comlink && <History comlink={comlink} history={history} />}
       {comlink && <Meta comlink={comlink} />}
       {comlink && refresh && <Refresh comlink={comlink} refresh={refresh} />}
     </>

--- a/packages/visual-editing/src/ui/VisualEditing.tsx
+++ b/packages/visual-editing/src/ui/VisualEditing.tsx
@@ -43,10 +43,25 @@ export const VisualEditing: FunctionComponent<VisualEditingOptions> = (props) =>
       // @ts-expect-error @todo
       input: {client: {withConfig: () => {}}, sharedListener: listener},
     })
-    setActor(actor)
+
+    // Fetch features to determine if optimistic updates are supported
+    const abortController = new AbortController()
+    comlink
+      .fetch({type: 'visual-editing/features', data: undefined}, {signal: abortController.signal})
+      .then((data) => {
+        if (data.features['optimistic']) {
+          setActor(actor)
+        }
+      })
 
     actor.start()
     comlink.start()
+
+    return () => {
+      abortController.abort()
+      actor.stop()
+      comlink.stop()
+    }
   }, [inFrame])
 
   return (

--- a/packages/visual-editing/src/ui/VisualEditing.tsx
+++ b/packages/visual-editing/src/ui/VisualEditing.tsx
@@ -67,14 +67,18 @@ export const VisualEditing: FunctionComponent<VisualEditingOptions> = (props) =>
   return (
     <>
       <Overlays
-        componentResolver={components}
         comlink={comlink}
+        componentResolver={components}
         inFrame={inFrame}
         zIndex={zIndex}
       />
-      {comlink && <History comlink={comlink} history={history} />}
-      {comlink && <Meta comlink={comlink} />}
-      {comlink && refresh && <Refresh comlink={comlink} refresh={refresh} />}
+      {comlink && (
+        <>
+          <History comlink={comlink} history={history} />
+          <Meta comlink={comlink} />
+          {refresh && <Refresh comlink={comlink} refresh={refresh} />}
+        </>
+      )}
     </>
   )
 }

--- a/packages/visual-editing/src/ui/optimistic-state/machines/createSharedListener.ts
+++ b/packages/visual-editing/src/ui/optimistic-state/machines/createSharedListener.ts
@@ -4,7 +4,15 @@ import {
   type ReconnectEvent,
   type WelcomeEvent,
 } from '@sanity/client'
-import {filter, merge, Observable, shareReplay, Subject, type ObservedValueOf} from 'rxjs'
+import {
+  filter,
+  merge,
+  Observable,
+  ReplaySubject,
+  shareReplay,
+  Subject,
+  type ObservedValueOf,
+} from 'rxjs'
 import type {VisualEditingNode} from '../../../types'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -14,40 +22,29 @@ type SharedListenEvent = ListenEvent<Record<string, any>>
  * Creates a single, shared, listener EventSource that strems remote mutations, and notifies when it's online (welcome), offline (reconnect).
  */
 export function createSharedListener(comlink: VisualEditingNode): Observable<SharedListenEvent> {
-  const incomingEvents$ = new Subject<SharedListenEvent>()
+  // Welcome events could be received before the listener has been subscribed
+  // to. Using a ReplaySubject will ensure the welcome event is re-emitted when
+  // a new subscriber arrives.
+  const incomingConnection$ = new ReplaySubject<SharedListenEvent>(1)
+  const incomingMutations$ = new Subject<SharedListenEvent>()
 
-  comlink.on('presentation/snapshot-event', (data) => {
-    incomingEvents$.next(data.event)
+  comlink.fetch({type: 'visual-editing/snapshot-welcome', data: undefined}).then((data) => {
+    incomingConnection$.next(data.event)
   })
 
-  // Reconnect events emitted in case the connection is lost
-  const reconnect = incomingEvents$.pipe(
-    filter((event): event is ReconnectEvent => event.type === 'reconnect'),
-  )
+  comlink.on('presentation/snapshot-event', (data) => {
+    // Welcome events are still emitted by Presentation for backwards
+    // compatibility. We don't need them anymore as we explicitly fetch the
+    // welcome event, so filter them out here.
+    if (data.event.type === 'reconnect') {
+      incomingConnection$.next(data.event)
+    }
+    if (data.event.type === 'mutation') {
+      incomingMutations$.next(data.event)
+    }
+  })
 
-  // Welcome events are emitted when the listener is (re)connected
-  const welcome = incomingEvents$.pipe(
-    filter((event): event is WelcomeEvent => event.type === 'welcome'),
-  )
-
-  // Mutation events coming from the listener
-  const mutations = incomingEvents$.pipe(
-    filter((event): event is MutationEvent => event.type === 'mutation'),
-  )
-
-  // Replay the latest connection event that was emitted either when the connection was disconnected ('reconnect'), established or re-established ('welcome')
-  const connectionEvent = merge(welcome, reconnect).pipe(
-    shareReplay({bufferSize: 1, refCount: false}),
-  )
-
-  // Emit the welcome event if the latest connection event was the 'welcome' event.
-  // Downstream subscribers will typically map the welcome event to an initial fetch
-  const replayWelcome = connectionEvent.pipe(
-    filter((latestConnectionEvent) => latestConnectionEvent.type === 'welcome'),
-  )
-
-  // Combine into a single stream
-  return merge(replayWelcome, mutations, reconnect)
+  return merge(incomingConnection$, incomingMutations$)
 }
 
 export type SharedListenerEvents = ObservedValueOf<ReturnType<typeof createSharedListener>>

--- a/packages/visual-editing/src/ui/optimistic-state/machines/createSharedListener.ts
+++ b/packages/visual-editing/src/ui/optimistic-state/machines/createSharedListener.ts
@@ -1,18 +1,5 @@
-import {
-  type ListenEvent,
-  type MutationEvent,
-  type ReconnectEvent,
-  type WelcomeEvent,
-} from '@sanity/client'
-import {
-  filter,
-  merge,
-  Observable,
-  ReplaySubject,
-  shareReplay,
-  Subject,
-  type ObservedValueOf,
-} from 'rxjs'
+import {type ListenEvent} from '@sanity/client'
+import {merge, Observable, ReplaySubject, Subject, type ObservedValueOf} from 'rxjs'
 import type {VisualEditingNode} from '../../../types'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/visual-editing/src/ui/optimistic-state/useOptimisticActor.ts
+++ b/packages/visual-editing/src/ui/optimistic-state/useOptimisticActor.ts
@@ -1,5 +1,12 @@
-import {useCallback, useSyncExternalStore} from 'react'
-import {actor, emptyActor, listeners, type EmptyActor, type MutatorActor} from './context'
+import {useCallback, useMemo, useSyncExternalStore} from 'react'
+import {
+  actor,
+  emptyActor,
+  isEmptyActor,
+  listeners,
+  type EmptyActor,
+  type MutatorActor,
+} from './context'
 
 export function useOptimisticActor(): MutatorActor | EmptyActor {
   const subscribe = useCallback((listener: () => void) => {
@@ -14,4 +21,9 @@ export function useOptimisticActor(): MutatorActor | EmptyActor {
   )
 
   return actorRef
+}
+
+export function useOptimisticActorReady(): boolean {
+  const actor = useOptimisticActor()
+  return useMemo(() => !isEmptyActor(actor), [actor])
 }

--- a/packages/visual-editing/src/ui/schema/SchemaProvider.tsx
+++ b/packages/visual-editing/src/ui/schema/SchemaProvider.tsx
@@ -199,6 +199,9 @@ export const SchemaProvider: FunctionComponent<
 
         if ('fields' in schemaType) {
           const objectField = schemaType.fields[next]
+          if (!objectField && 'rest' in schemaType) {
+            return fieldFromPath(schemaType.rest, path, schemaType)
+          }
           if (!rest.length) {
             return {field: objectField, parent}
           }
@@ -226,7 +229,9 @@ export const SchemaProvider: FunctionComponent<
           const type = getType(schemaType.name, 'type')
           return fieldFromPath((type as TypeSchema).value, path, schemaType)
         }
-        throw new Error(`No field could be resolved at path: "${path.join('.')}"`)
+        // eslint-disable-next-line no-console
+        console.warn(`No field could be resolved at path: "${path.join('.')}"`)
+        return {field: undefined, parent: undefined}
       }
 
       const nodePath = node.path.split('.').flatMap((part) => {

--- a/packages/visual-editing/src/ui/useController.tsx
+++ b/packages/visual-editing/src/ui/useController.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useRef, type MutableRefObject} from 'react'
 import {createOverlayController} from '../controller'
 import type {OverlayController, OverlayEventHandler} from '../types'
+import {useOptimisticActorReady} from './optimistic-state/useOptimisticActor'
 
 /**
  * Hook for using an overlay controller
@@ -13,6 +14,8 @@ export function useController(
 ): MutableRefObject<OverlayController | undefined> {
   const overlayController = useRef<OverlayController | undefined>()
 
+  const optimisticActorReady = useOptimisticActorReady()
+
   useEffect(() => {
     if (!element) return undefined
 
@@ -20,13 +23,14 @@ export function useController(
       handler,
       overlayElement: element,
       inFrame,
+      optimisticActorReady,
     })
 
     return () => {
       overlayController.current?.destroy()
       overlayController.current = undefined
     }
-  }, [element, handler, inFrame])
+  }, [element, handler, inFrame, optimisticActorReady])
 
   return overlayController
 }

--- a/packages/visual-editing/src/ui/usePerspectiveSync.tsx
+++ b/packages/visual-editing/src/ui/usePerspectiveSync.tsx
@@ -1,0 +1,18 @@
+import type {VisualEditingControllerMsg} from '@repo/visual-editing-helpers'
+import {useEffect} from 'react'
+import type {OverlayMsg, VisualEditingNode} from '../types'
+
+export function usePerspectiveSync(
+  comlink: VisualEditingNode | undefined,
+  dispatch: (value: OverlayMsg | VisualEditingControllerMsg) => void,
+): void {
+  useEffect(() => {
+    comlink?.fetch({type: 'visual-editing/fetch-perspective', data: undefined}).then((data) => {
+      dispatch({type: 'presentation/perspective', data})
+    })
+
+    return comlink?.on('presentation/perspective', (data) => {
+      dispatch({type: 'presentation/perspective', data})
+    })
+  }, [comlink, dispatch])
+}

--- a/packages/visual-editing/src/ui/useReportDocuments.ts
+++ b/packages/visual-editing/src/ui/useReportDocuments.ts
@@ -1,0 +1,79 @@
+import {DRAFTS_PREFIX} from '@repo/visual-editing-helpers/csm'
+import type {ClientPerspective, ContentSourceMapDocuments} from '@sanity/client'
+import {useCallback, useEffect, useRef} from 'react'
+import type {ElementState, SanityNode, VisualEditingNode} from '../types'
+
+function isEqualSets(a: Set<string>, b: Set<string>) {
+  if (a === b) return true
+  if (a.size !== b.size) return false
+  for (const value of a) if (!b.has(value)) return false
+  return true
+}
+
+/**
+ * Hook for reporting in use documents to Presentation
+ * @internal
+ */
+export function useReportDocuments(
+  comlink: VisualEditingNode | undefined,
+  elements: ElementState[],
+  perspective: ClientPerspective,
+): void {
+  const lastReported = useRef<
+    | {
+        nodeIds: Set<string>
+        perspective: ClientPerspective
+      }
+    | undefined
+  >(undefined)
+
+  const reportDocuments = useCallback(
+    (documents: ContentSourceMapDocuments, perspective: ClientPerspective) => {
+      comlink?.post({
+        type: 'visual-editing/documents',
+        data: {
+          documents,
+          perspective,
+        },
+      })
+    },
+    [comlink],
+  )
+
+  useEffect(() => {
+    // Report only nodes of type `SanityNode`. Untransformed `SanityStegaNode`
+    // nodes without an `id`, are not reported as they will not contain the
+    // necessary document data.
+    const nodes = elements
+      .map((e) => {
+        const {sanity} = e
+        if (!('id' in sanity)) return null
+        return {
+          ...sanity,
+          id: 'isDraft' in sanity ? `${DRAFTS_PREFIX}${sanity.id}` : sanity.id,
+        }
+      })
+      .filter((s) => !!s) as SanityNode[]
+
+    const nodeIds = new Set<string>(nodes.map((e) => e.id))
+    // Report if:
+    // - Documents not yet reported
+    // - Document IDs changed
+    // - Perspective changed
+    if (
+      !lastReported.current ||
+      !isEqualSets(nodeIds, lastReported.current.nodeIds) ||
+      perspective !== lastReported.current.perspective
+    ) {
+      const documentsOnPage: ContentSourceMapDocuments = Array.from(nodeIds).map((_id) => {
+        const node = nodes.find((node) => node.id === _id)!
+        const {type, projectId: _projectId, dataset: _dataset} = node
+        return _projectId && _dataset
+          ? {_id, _type: type!, _projectId, _dataset}
+          : {_id, _type: type!}
+      })
+      lastReported.current = {nodeIds, perspective}
+      reportDocuments(documentsOnPage, perspective)
+    }
+  }, [elements, perspective, reportDocuments])
+}


### PR DESCRIPTION
This PR contains quite a few fixes related to features recently merged into `main` from `canary`. LMK if you'd like these to be split into separate PRs! I'd recommend reviewing each commit in turn if not.

Key commits explained below:

#### fix(visual-editing): support schema inline array items
Fixes a bug reported earlier today where trying to resolve an inline array item field from the schema would throw an error. High importance as hovering over overlay elements now triggers field resolution, so if an overlay's path points to an inline array item, an uncaught error is thrown.

#### fix: correctly handle popups
Previously new comlink targets for popups were added by using the `.size` of a Set stored as state as a `useEffect` dependency, but `.add()` was being called directly, rather than the `Set` being replaced using `setState`, which I believe failed to trigger the `useEffect`.

#### fix(presentation): suppress postMessage warnings
Prevents Presentation's comlink controller from initialising until the iframe has loaded, which suppresses the annoying `postMessage` warnings.

#### fix: support document snapshots on delayed comlink init
Fixes an issue where the welcome event was only emitted when Presentation initialised, and so would not be replayed to new window contexts, meaning document snapshots would not be fetched.

#### fix: enable optimistic features only when supported
Disables new features when communicating with an outdated version of Presentation that doesn't support mutations or in contexts where the optimistic actor is unavailable. Drag and drop, context menu, custom component mounting, etc. 

#### fix: explicit perspective fetching / fix: explicit schema fetching
Adds methods for explicitly fetching information needed when a context is initialised. Previously window contexts relied on Presentation blindly emitting some initial events, which means that any newly added contexts (popups) would not receive them.