### PR TITLE
fix(visual-editing): correct component resolver array return types

### DIFF
--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -395,9 +395,8 @@ export type OverlayComponentResolver<
   context: OverlayComponentResolverContext,
 ) =>
   | T
-  | Array<T>
   | {component: T; props?: Record<string, unknown>}
-  | Array<{component: T; props?: Record<string, unknown>}>
+  | Array<T | {component: T; props?: Record<string, unknown>}>
   | undefined
   | void
 


### PR DESCRIPTION
Small change to the overlay component resolver return type.

Moves the union to the array itself rather than applying the union at array level, and so allowing for arrays of mixed types.