### PR TITLE
feat(visual-editing): add `defineOverlayComponents` helper function

### DIFF
--- a/packages/visual-editing/src/overlay-components/defineOverlayComponents.ts
+++ b/packages/visual-editing/src/overlay-components/defineOverlayComponents.ts
@@ -1,0 +1,8 @@
+import type {OverlayComponent, OverlayComponentResolver} from '../types'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function defineOverlayComponents<T extends OverlayComponent>(
+  resolver: OverlayComponentResolver<T>,
+): typeof resolver {
+  return resolver
+}

--- a/packages/visual-editing/src/overlay-components/index.ts
+++ b/packages/visual-editing/src/overlay-components/index.ts
@@ -1,10 +1,12 @@
 export {PointerEvents} from './components/PointerEvents'
 export {UnionInsertMenuOverlay} from './components/UnionInsertMenuOverlay'
 export {defineOverlayComponent} from './defineOverlayComponent'
+export {defineOverlayComponents} from './defineOverlayComponents'
 export type {
   ElementNode,
   OverlayComponent,
   OverlayComponentProps,
+  OverlayComponentResolver,
   OverlayComponentResolverContext,
   OverlayElementField,
   OverlayElementParent,


### PR DESCRIPTION
Adds a helper function to allow creating overlay component resolvers using a helper function:

```ts
const components = defineOverlayComponents((context) => {
  return defineOverlayComponent(SomeComponent, props)
})
```

Rather than mixing a type and fn for individual component definitions:

```ts
const components: OverlayComponentResolver = (context) => {
  return defineOverlayComponent(SomeComponent, props)
}
```

