### PR TITLE
feat: add `useIsLivePreview` & `useIsPresentationTool` hooks

### DIFF
--- a/apps/live-next/app/alert-banner.tsx
+++ b/apps/live-next/app/alert-banner.tsx
@@ -1,20 +1,15 @@
 'use client'
 
+import {useIsPresentationTool} from '@sanity/next-loader/hooks'
 import {useRouter} from 'next/navigation'
-import {useSyncExternalStore, useTransition} from 'react'
+import {useTransition} from 'react'
 import {disableDraftMode} from './actions'
-
-const emptySubscribe = () => () => {}
 
 export default function AlertBanner() {
   const router = useRouter()
   const [pending, startTransition] = useTransition()
 
-  const shouldShow = useSyncExternalStore(
-    emptySubscribe,
-    () => window.top === window,
-    () => false,
-  )
+  const shouldShow = useIsPresentationTool() === false
 
   if (!shouldShow) return null
 

--- a/apps/live-next/app/draft-mode-status.tsx
+++ b/apps/live-next/app/draft-mode-status.tsx
@@ -1,10 +1,18 @@
 'use client'
 
-import {useDraftModeEnvironment, useDraftModePerspective} from '@sanity/next-loader/hooks'
+import {
+  useDraftModeEnvironment,
+  useDraftModePerspective,
+  useIsLivePreview,
+} from '@sanity/next-loader/hooks'
 
 export function DraftModeStatus() {
+  const isLivePreview = useIsLivePreview()
   const perspective = useDraftModePerspective()
   const environment = useDraftModeEnvironment()
+
+  if (isLivePreview !== true) return null
+
   return (
     <div className="fixed bottom-3 right-3 block rounded bg-theme-inverse px-2 py-1 text-xs text-theme-inverse">
       <p>perspective: {perspective}</p>

--- a/apps/live-next/app/layout.tsx
+++ b/apps/live-next/app/layout.tsx
@@ -80,12 +80,8 @@ export default async function RootLayout({children}: {children: React.ReactNode}
     >
       <body>
         <section className="min-h-screen">
-          {(await draftMode()).isEnabled && (
-            <>
-              <AlertBanner />
-              <DraftModeStatus />
-            </>
-          )}
+          {(await draftMode()).isEnabled && <AlertBanner />}
+          <DraftModeStatus />
           <main>{children}</main>
           <Suspense>
             <Footer />

--- a/apps/live-next/package.json
+++ b/apps/live-next/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "debug": "NEXT_PRIVATE_DEBUG_CACHE=1 next build --profile && NEXT_PRIVATE_DEBUG_CACHE=1 next start -p 3009",
     "predev": "npm run typegen",
-    "dev": "next dev -p 3009 --turbo",
+    "dev": "next dev -p 3009",
     "lint": "next lint",
     "start": "next start",
     "typegen": "sanity typegen generate"

--- a/packages/next-loader/src/hooks/context.ts
+++ b/packages/next-loader/src/hooks/context.ts
@@ -32,6 +32,7 @@ export type DraftEnvironment =
   | 'presentation-iframe'
   | 'presentation-window'
   | 'live'
+  | 'static'
   | 'unknown'
 
 /** @internal */

--- a/packages/next-loader/src/hooks/index.ts
+++ b/packages/next-loader/src/hooks/index.ts
@@ -3,3 +3,5 @@
 export * from './useDraftMode'
 export type {DraftPerspective, DraftEnvironment} from './context'
 export type {ClientPerspective} from '@sanity/client'
+export * from './useIsPresentationTool'
+export * from './useIsLivePreview'

--- a/packages/next-loader/src/hooks/useIsLivePreview.ts
+++ b/packages/next-loader/src/hooks/useIsLivePreview.ts
@@ -1,0 +1,25 @@
+import {useDraftModeEnvironment} from './useDraftMode'
+
+/**
+ * Detects if the application is considered to be in a "Live Preview" mode.
+ * Live Preview means that the application is either:
+ * - being previewed inside Sanity Presentation Tool
+ * - being previewed in Draft Mode, with a `browserToken` given to `defineLive`, also known as "Standalone Live Preview'"
+ * When in Live Preview mode, you typically want UI to update as new content comes in, without any manual intervention.
+ * This is very different from Live Production mode, where you usually want to delay updates that might cause layout shifts,
+ * to avoid interrupting the user that is consuming your content.
+ * This hook lets you adapt to this difference, making sure production doesn't cause layout shifts that worsen the UX,
+ * while in Live Preview mode layout shift is less of an issue and it's better for the editorial experience to auto refresh in real time.
+ *
+ * The hook returns `null` initially, to signal it doesn't yet know if it's live previewing or not.
+ * Then `true` if it is, and `false` otherwise.
+ * @public
+ */
+export function useIsLivePreview(): boolean | null {
+  const environment = useDraftModeEnvironment()
+  return environment === 'checking'
+    ? null
+    : environment === 'presentation-iframe' ||
+        environment === 'presentation-window' ||
+        environment === 'live'
+}

--- a/packages/next-loader/src/hooks/useIsPresentationTool.ts
+++ b/packages/next-loader/src/hooks/useIsPresentationTool.ts
@@ -1,0 +1,18 @@
+import {useDraftModeEnvironment} from './useDraftMode'
+
+/**
+ * Detects if the application is being previewed inside Sanity Presentation Tool.
+ * Presentation Tool can open the application in an iframe, or in a new window.
+ * When in this context there are some UI you usually don't want to show,
+ * for example a Draft Mode toggle, or a "Viewing draft content" indicators, these are unnecessary and add clutter to
+ * the editorial experience.
+ * The hook returns `null` initially, when it's not yet sure if the application is running inside Presentation Tool,
+ * then `true` if it is, and `false` otherwise.
+ * @public
+ */
+export function useIsPresentationTool(): boolean | null {
+  const environment = useDraftModeEnvironment()
+  return environment === 'checking'
+    ? null
+    : environment === 'presentation-iframe' || environment === 'presentation-window'
+}


### PR DESCRIPTION
The new hooks are higher level, and tailored to the use cases I've found is needed in most templates:
1. I want to show a UI warning that the app is in draft mode when outside of Presentation Tool, so editors don't freak out and think they've accidentally published some content.
3. In production it's awesome to show a "A new post is available" toast with a refresh button so that my visitors can consume my content in peace and decide when to see the new content. In live preview however I don't want my editors to constantly hit a refresh button toast every time they make a draft edit before they can see it.

I want to only show a Draft Mode message if I'm not in the Presentation Tool:
```tsx
"use client";

import { useIsPresentationTool } from "next-sanity/hooks";
import { useEffect } from "react";
import { toast } from "sonner";
import { disableDraftMode } from "./actions";

export default function DraftModeToast() {
  const isPresentationTool = useIsPresentationTool();

  useEffect(() => {
    if(isPresentationTool === false) {
      toast("Draft Mode Enabled", {
        action: {
          label: "Disable",
          onClick: () => disableDraftMode(),
        },
      });
    }
  }, [isPresentationTool]);

  return null;
}
```

I want to delay layout shift in production, and passthrough in live preview:
```tsx
"use client";

import { useIsLivePreview } from "next-sanity/hooks";
import { useEffect } from "react";
import { toast } from "sonner";
import { useDeferredLayoutShift } from "./use-deferred-transition";

/**
 * Suspends layout shift for the more stories section when a new post is published.
 * On changes it'll require opt-in form the user before the post is shown.
 * If the post itself is edited, it'll refresh automatically to allow fixing typos.
 */

export function MoreStoriesLayoutShift(props: {
  children: React.ReactNode;
  ids: string[];
}) {
  const [children, pending, startViewTransition] = useDeferredLayoutShift(
    props.children,
    props.ids,
  );
  const isLivePreview = useIsLivePreview();

  /**
   * We need to suspend layout shift for user opt-in.
   */
  useEffect(() => {
    if(pending && isLivePreview === false) {
      toast("More stories have been published", {
        id: "more-stories-layout-shift",
        duration: Infinity,
        action: {
          label: "Refresh",
          onClick: () => startViewTransition(),
        },
      });
    }
  }, [pending, isLivePreview, startViewTransition]);

  /**
   * If we're in Live Preview we want our editors to see their changes right away,
   * without requiring any user interactions, so they can preview on many screens and devices all at once
   */
  if(isLivePreview) {
    return props.children
  }

  return children;
}

```