### PR TITLE
feat: add configurable timeout to PreviewFrame

### DIFF
--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -546,6 +546,7 @@ export default function PresentationTool(props: {
                         setPerspective={setPerspective}
                         setViewport={setViewport}
                         targetOrigin={targetOrigin}
+                        connectionTimeout={tool.options.timeout}
                         toggleNavigator={toggleNavigator}
                         toggleOverlay={toggleOverlay}
                         viewport={viewport}

--- a/packages/presentation/src/preview/PreviewFrame.tsx
+++ b/packages/presentation/src/preview/PreviewFrame.tsx
@@ -93,6 +93,7 @@ export interface PreviewFrameProps extends Pick<PresentationState, 'iframe' | 'v
   setPerspective: (perspective: 'previewDrafts' | 'published') => void
   setViewport: (mode: 'desktop' | 'mobile') => void
   targetOrigin: string
+  connectionTimeout?: number
   toggleNavigator?: () => void
   toggleOverlay: () => void
   viewport: PresentationViewport
@@ -119,6 +120,7 @@ export const PreviewFrame = memo(
         setPerspective,
         setViewport,
         targetOrigin,
+        connectionTimeout = 5_000,
         toggleNavigator,
         toggleOverlay,
         viewport,
@@ -185,7 +187,7 @@ export const PreviewFrame = memo(
         if (overlaysConnection === 'connecting' || overlaysConnection === 'reconnecting') {
           const timeout = setTimeout(() => {
             setShowOverlaysConnectionState(true)
-          }, 5_000)
+          }, connectionTimeout)
           return () => clearTimeout(timeout)
         }
         return

--- a/packages/presentation/src/types.ts
+++ b/packages/presentation/src/types.ts
@@ -147,6 +147,10 @@ export interface PresentationPluginOptions {
   icon?: ComponentType
   name?: string
   title?: string
+  /** Number of milliseconds before preview component will time out
+   * @default 5000
+   */
+  timeout?: number
   /**
    * @deprecated use `resolve.locations` instead
    */


### PR DESCRIPTION
I'm constantly unable to connect in my production env. Personally I think 5 seconds is too short as default (the code I use pretty close to the old AKVA template), but just having it be configurable would be a huge help.

Also, I was unable to find a CONTRIBUTING.md for this project, so the code is fairly quick n dirty. Happy to just use this PR as a starting point :) 