### PR TITLE
fix(presentation): prevent controller reinit on iframe status change

### DIFF
--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -209,10 +209,12 @@ export default function PresentationTool(props: {
     }
   }, [])
 
+  const isLoading = state.iframe.status === 'loading'
+
   useEffect(() => {
     const target = iframeRef.current?.contentWindow
 
-    if (!target || state.iframe.status === 'loading') return
+    if (!target || isLoading) return
 
     const controller = createController({targetOrigin})
     controller.addTarget(target)
@@ -222,7 +224,7 @@ export default function PresentationTool(props: {
       controller.destroy()
       setController(undefined)
     }
-  }, [targetOrigin, state.iframe.status])
+  }, [targetOrigin, isLoading])
 
   useEffect(() => {
     const unsubs: Array<() => void> = []


### PR DESCRIPTION
Attempted fix for the unnecessary refresh issue users are reporting, e.g. https://github.com/sanity-io/visual-editing/issues/2087

Turns out Presentation's comlink controller was being reinitialised each time the iframe state changed due to an incorrect `useEffect` dependency.