### PR TITLE
fix: backwards compatible handshake payloads

### DIFF
--- a/packages/visual-editing-helpers/src/comlinkCompatibility.ts
+++ b/packages/visual-editing-helpers/src/comlinkCompatibility.ts
@@ -119,6 +119,14 @@ const convertToChannelsMessage = (message: ProtocolMessage): ProtocolMessage => 
     message.data = {responseTo: message.responseTo}
   }
 
+  if (
+    message.type === 'handshake/syn' ||
+    message.type === 'handshake/syn-ack' ||
+    message.type === 'handshake/ack'
+  ) {
+    message.data = {id: message.connectionId}
+  }
+
   return message
 }
 


### PR DESCRIPTION
- Handshake messages in the internal `@sanity/channels` package sent the connection ID as the value of `data.id`.
- Comlink handshakes don't, and instead just check against the `connectionId` property.
- `data.id` isn't currently set in the comlink to channel compatibility transform.
- So handshakes currently fail when a newer version of `@sanity/presentation` is trying to communicate with an older version of `@sanity/visual-editing`.
- This PR adds the necessary `data.id` value in the compatibility transform.