### PR TITLE
feat(visual-editing): add package version mismatch warning

### DIFF
--- a/packages/comlink/src/types.ts
+++ b/packages/comlink/src/types.ts
@@ -45,7 +45,10 @@ export interface RequestData<S extends Message> {
   responseTo?: string
   type: MessageType
   resolvable?: PromiseWithResolvers<S['response']>
-  signal?: AbortSignal
+  options?: {
+    signal?: AbortSignal
+    suppressWarnings?: boolean
+  }
 }
 
 /**

--- a/packages/visual-editing/src/ui/VisualEditing.tsx
+++ b/packages/visual-editing/src/ui/VisualEditing.tsx
@@ -45,24 +45,29 @@ export const VisualEditing: FunctionComponent<VisualEditingOptions> = (props) =>
     })
 
     // Fetch features to determine if optimistic updates are supported
-    const abortController = new AbortController()
+    const controller = new AbortController()
     comlink
-      .fetch({type: 'visual-editing/features', data: undefined}, {signal: abortController.signal})
+      .fetch(
+        {type: 'visual-editing/features', data: undefined},
+        {signal: controller.signal, suppressWarnings: true},
+      )
       .then((data) => {
         if (data.features['optimistic']) {
           setActor(actor)
         }
       })
       .catch(() => {
-        // Fail silently as the app may be communicating with a version of
-        // Presentation that does not support this feature
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[@sanity/visual-editing] Package version mismatch detected: Please update your Sanity studio to prevent potential compatibility issues.',
+        )
       })
 
     actor.start()
     comlink.start()
 
     return () => {
-      abortController.abort()
+      controller.abort()
       actor.stop()
       comlink.stop()
     }

--- a/packages/visual-editing/src/ui/optimistic-state/machines/createSharedListener.ts
+++ b/packages/visual-editing/src/ui/optimistic-state/machines/createSharedListener.ts
@@ -15,9 +15,15 @@ export function createSharedListener(comlink: VisualEditingNode): Observable<Sha
   const incomingConnection$ = new ReplaySubject<SharedListenEvent>(1)
   const incomingMutations$ = new Subject<SharedListenEvent>()
 
-  comlink.fetch({type: 'visual-editing/snapshot-welcome', data: undefined}).then((data) => {
-    incomingConnection$.next(data.event)
-  })
+  comlink
+    .fetch({type: 'visual-editing/snapshot-welcome', data: undefined}, {suppressWarnings: true})
+    .then((data) => {
+      incomingConnection$.next(data.event)
+    })
+    .catch(() => {
+      // Fail silently as the app may be communicating with a version of
+      // Presentation that does not support this feature
+    })
 
   comlink.on('presentation/snapshot-event', (data) => {
     // Welcome events are still emitted by Presentation for backwards

--- a/packages/visual-editing/src/ui/schema/SchemaProvider.tsx
+++ b/packages/visual-editing/src/ui/schema/SchemaProvider.tsx
@@ -82,7 +82,7 @@ export const SchemaProvider: FunctionComponent<
             type: 'visual-editing/schema',
             data: undefined,
           },
-          {signal},
+          {signal, suppressWarnings: true},
         )
         setSchema(response.schema)
       } catch (e) {
@@ -110,7 +110,7 @@ export const SchemaProvider: FunctionComponent<
             type: 'visual-editing/schema-union-types',
             data: {paths},
           },
-          {signal},
+          {signal, suppressWarnings: true},
         )
         setResolvedTypes(response.types)
         reportedPathsRef.current = paths


### PR DESCRIPTION
This adds a new warning message about package version mismatching when visual editing doesn't receive a response to a features request. This replaces all the individual warnings emitted by other requests used to support new features (e.g. fetching the schema) when these are not supported by the user's Presentation version.