### PR TITLE
fix(presentation): remove media from preview snapshot payload

### DIFF
--- a/packages/visual-editing-helpers/src/types/comlink.ts
+++ b/packages/visual-editing-helpers/src/types/comlink.ts
@@ -80,6 +80,16 @@ export type HistoryRefresh =
 /**
  * @public
  */
+export type PreviewSnapshot = {
+  // Explicitly exclude media, as it's not serializable
+  [K in keyof Omit<PreviewValue, 'media'>]?: Omit<PreviewValue, 'media'>[K]
+} & {
+  _id: string
+}
+
+/**
+ * @public
+ */
 export type VisualEditingControllerMsg =
   | {
       type: 'presentation/focus'
@@ -120,7 +130,7 @@ export type VisualEditingControllerMsg =
   | {
       type: 'presentation/preview-snapshots'
       data: {
-        snapshots: Array<PreviewValue & {_id: string}>
+        snapshots: PreviewSnapshot[]
       }
     }
   | {

--- a/packages/visual-editing/src/ui/preview/PreviewSnapshotsContext.tsx
+++ b/packages/visual-editing/src/ui/preview/PreviewSnapshotsContext.tsx
@@ -1,6 +1,6 @@
-import type {PreviewValue} from '@sanity/types'
+import type {PreviewSnapshot} from '@repo/visual-editing-helpers'
 import {createContext} from 'react'
 
-export type PreviewSnapshotsContextValue = Array<PreviewValue & {_id: string}>
+export type PreviewSnapshotsContextValue = PreviewSnapshot[]
 
 export const PreviewSnapshotsContext = createContext<PreviewSnapshotsContextValue | null>(null)


### PR DESCRIPTION
Fix for https://github.com/sanity-io/sanity/issues/7689. Removes the (unused) media value from preview snapshot payloads.