### PR TITLE
fix(visual-editing): remove useOptimistic nullable check

### DIFF
--- a/apps/page-builder-demo/src/components/page/Page.tsx
+++ b/apps/page-builder-demo/src/components/page/Page.tsx
@@ -19,9 +19,10 @@ export function Page(props: {data: PageData}) {
       if (action.id === data._id && action.document.sections) {
         return action.document.sections
           .map(
-            (section: {_key: string} | undefined) => state?.find((s) => s._key === section?._key)!,
+            (section: {_key: string} | undefined) =>
+              state?.find((s) => s._key === section?._key) || section,
           )
-          .filter(Boolean)
+          .filter(Boolean) as PageSection[]
       }
       return state
     },

--- a/packages/visual-editing/src/ui/optimistic-state/useOptimistic.ts
+++ b/packages/visual-editing/src/ui/optimistic-state/useOptimistic.ts
@@ -112,10 +112,6 @@ export function useOptimistic<T, U = SanityDocument>(
       // If we don't have a lastEvent when we are pristine, it's a fatal error
       throw new Error('No last event found when syncing passthrough')
     }
-    if (!lastPassthrough) {
-      // If we don't have a lastPassthrough, it's a fatal error
-      throw new Error('No last passthrough found when syncing passthrough')
-    }
     if (lastPassthrough === passthrough) {
       // If the passthrough hasn't changed, then we don't need to rerun the reducers
       return undefined


### PR DESCRIPTION
There are likely scenarios where you would want to use `useOptimistic` with a nullable passthrough value. For example when rendering a page with an optionally empty value.

This PR just removes the nullable `lastPassthrough` check. I'm sure it was there for good reason, but I haven't been able to find a situation where removing it causes issues so far.

@stipsan assigning you to this as you wrote it originally and probably have a good idea of why that check exists.