### PR TITLE
fix(presentation): remove shared state value removal on unmount

### DIFF
--- a/packages/presentation/src/overlays/useSharedState.ts
+++ b/packages/presentation/src/overlays/useSharedState.ts
@@ -9,17 +9,11 @@ export const useSharedState = (key: string, value: Serializable): undefined => {
     throw new Error('Preview Snapshots context is missing')
   }
 
-  const {removeValue, setValue} = context
+  const {setValue} = context
 
   useEffect(() => {
     setValue(key, value)
   }, [key, value, setValue])
-
-  useEffect(() => {
-    return () => {
-      removeValue(key)
-    }
-  }, [key, removeValue])
 
   return undefined
 }


### PR DESCRIPTION
Removes the unnecessary removal of shared state values when the component using `useSharedState` unmounts.