### PR TITLE
fix(comlink): ensure nodes always accept handshake synchronize events

### DIFF
--- a/packages/comlink/src/constants.ts
+++ b/packages/comlink/src/constants.ts
@@ -4,7 +4,10 @@ import type {MessageType} from './types'
 export const DOMAIN = 'sanity/comlink'
 
 /** @internal */
-export const RESPONSE_TIMEOUT = 10000
+export const RESPONSE_TIMEOUT_DEFAULT = 3_000
+
+/** @internal */
+export const FETCH_TIMEOUT_DEFAULT = 10_000
 
 /** @internal */
 export const HEARTBEAT_INTERVAL = 1000

--- a/packages/comlink/src/controller.ts
+++ b/packages/comlink/src/controller.ts
@@ -260,8 +260,7 @@ export const createController = (input: {targetOrigin: string}): Controller => {
 
     const stop = () => {
       channels.forEach((channel) => {
-        channel.disconnect()
-        channel.stop()
+        cleanupChannel(channel as unknown as Channel<Message, Message>)
       })
     }
 

--- a/packages/comlink/src/node.ts
+++ b/packages/comlink/src/node.ts
@@ -5,7 +5,6 @@ import {
   createActor,
   emit,
   enqueueActions,
-  fromCallback,
   raise,
   setup,
   stopChild,

--- a/packages/comlink/src/request.ts
+++ b/packages/comlink/src/request.ts
@@ -8,7 +8,7 @@ import {
   type ActorRefFrom,
   type AnyActorRef,
 } from 'xstate'
-import {MSG_RESPONSE, RESPONSE_TIMEOUT} from './constants'
+import {MSG_RESPONSE, RESPONSE_TIMEOUT_DEFAULT} from './constants'
 import type {Message, MessageData, MessageType, ProtocolMessage, ResponseMessage} from './types'
 
 const throwOnEvent =
@@ -34,6 +34,7 @@ export interface RequestMachineContext<S extends Message> {
   parentRef: AnyActorRef
   resolvable: PromiseWithResolvers<S['response']> | undefined
   response: S['response'] | null
+  responseTimeout: number | undefined
   responseTo: string | undefined
   signal: AbortSignal | undefined
   suppressWarnings: boolean | undefined
@@ -82,6 +83,7 @@ export const createRequestMachine = <
         from: string
         parentRef: AnyActorRef
         resolvable?: PromiseWithResolvers<S['response']>
+        responseTimeout?: number
         responseTo?: string
         signal?: AbortSignal
         sources: Set<MessageEventSource> | MessageEventSource
@@ -176,7 +178,7 @@ export const createRequestMachine = <
     },
     delays: {
       initialTimeout: 0,
-      responseTimeout: RESPONSE_TIMEOUT,
+      responseTimeout: ({context}) => context.responseTimeout ?? RESPONSE_TIMEOUT_DEFAULT,
     },
   }).createMachine({
     /** @xstate-layout N4IgpgJg5mDOIC5QAoC2BDAxgCwJYDswBKAOlwgBswBiAD1gBd0GwT0AzFgJ2QNwdzoKAFVyowAewCuDItTRY8hUuSoBtAAwBdRKAAOE2P1wT8ukLUQBGAEwBWEgBYAnK+eOAzB7sB2DzY8rABoQAE9rDQc3V0cNTw8fAA4NHwBfVJCFHAJiElgwfAgCKGpNHSQQAyMBU3NLBDsrDxI7DTaAjQA2OOcNDxDwhHsNJx9Ou0TOq2cJxP9HdMyMbOU8gqL8ErUrcv1DY1qK+sbm1vaPLp6+gcRnGydo9wDGycWQLKVc9AB3dGNN6jiWCwdAwMrmKoHMxHRCJRKOEiJHwuZKBZwXKzBMKIGyYkhtAkXOweTqOHw2RJvD45Ug-P4CAH0JgsNicMA8LhwAz4fKicTSWTyZafWm-f5QcEVSE1aGgepwhFIlF9aYYrGDC4+JzEppjGzOUkeGbpDIgfASCBwczU5QQ-YyuqIAC0nRuCBd+IJXu9KSpwppZEoYDt1RMsosiEcNjdVjiJEeGisiSTHkcVgWpptuXyhWKIahjqGzi1BqRJINnVcdkcbuTLS9VYC8ISfsUAbp4vzDphCHJIyjBvJNlxNmRNexQ3sJGH43GPj8jWJrZWuXYfyoEC7YcLsbrgRsjkcvkmdgNbopVhIPhVfnsh8ClMz-tWsCkmEwcHgUvt257u8v+6Hse4xnhOdZnImVidPqCRNB4JqpEAA */
@@ -191,6 +193,7 @@ export const createRequestMachine = <
         parentRef: input.parentRef,
         resolvable: input.resolvable,
         response: null,
+        responseTimeout: input.responseTimeout,
         responseTo: input.responseTo,
         signal: input.signal,
         sources: input.sources instanceof Set ? input.sources : new Set([input.sources]),

--- a/packages/comlink/src/types.ts
+++ b/packages/comlink/src/types.ts
@@ -46,6 +46,7 @@ export interface RequestData<S extends Message> {
   type: MessageType
   resolvable?: PromiseWithResolvers<S['response']>
   options?: {
+    responseTimeout?: number
     signal?: AbortSignal
     suppressWarnings?: boolean
   }


### PR DESCRIPTION
Currently, comlink's node state machine will only handle syn handshake events when in an `idle` state. In some situations, the controller or some of the channels it maintains may detect a loss of connection and transition to a `handshaking` state, the disconnect event emitted at this point may then fail to reach the relevant node(s), and thus the node will remain in a `connected` state, as the nodes themselves only blindly respond to heartbeat events.

This PR adds a change so that the node state machine will _always_ transition to its internal `handshaking` state when receiving a syn handshake event, regardless of the state it is currently in. This should greatly improve the success rate of attempt reconnects. For example you may have noticed in our test environments that the connection is often lost after a HMR, this should no longer be the case.

It also drops the default expected response timeout to 3s from 10s for requests for all requests that expect a response except for those initiated with `.fetch` (which remains at 10s).