### PR TITLE
chore: set release scripts for corel

### DIFF
--- a/.github/workflows/release-corel.yml
+++ b/.github/workflows/release-corel.yml
@@ -1,0 +1,51 @@
+name: Release Corel
+
+on: workflow_dispatch
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # for checkout
+
+jobs:
+  release-corel:
+    permissions:
+        contents: read # for checkout
+        id-token: write # to enable use of OIDC for npm provenance
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      # The Live Draft Content API is much faster than the legacy Listen API based approach for loader live mode
+      PRESENTATION_ENABLE_LIVE_DRAFT_EVENTS: true
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v4
+        with:
+          ref: corel
+          token: ${{ steps.generate-token.outputs.token }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: lts/*
+      - run: pnpm install --ignore-scripts
+      - run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
+      - name: release corel & commit + push the changed versions
+        env:
+          NPM_CONFIG_PROVENANCE: true
+        run: |
+          pnpm release:corel
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "chore(release): publish corel [skip ci]"
+          git push

--- a/scripts/release-corel.mjs
+++ b/scripts/release-corel.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env zx
+import 'zx/globals'
+
+const {packages} = await fs.readJson('./release-please-config.json')
+const workspaces = Object.keys(packages)
+
+echo`found ${chalk.blue(workspaces.length)} workspaces to publish canaries for`
+
+const prev = new Map()
+const next = new Map()
+
+for (const workspace of workspaces) {
+  const {name, version, private: isPrivate} = await fs.readJson(`./${workspace}/package.json`)
+  if (!isPrivate) {
+    await spinner(`bumping ${chalk.blue(name)} from ${chalk.yellow(version)}`, async () => {
+      prev.set(name, version)
+      // `pnpm version` is really just an alias for `npm version` atm, so we have to jump through some hoops
+      await $`pnpm --filter="${name}" exec pnpm version --no-commit-hooks --no-git-tag-version --preid release prerelease`
+      next.set(name, (await fs.readJson(`./${workspace}/package.json`)).version)
+    })
+    echo`bumped ${chalk.blue(name)} from ${chalk.yellow(prev.get(name))} to ${chalk.green(next.get(name))}`
+  }
+}
+
+await $`pnpm build --output-logs=errors-only`.pipe(process.stdout)
+
+// If provenance isn't enabled, assume we're running locally and need to confirm before publishing
+if (process.env.NPM_CONFIG_PROVENANCE !== 'true') {
+  const shouldProceed = await question('Are you sure you want to proceed? (y/n) ')
+  if (shouldProceed.toLowerCase() !== 'y' && shouldProceed.toLowerCase() !== 'yes') {
+    console.log('Operation cancelled.')
+    for (const workspace of workspaces) {
+      const {name, ...rest} = await fs.readJson(`./${workspace}/package.json`)
+      if (prev.has(name)) {
+        await fs.writeJson(`./${workspace}/package.json`, {name, ...rest, version: prev.get(name)})
+        await $`prettier --write ./${workspace}/package.json`
+      }
+    }
+    process.exit(0)
+  }
+}
+
+for (const name of next.keys()) {
+  await $`pnpm --filter="${name}" publish --tag release --no-git-checks`.pipe(process.stdout)
+}
+
+echo`published canaries for ${chalk.blue(workspaces.length)} workspaces`


### PR DESCRIPTION
adds release scripts for `corel`
Using `corel` tag as it matches with the tag we have in `sanity` 

