### PR TITLE
feat(visual-editing): simplify overlay component context and props

### DIFF
--- a/apps/page-builder-demo/src/components/overlays/ExcitingTitleControl.tsx
+++ b/apps/page-builder-demo/src/components/overlays/ExcitingTitleControl.tsx
@@ -2,10 +2,14 @@
 
 import {at, set} from '@sanity/mutate'
 import {get} from '@sanity/util/paths'
-import {useDocuments, type OverlayComponent} from '@sanity/visual-editing'
+import {SanityNode, useDocuments, type OverlayComponent} from '@sanity/visual-editing'
+import {FunctionComponent, HTMLAttributes, PropsWithChildren} from 'react'
 
-export const ExcitingTitleControl: OverlayComponent = (props) => {
-  const {PointerEvents, node} = props
+export const ExcitingTitleControl: FunctionComponent<{
+  node: SanityNode
+  PointerEvents: FunctionComponent<PropsWithChildren<HTMLAttributes<HTMLDivElement>>>
+}> = (props) => {
+  const {node, PointerEvents} = props
 
   const {getDocument} = useDocuments()
   const doc = getDocument(node.id)

--- a/apps/page-builder-demo/src/components/overlays/resolver.tsx
+++ b/apps/page-builder-demo/src/components/overlays/resolver.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import {OverlayComponent, OverlayComponentResolver, useSharedState} from '@sanity/visual-editing'
+import {OverlayComponent, OverlayComponentResolver} from '@sanity/visual-editing'
 import {
   defineOverlayComponent,
+  PointerEvents,
   UnionInsertMenuOverlay,
 } from '@sanity/visual-editing/unstable_overlay-components'
 import {ExcitingTitleControl} from './ExcitingTitleControl'
@@ -21,7 +22,7 @@ export const components: OverlayComponentResolver = (props) => {
   > = [OverlayHighlight]
 
   if (type === 'string' && node.path === 'title') {
-    components.push(ExcitingTitleControl)
+    return <ExcitingTitleControl node={node} PointerEvents={PointerEvents} />
   }
 
   if (type === 'object' && node.path.endsWith('rotations')) {

--- a/packages/visual-editing/src/index.ts
+++ b/packages/visual-editing/src/index.ts
@@ -17,6 +17,7 @@ export type {
   OverlayComponentResolver,
   OverlayComponentResolverContext,
   OverlayController,
+  OverlayElementField,
   OverlayElementParent,
   OverlayEventHandler,
   OverlayMsg,

--- a/packages/visual-editing/src/next-pages-router/index.ts
+++ b/packages/visual-editing/src/next-pages-router/index.ts
@@ -8,6 +8,7 @@ export type {
   OverlayComponentProps,
   OverlayComponentResolver,
   OverlayComponentResolverContext,
+  OverlayElementField,
   OverlayElementParent,
   SanityNode,
   VisualEditingOptions,

--- a/packages/visual-editing/src/overlay-components/components/PointerEvents.tsx
+++ b/packages/visual-editing/src/overlay-components/components/PointerEvents.tsx
@@ -1,0 +1,11 @@
+import type {FunctionComponent, HTMLAttributes, PropsWithChildren} from 'react'
+
+export const PointerEvents: FunctionComponent<
+  PropsWithChildren<HTMLAttributes<HTMLDivElement>>
+> = ({children, style, ...rest}) => {
+  return (
+    <div style={{...style, pointerEvents: 'all'}} data-sanity-overlay-element {...rest}>
+      {children}
+    </div>
+  )
+}

--- a/packages/visual-editing/src/overlay-components/index.ts
+++ b/packages/visual-editing/src/overlay-components/index.ts
@@ -4,6 +4,8 @@ export type {
   ElementNode,
   OverlayComponent,
   OverlayComponentProps,
+  OverlayComponentResolverContext,
+  OverlayElementField,
   OverlayElementParent,
 } from '../types'
 export type {

--- a/packages/visual-editing/src/overlay-components/index.ts
+++ b/packages/visual-editing/src/overlay-components/index.ts
@@ -1,3 +1,4 @@
+export {PointerEvents} from './components/PointerEvents'
 export {UnionInsertMenuOverlay} from './components/UnionInsertMenuOverlay'
 export {defineOverlayComponent} from './defineOverlayComponent'
 export type {

--- a/packages/visual-editing/src/react/index.ts
+++ b/packages/visual-editing/src/react/index.ts
@@ -8,6 +8,7 @@ export type {
   OverlayComponentProps,
   OverlayComponentResolver,
   OverlayComponentResolverContext,
+  OverlayElementField,
   OverlayElementParent,
   SanityNode,
   VisualEditingOptions,

--- a/packages/visual-editing/src/remix/index.ts
+++ b/packages/visual-editing/src/remix/index.ts
@@ -8,6 +8,7 @@ export type {
   OverlayComponentProps,
   OverlayComponentResolver,
   OverlayComponentResolverContext,
+  OverlayElementField,
   OverlayElementParent,
   SanityNode,
   VisualEditingOptions,

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -420,6 +420,7 @@ export type OverlayComponentResolver<
   | T
   | {component: T; props?: Record<string, unknown>}
   | Array<T | {component: T; props?: Record<string, unknown>}>
+  | ReactElement
   | undefined
   | void
 

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -378,10 +378,33 @@ export type DisableVisualEditing = () => void
 export interface OverlayComponentResolverContext<
   P extends OverlayElementParent = OverlayElementParent,
 > {
+  /**
+   * The resolved field's document schema type
+   */
+  document: DocumentSchema
+  /**
+   * The element node that the overlay is attached to
+   */
   element: ElementNode
+  /**
+   * The resolved field schema type
+   */
+  field: OverlayElementField
+  /**
+   * Whether the overlay is focused or not
+   */
   focused: boolean
+  /**
+   * The Sanity node data that triggered the overlay
+   */
   node: SanityNode
+  /**
+   * The resolved field's parent schema type
+   */
   parent: P
+  /**
+   * A convience property, equal to `field.value.type`
+   */
   type: string
 }
 
@@ -480,11 +503,9 @@ export type ContextMenuNode =
 /**
  * @public
  */
-export interface OverlayComponentProps<P extends OverlayElementParent = OverlayElementParent> {
+export interface OverlayComponentProps<P extends OverlayElementParent = OverlayElementParent>
+  extends OverlayComponentResolverContext<P> {
   PointerEvents: FunctionComponent<PropsWithChildren<HTMLAttributes<HTMLDivElement>>>
-  element: ElementNode
-  parent: P
-  node: SanityNode
 }
 
 /**


### PR DESCRIPTION
Passes additional values in the overlay component resolver context object and the props passed to overlay components.

Specifically the schema types for the given field and that field's document (alongside the existing field's parent schema type) have been added to context, and the props now extend that context with the additional `PointerEvents` helper component.

Added some comments in the context type to better clarify what value is what.

Also adds the ability to return a `ReactElement` directly from the resolver function.