### PR TITLE
feat: add shared state

### DIFF
--- a/apps/page-builder-demo/src/components/overlays/OverlayHighlight.tsx
+++ b/apps/page-builder-demo/src/components/overlays/OverlayHighlight.tsx
@@ -1,0 +1,25 @@
+import {useSharedState} from '@sanity/visual-editing'
+import {FunctionComponent} from 'react'
+
+export const OverlayHighlight: FunctionComponent = () => {
+  const overlayEnabled = useSharedState<boolean>('overlay-enabled')
+
+  if (!overlayEnabled) {
+    return null
+  }
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'rgba(0, 0, 255, 0.25)',
+      }}
+    />
+  )
+}

--- a/apps/page-builder-demo/src/components/overlays/resolver.ts
+++ b/apps/page-builder-demo/src/components/overlays/resolver.ts
@@ -1,29 +1,47 @@
 'use client'
 
-import {OverlayComponentResolver} from '@sanity/visual-editing'
+import {OverlayComponent, OverlayComponentResolver, useSharedState} from '@sanity/visual-editing'
 import {
   defineOverlayComponent,
   UnionInsertMenuOverlay,
 } from '@sanity/visual-editing/unstable_overlay-components'
 import {ExcitingTitleControl} from './ExcitingTitleControl'
+import {OverlayHighlight} from './OverlayHighlight'
 import {ProductModelRotationControl} from './ProductModelRotationControl'
 
 export const components: OverlayComponentResolver = (props) => {
-  const {type, node, parent} = props
+  const {element, type, node, parent} = props
+
+  const components: Array<
+    | OverlayComponent<Record<string, unknown>, any>
+    | {
+        component: OverlayComponent<Record<string, unknown>, any>
+        props?: Record<string, unknown>
+      }
+  > = [OverlayHighlight]
 
   if (type === 'string' && node.path === 'title') {
-    return ExcitingTitleControl
+    components.push(ExcitingTitleControl)
   }
 
   if (type === 'object' && node.path.endsWith('rotations')) {
-    return defineOverlayComponent(ProductModelRotationControl)
+    components.push(ProductModelRotationControl)
   }
 
   if (parent?.type === 'union') {
-    return defineOverlayComponent(UnionInsertMenuOverlay, {
-      direction: 'vertical',
-    })
+    const parentDataset = element.parentElement?.dataset || {}
+
+    const direction = (parentDataset.direction ?? 'vertical') as 'vertical' | 'horizontal'
+
+    const hoverAreaExtent = parentDataset.hoverExtent || 48
+
+    components.push(
+      defineOverlayComponent(UnionInsertMenuOverlay, {
+        direction,
+        hoverAreaExtent,
+      }),
+    )
   }
 
-  return undefined
+  return components
 }

--- a/apps/studio/presentation/CustomHeader.tsx
+++ b/apps/studio/presentation/CustomHeader.tsx
@@ -1,0 +1,45 @@
+import {CheckmarkIcon, CloseIcon, EllipsisVerticalIcon} from '@sanity/icons'
+import {useSharedState} from '@sanity/presentation'
+import {Button, Menu, MenuButton, MenuItem} from '@sanity/ui'
+import {useState, type FunctionComponent, type ReactNode} from 'react'
+import type {PreviewHeaderProps} from '../../../packages/presentation/src/preview/PreviewHeader'
+
+export const CustomHeader: FunctionComponent<
+  PreviewHeaderProps & {
+    renderDefault: (props: PreviewHeaderProps) => ReactNode
+  }
+> = (props) => {
+  const [enabled, setEnabled] = useState(false)
+
+  useSharedState('overlay-enabled', enabled)
+
+  return (
+    <>
+      {props.renderDefault(props)}
+      <MenuButton
+        button={
+          <Button fontSize={1} icon={EllipsisVerticalIcon} mode="bleed" padding={2} space={2} />
+        }
+        id="custom-menu"
+        menu={
+          <Menu style={{maxWidth: 240}}>
+            <MenuItem
+              fontSize={1}
+              icon={enabled ? CloseIcon : CheckmarkIcon}
+              onClick={() => setEnabled((enabled) => !enabled)}
+              padding={3}
+              tone={enabled ? 'caution' : 'positive'}
+              text={enabled ? 'Disable Highlighting' : 'Enable Highlighting'}
+            />
+          </Menu>
+        }
+        popover={{
+          animate: true,
+          constrainSize: true,
+          placement: 'bottom',
+          portal: true,
+        }}
+      />
+    </>
+  )
+}

--- a/apps/studio/presentation/CustomHeader.tsx
+++ b/apps/studio/presentation/CustomHeader.tsx
@@ -1,14 +1,10 @@
 import {CheckmarkIcon, CloseIcon, EllipsisVerticalIcon} from '@sanity/icons'
 import {useSharedState} from '@sanity/presentation'
+import type {PreviewHeaderProps} from '@sanity/presentation'
 import {Button, Menu, MenuButton, MenuItem} from '@sanity/ui'
-import {useState, type FunctionComponent, type ReactNode} from 'react'
-import type {PreviewHeaderProps} from '../../../packages/presentation/src/preview/PreviewHeader'
+import {useState, type FunctionComponent} from 'react'
 
-export const CustomHeader: FunctionComponent<
-  PreviewHeaderProps & {
-    renderDefault: (props: PreviewHeaderProps) => ReactNode
-  }
-> = (props) => {
+export const CustomHeader: FunctionComponent<PreviewHeaderProps> = (props) => {
   const [enabled, setEnabled] = useState(false)
 
   useSharedState('overlay-enabled', enabled)

--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -16,6 +16,7 @@ import {
 import {debugSecrets} from '@sanity/preview-url-secret/sanity-plugin-debug-secrets'
 import {visionTool} from '@sanity/vision'
 import {defineConfig, definePlugin, type PluginOptions} from 'sanity'
+import {CustomHeader} from './presentation/CustomHeader'
 import {CustomNavigator} from './presentation/CustomNavigator'
 import {StegaDebugger} from './presentation/DebugStega'
 
@@ -138,6 +139,9 @@ export default defineConfig([
         workspaces['page-builder-demo'].tool,
       ),
       components: {
+        unstable_header: {
+          component: CustomHeader,
+        },
         unstable_navigator: {
           minWidth: 120,
           maxWidth: 240,

--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -36,6 +36,7 @@ import {
 } from './constants'
 import {useUnique, useWorkspace, type CommentIntentGetter} from './internals'
 import {debounce} from './lib/debounce'
+import {SharedStateProvider} from './overlays/SharedStateProvider'
 import {Panel} from './panels/Panel'
 import {Panels} from './panels/Panels'
 import {PresentationContent} from './PresentationContent'
@@ -92,7 +93,7 @@ export default function PresentationTool(props: {
   const components = tool.options?.components
   const _previewUrl = tool.options?.previewUrl
   const name = tool.name || DEFAULT_TOOL_NAME
-  const {unstable_navigator} = components || {}
+  const {unstable_navigator, unstable_header} = components || {}
 
   const {navigate: routerNavigate, state: routerState} = useRouter() as RouterContextValue & {
     state: PresentationStateParams
@@ -516,58 +517,61 @@ export default function PresentationTool(props: {
       >
         <PresentationNavigateProvider navigate={navigate}>
           <PresentationParamsProvider params={params}>
-            <Container height="fill">
-              <Panels>
-                <PresentationNavigator />
-                <Panel
-                  id="preview"
-                  minWidth={325}
-                  defaultSize={navigatorEnabled ? 50 : 75}
-                  order={3}
-                >
-                  <Flex direction="column" flex={1} height="fill" ref={setBoundaryElement}>
-                    <BoundaryElementProvider element={boundaryElement}>
-                      <Preview
-                        canSharePreviewAccess={canSharePreviewAccess}
-                        canToggleSharePreviewAccess={canToggleSharePreviewAccess}
-                        canUseSharedPreviewAccess={canUseSharedPreviewAccess}
-                        dispatch={dispatch}
-                        iframe={state.iframe}
-                        initialUrl={initialPreviewUrl}
-                        loadersConnection={loadersConnection}
-                        navigatorEnabled={navigatorEnabled}
-                        onPathChange={handlePreviewPath}
-                        onRefresh={handleRefresh}
-                        openPopup={handleOpenPopup}
-                        overlaysConnection={overlaysConnection}
-                        previewUrl={params.preview}
-                        perspective={perspective}
-                        ref={iframeRef}
-                        setPerspective={setPerspective}
-                        setViewport={setViewport}
-                        targetOrigin={targetOrigin}
-                        toggleNavigator={toggleNavigator}
-                        toggleOverlay={toggleOverlay}
-                        viewport={viewport}
-                        visualEditing={state.visualEditing}
-                      />
-                    </BoundaryElementProvider>
-                  </Flex>
-                </Panel>
-                <PresentationContent
-                  documentId={params.id}
-                  documentsOnPage={documentsOnPage}
-                  documentType={params.type}
-                  getCommentIntent={getCommentIntent}
-                  mainDocumentState={mainDocumentState}
-                  onFocusPath={handleFocusPath}
-                  onStructureParams={handleStructureParams}
-                  searchParams={searchParams}
-                  setDisplayedDocument={setDisplayedDocument}
-                  structureParams={structureParams}
-                />
-              </Panels>
-            </Container>
+            <SharedStateProvider comlink={visualEditingComlink}>
+              <Container height="fill">
+                <Panels>
+                  <PresentationNavigator />
+                  <Panel
+                    id="preview"
+                    minWidth={325}
+                    defaultSize={navigatorEnabled ? 50 : 75}
+                    order={3}
+                  >
+                    <Flex direction="column" flex={1} height="fill" ref={setBoundaryElement}>
+                      <BoundaryElementProvider element={boundaryElement}>
+                        <Preview
+                          canSharePreviewAccess={canSharePreviewAccess}
+                          canToggleSharePreviewAccess={canToggleSharePreviewAccess}
+                          canUseSharedPreviewAccess={canUseSharedPreviewAccess}
+                          dispatch={dispatch}
+                          header={unstable_header}
+                          iframe={state.iframe}
+                          initialUrl={initialPreviewUrl}
+                          loadersConnection={loadersConnection}
+                          navigatorEnabled={navigatorEnabled}
+                          onPathChange={handlePreviewPath}
+                          onRefresh={handleRefresh}
+                          openPopup={handleOpenPopup}
+                          overlaysConnection={overlaysConnection}
+                          previewUrl={params.preview}
+                          perspective={perspective}
+                          ref={iframeRef}
+                          setPerspective={setPerspective}
+                          setViewport={setViewport}
+                          targetOrigin={targetOrigin}
+                          toggleNavigator={toggleNavigator}
+                          toggleOverlay={toggleOverlay}
+                          viewport={viewport}
+                          visualEditing={state.visualEditing}
+                        />
+                      </BoundaryElementProvider>
+                    </Flex>
+                  </Panel>
+                  <PresentationContent
+                    documentId={params.id}
+                    documentsOnPage={documentsOnPage}
+                    documentType={params.type}
+                    getCommentIntent={getCommentIntent}
+                    mainDocumentState={mainDocumentState}
+                    onFocusPath={handleFocusPath}
+                    onStructureParams={handleStructureParams}
+                    searchParams={searchParams}
+                    setDisplayedDocument={setDisplayedDocument}
+                    structureParams={structureParams}
+                  />
+                </Panels>
+              </Container>
+            </SharedStateProvider>
           </PresentationParamsProvider>
         </PresentationNavigateProvider>
       </PresentationProvider>

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -27,6 +27,7 @@ export {
   usePresentationNavigate,
 } from './usePresentationNavigate'
 export {usePresentationParams} from './usePresentationParams'
+export {useSharedState} from './overlays/useSharedState'
 export type {PreviewHeaderProps} from './preview/PreviewHeader'
 export type {PreviewProps} from './preview/Preview'
 export {
@@ -42,3 +43,9 @@ export {
   type PresentationState,
   type VisualEditingOverlaysToggleAction,
 } from './reducers/presentationReducer'
+export type {
+  Serializable,
+  SerializableArray,
+  SerializableObject,
+  SerializablePrimitive,
+} from '@repo/visual-editing-helpers'

--- a/packages/presentation/src/overlays/SharedStateContext.tsx
+++ b/packages/presentation/src/overlays/SharedStateContext.tsx
@@ -1,0 +1,9 @@
+import type {Serializable} from '@repo/visual-editing-helpers'
+import {createContext} from 'react'
+
+export interface SharedStateContextValue {
+  removeValue: (key: string) => void
+  setValue: (key: string, value: Serializable) => void
+}
+
+export const SharedStateContext = createContext<SharedStateContextValue | null>(null)

--- a/packages/presentation/src/overlays/SharedStateProvider.tsx
+++ b/packages/presentation/src/overlays/SharedStateProvider.tsx
@@ -1,0 +1,50 @@
+import type {Serializable, SerializableObject} from '@repo/visual-editing-helpers'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type FunctionComponent,
+  type PropsWithChildren,
+} from 'react'
+import type {VisualEditingConnection} from '../types'
+import {SharedStateContext, type SharedStateContextValue} from './SharedStateContext'
+
+export const SharedStateProvider: FunctionComponent<
+  PropsWithChildren<{
+    comlink: VisualEditingConnection | null
+  }>
+> = function (props) {
+  const {comlink, children} = props
+
+  const sharedState = useRef<SerializableObject>({})
+
+  useEffect(() => {
+    return comlink?.on('visual-editing/shared-state', () => {
+      return {state: sharedState.current}
+    })
+  }, [comlink])
+
+  const setValue = useCallback(
+    (key: string, value: Serializable) => {
+      sharedState.current[key] = value
+      comlink?.post({type: 'presentation/shared-state', data: {key, value}})
+    },
+    [comlink],
+  )
+
+  const removeValue = useCallback(
+    (key: string) => {
+      comlink?.post({type: 'presentation/shared-state', data: {key}})
+      delete sharedState.current[key]
+    },
+    [comlink],
+  )
+
+  const context = useMemo<SharedStateContextValue>(
+    () => ({removeValue, setValue}),
+    [removeValue, setValue],
+  )
+
+  return <SharedStateContext.Provider value={context}>{children}</SharedStateContext.Provider>
+}

--- a/packages/presentation/src/overlays/useSharedState.ts
+++ b/packages/presentation/src/overlays/useSharedState.ts
@@ -1,0 +1,25 @@
+import type {Serializable} from '@repo/visual-editing-helpers'
+import {useContext, useEffect} from 'react'
+import {SharedStateContext} from './SharedStateContext'
+
+export const useSharedState = (key: string, value: Serializable): undefined => {
+  const context = useContext(SharedStateContext)
+
+  if (!context) {
+    throw new Error('Preview Snapshots context is missing')
+  }
+
+  const {removeValue, setValue} = context
+
+  useEffect(() => {
+    setValue(key, value)
+  }, [key, value, setValue])
+
+  useEffect(() => {
+    return () => {
+      removeValue(key)
+    }
+  }, [key, removeValue])
+
+  return undefined
+}

--- a/packages/presentation/src/preview/PreviewHeader.tsx
+++ b/packages/presentation/src/preview/PreviewHeader.tsx
@@ -59,9 +59,12 @@ const PERSPECTIVE_ICONS: Record<PresentationPerspective, ComponentType> = {
 
 export interface PreviewHeaderProps extends PreviewProps {
   iframeRef: RefObject<HTMLIFrameElement>
+  renderDefault: (props: PreviewHeaderProps) => ReactNode
 }
 
-const PreviewHeaderDefault: FunctionComponent<PreviewHeaderProps> = (props) => {
+const PreviewHeaderDefault: FunctionComponent<Omit<PreviewHeaderProps, 'renderDefault'>> = (
+  props,
+) => {
   const {
     canSharePreviewAccess,
     canToggleSharePreviewAccess,
@@ -375,10 +378,10 @@ const PreviewHeaderDefault: FunctionComponent<PreviewHeaderProps> = (props) => {
   )
 }
 
-const PreviewHeader: FunctionComponent<PreviewHeaderProps & {options?: HeaderOptions}> = (
-  props,
-) => {
-  const renderDefault = useCallback((props: PreviewHeaderProps) => {
+const PreviewHeader: FunctionComponent<
+  Omit<PreviewHeaderProps, 'renderDefault'> & {options?: HeaderOptions}
+> = (props) => {
+  const renderDefault = useCallback((props: Omit<PreviewHeaderProps, 'renderDefault'>) => {
     return createElement(PreviewHeaderDefault, props)
   }, [])
 
@@ -397,7 +400,7 @@ const PreviewHeader: FunctionComponent<PreviewHeaderProps & {options?: HeaderOpt
 
 /** @internal */
 export function usePresentationPreviewHeader(
-  props: PreviewHeaderProps & {options?: HeaderOptions},
+  props: Omit<PreviewHeaderProps, 'renderDefault'> & {options?: HeaderOptions},
 ): () => ReactNode {
   const Component = useCallback(() => {
     return <PreviewHeader {...props} />

--- a/packages/presentation/src/types.ts
+++ b/packages/presentation/src/types.ts
@@ -10,7 +10,7 @@ import type {
   PreviewUrlResolver,
   PreviewUrlResolverOptions,
 } from '@sanity/preview-url-secret/define-preview-url'
-import type {ComponentType, ReactNode} from 'react'
+import type {ComponentType} from 'react'
 import type {Observable} from 'rxjs'
 import type {SanityClient} from 'sanity'
 import type {DocumentStore} from './internals'
@@ -71,9 +71,7 @@ export interface NavigatorOptions {
 }
 
 export interface HeaderOptions {
-  component: ComponentType<
-    PreviewHeaderProps & {renderDefault: (props: PreviewHeaderProps) => ReactNode}
-  >
+  component: ComponentType<PreviewHeaderProps>
 }
 
 export type PreviewUrlOption = string | PreviewUrlResolver<SanityClient> | PreviewUrlResolverOptions

--- a/packages/visual-editing-helpers/src/types/comlink.ts
+++ b/packages/visual-editing-helpers/src/types/comlink.ts
@@ -139,6 +139,13 @@ export type VisualEditingControllerMsg =
         event: ReconnectEvent | WelcomeEvent | MutationEvent
       }
     }
+  | {
+      type: 'presentation/shared-state'
+      data: {
+        key: string
+        value?: Serializable
+      }
+    }
 
 /**
  * @public
@@ -258,6 +265,13 @@ export type VisualEditingNodeMsg =
         features: Record<string, boolean>
       }
     }
+  | {
+      type: 'visual-editing/shared-state'
+      data: undefined
+      response: {
+        state: SerializableObject
+      }
+    }
 
 /**
  * @public
@@ -345,3 +359,20 @@ export type PreviewKitNodeMsg = {
     documents: ContentSourceMapDocuments
   }
 }
+
+/**
+ * @public
+ */
+export type SerializablePrimitive = string | number | boolean | null | undefined
+/**
+ * @public
+ */
+export type SerializableObject = {[key: string]: Serializable}
+/**
+ * @public
+ */
+export type SerializableArray = Serializable[]
+/**
+ * @public
+ */
+export type Serializable = SerializablePrimitive | SerializableObject | SerializableArray

--- a/packages/visual-editing/src/index.ts
+++ b/packages/visual-editing/src/index.ts
@@ -64,6 +64,7 @@ export {
   useDocuments,
   useOptimistic,
 } from './ui/optimistic-state'
+export {useSharedState} from './ui/shared-state/useSharedState'
 export {
   type CreateDataAttribute,
   type CreateDataAttributeProps,

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -39,6 +39,7 @@ import {OverlayMinimapPrompt} from './OverlayMinimapPrompt'
 import {overlayStateReducer} from './overlayStateReducer'
 import {PreviewSnapshotsProvider} from './preview/PreviewSnapshotsProvider'
 import {SchemaProvider} from './schema/SchemaProvider'
+import {SharedStateProvider} from './shared-state/SharedStateProvider.tsx'
 import {useController} from './useController'
 import {usePerspectiveSync} from './usePerspectiveSync'
 import {useReportDocuments} from './useReportDocuments'
@@ -338,68 +339,70 @@ export const Overlays: FunctionComponent<{
         <PortalProvider element={rootElement}>
           <SchemaProvider comlink={comlink} elements={elements}>
             <PreviewSnapshotsProvider comlink={comlink}>
-              <Root
-                data-fading-out={fadingOut ? '' : undefined}
-                data-overlays={overlaysFlash ? '' : undefined}
-                ref={setRootElement}
-                $zIndex={zIndex}
-              >
-                <DocumentReporter documentIds={documentIds} perspective={perspective} />
-                <OverlaysController
-                  comlink={comlink}
-                  dispatch={dispatch}
-                  inFrame={inFrame}
-                  onDrag={updateDragPreviewCustomProps}
-                  overlayEnabled={overlayEnabled}
-                  rootElement={rootElement}
-                />
-                {contextMenu && <ContextMenu {...contextMenu} onDismiss={closeContextMenu} />}
-                {!isDragging &&
-                  elementsToRender.map(
-                    ({id, element, focused, hovered, rect, sanity, dragDisabled}) => {
-                      const draggable =
-                        !dragDisabled &&
-                        !!element.getAttribute('data-sanity') &&
-                        optimisticActorReady &&
-                        elements.some((e) =>
-                          'id' in e.sanity && 'id' in sanity
-                            ? sanityNodesExistInSameArray(e.sanity, sanity) &&
-                              e.sanity.path !== sanity.path
-                            : false,
+              <SharedStateProvider comlink={comlink}>
+                <Root
+                  data-fading-out={fadingOut ? '' : undefined}
+                  data-overlays={overlaysFlash ? '' : undefined}
+                  ref={setRootElement}
+                  $zIndex={zIndex}
+                >
+                  <DocumentReporter documentIds={documentIds} perspective={perspective} />
+                  <OverlaysController
+                    comlink={comlink}
+                    dispatch={dispatch}
+                    inFrame={inFrame}
+                    onDrag={updateDragPreviewCustomProps}
+                    overlayEnabled={overlayEnabled}
+                    rootElement={rootElement}
+                  />
+                  {contextMenu && <ContextMenu {...contextMenu} onDismiss={closeContextMenu} />}
+                  {!isDragging &&
+                    elementsToRender.map(
+                      ({id, element, focused, hovered, rect, sanity, dragDisabled}) => {
+                        const draggable =
+                          !dragDisabled &&
+                          !!element.getAttribute('data-sanity') &&
+                          optimisticActorReady &&
+                          elements.some((e) =>
+                            'id' in e.sanity && 'id' in sanity
+                              ? sanityNodesExistInSameArray(e.sanity, sanity) &&
+                                e.sanity.path !== sanity.path
+                              : false,
+                          )
+
+                        return (
+                          <ElementOverlay
+                            componentResolver={componentResolver}
+                            element={element}
+                            enableScrollIntoView={
+                              !isDragging && !dragMinimapTransition && !dragShowMinimap
+                            }
+                            key={id}
+                            focused={focused}
+                            hovered={hovered}
+                            node={sanity}
+                            rect={rect}
+                            showActions={!inFrame}
+                            draggable={draggable}
+                            isDragging={isDragging || dragMinimapTransition}
+                            wasMaybeCollapsed={focused && wasMaybeCollapsed}
+                          />
                         )
-
-                      return (
-                        <ElementOverlay
-                          componentResolver={componentResolver}
-                          element={element}
-                          enableScrollIntoView={
-                            !isDragging && !dragMinimapTransition && !dragShowMinimap
-                          }
-                          key={id}
-                          focused={focused}
-                          hovered={hovered}
-                          node={sanity}
-                          rect={rect}
-                          showActions={!inFrame}
-                          draggable={draggable}
-                          isDragging={isDragging || dragMinimapTransition}
-                          wasMaybeCollapsed={focused && wasMaybeCollapsed}
-                        />
-                      )
-                    },
-                  )}
-
-                {isDragging && !dragMinimapTransition && (
-                  <>
-                    {dragInsertPosition && (
-                      <OverlayDragInsertMarker dragInsertPosition={dragInsertPosition} />
+                      },
                     )}
-                    {dragShowMinimapPrompt && <OverlayMinimapPrompt />}
-                    {dragGroupRect && <OverlayDragGroupRect dragGroupRect={dragGroupRect} />}
-                  </>
-                )}
-                {isDragging && dragSkeleton && <OverlayDragPreview skeleton={dragSkeleton} />}
-              </Root>
+
+                  {isDragging && !dragMinimapTransition && (
+                    <>
+                      {dragInsertPosition && (
+                        <OverlayDragInsertMarker dragInsertPosition={dragInsertPosition} />
+                      )}
+                      {dragShowMinimapPrompt && <OverlayMinimapPrompt />}
+                      {dragGroupRect && <OverlayDragGroupRect dragGroupRect={dragGroupRect} />}
+                    </>
+                  )}
+                  {isDragging && dragSkeleton && <OverlayDragPreview skeleton={dragSkeleton} />}
+                </Root>
+              </SharedStateProvider>
             </PreviewSnapshotsProvider>
           </SchemaProvider>
         </PortalProvider>

--- a/packages/visual-editing/src/ui/shared-state/SharedStateContext.ts
+++ b/packages/visual-editing/src/ui/shared-state/SharedStateContext.ts
@@ -1,0 +1,10 @@
+import {createContext} from 'react'
+import type {VisualEditingNode} from '../../types'
+import type {SharedStateStore} from './sharedStateStore'
+
+export interface SharedStateContextValue {
+  comlink?: VisualEditingNode
+  store: SharedStateStore
+}
+
+export const SharedStateContext = createContext<SharedStateContextValue | null>(null)

--- a/packages/visual-editing/src/ui/shared-state/SharedStateProvider.tsx
+++ b/packages/visual-editing/src/ui/shared-state/SharedStateProvider.tsx
@@ -1,0 +1,67 @@
+import type {SerializableObject} from '@repo/visual-editing-helpers'
+import {useEffect, useMemo, type FunctionComponent, type PropsWithChildren} from 'react'
+import type {VisualEditingNode} from '../../types'
+import {SharedStateContext} from './SharedStateContext'
+
+const createStore = (initialState: SerializableObject) => {
+  let state = initialState
+  const getState = () => state
+  const listeners = new Set<() => void>()
+  const setState = (fn: (state: SerializableObject) => SerializableObject) => {
+    state = fn(state)
+    listeners.forEach((l) => l())
+  }
+  const subscribe = (listener: () => void) => {
+    listeners.add(listener)
+    return () => listeners.delete(listener)
+  }
+  return {getState, setState, subscribe}
+}
+
+const store = createStore({})
+
+export const SharedStateProvider: FunctionComponent<
+  PropsWithChildren<{
+    comlink?: VisualEditingNode
+  }>
+> = (props) => {
+  const {comlink, children} = props
+
+  useEffect(() => {
+    return comlink?.on('presentation/shared-state', (data) => {
+      if ('value' in data) {
+        store.setState((prev) => ({...prev, [data.key]: data.value}))
+      } else {
+        store.setState((prev) => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const {[data.key]: _removed, ...rest} = prev
+          return rest
+        })
+      }
+    })
+  }, [comlink])
+
+  useEffect(() => {
+    const fetch = async () => {
+      try {
+        const value = await comlink?.fetch(
+          {type: 'visual-editing/shared-state', data: undefined},
+          {suppressWarnings: true},
+        )
+        if (value) {
+          store.setState(() => value.state)
+        }
+      } catch {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[@sanity/visual-editing]: Failed to fetch shared state. Check your version of `@sanity/presentation` is up-to-date',
+        )
+      }
+    }
+    fetch()
+  }, [comlink])
+
+  const value = useMemo(() => ({comlink, store}), [comlink])
+
+  return <SharedStateContext.Provider value={value}>{children}</SharedStateContext.Provider>
+}

--- a/packages/visual-editing/src/ui/shared-state/sharedStateStore.ts
+++ b/packages/visual-editing/src/ui/shared-state/sharedStateStore.ts
@@ -1,0 +1,27 @@
+import type {SerializableObject} from '@repo/visual-editing-helpers'
+
+export interface SharedStateStore<T extends SerializableObject = SerializableObject> {
+  getState: () => T
+  setState: (fn: (state: T) => T) => void
+  subscribe: (listener: () => void) => () => void
+}
+
+const createStore = <T extends SerializableObject>(initialState: T): SharedStateStore<T> => {
+  let state = initialState
+  const listeners = new Set<() => void>()
+
+  const getState = () => state
+  const setState = (fn: (state: T) => T) => {
+    state = fn(state)
+    listeners.forEach((l) => l())
+  }
+
+  const subscribe = (listener: () => void) => {
+    listeners.add(listener)
+    return () => listeners.delete(listener)
+  }
+
+  return {getState, setState, subscribe}
+}
+
+export const store = createStore({})

--- a/packages/visual-editing/src/ui/shared-state/useSharedState.ts
+++ b/packages/visual-editing/src/ui/shared-state/useSharedState.ts
@@ -1,0 +1,20 @@
+import {useCallback, useContext, useSyncExternalStore} from 'react'
+import {SharedStateContext} from './SharedStateContext'
+
+export function useSharedState<
+  T extends boolean | null | number | object | string | undefined | unknown = unknown,
+>(key: string): T {
+  const context = useContext(SharedStateContext)
+  if (!context) {
+    throw new Error('useSharedState must be used within a SharedStateProvider')
+  }
+
+  const {store} = context
+
+  const value = useSyncExternalStore(
+    store.subscribe,
+    useCallback(() => store.getState()[key] as T, [key, store]),
+  )
+
+  return value
+}


### PR DESCRIPTION
This one relies on #2117 (will fix the `visual-editing-page-builder-demo` deployment), and #2118 to allow mounting a component which can demonstrate how shared state is used.

I'll write more comprehensive documentation, but the TL;DR of it is:

In Presentation, you can share state by passing a key and value using the `useSharedState` hook:
```ts
import {useShatedState} from '@sanity/presentation'
const [enabled, setEnabled] = useState(false)
useSharedState('overlay-enabled', enabled)
```

Then, in your app, you can define a custom overlay component which uses an identically named hook (is this sensible?) which accepts just a single param—the key—and returns the shared value:
```ts
import {useShatedState} from '@sanity/visual-editing'
const enabled = useSharedState('overlay-enabled')
```

Video below showing how this state might be used, to optionally render more "visible" overlays:

https://github.com/user-attachments/assets/2939a4f5-9098-4040-9b60-1ee35d108d3f

Please feel free to weigh in on the API design, this isn't urgent so we might want to hold off merging until we've discussed this and #2118 a bit more.