### PR TITLE
fix(visual-editing): prevent always activating elements on registration

### DIFF
--- a/packages/visual-editing/src/controller.ts
+++ b/packages/visual-editing/src/controller.ts
@@ -351,7 +351,10 @@ export function createOverlayController({
       sanity,
       dragDisabled: !!element.getAttribute('data-sanity-drag-disable'),
     })
-    activateElement(sanityNode)
+
+    if (activated) {
+      activateElement(sanityNode)
+    }
   }
 
   function updateElement({elements, sanity}: ResolvedElement) {


### PR DESCRIPTION
It looks like elements are  currently activated (i.e. become visible) on registration (i.e. when they are detected in the DOM), even if the controller itself is deactivated (i.e. the Edit button is in the "Off" state). So for example navigating between pages in an app with Edit set to "Off" will result in overlays being rendered.

This PR adds a simple check to prevent that.