### PR TITLE
feat(visual-editing): add async getSnapshot to optimistic documents

### DIFF
--- a/apps/page-builder-demo/src/components/overlays/ExcitingTitleControl.tsx
+++ b/apps/page-builder-demo/src/components/overlays/ExcitingTitleControl.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import {at, set} from '@sanity/mutate'
 import {get} from '@sanity/util/paths'
 import {SanityNode, useDocuments, type OverlayComponent} from '@sanity/visual-editing'
@@ -15,8 +13,12 @@ export const ExcitingTitleControl: FunctionComponent<{
   const doc = getDocument(node.id)
 
   const onChange = () => {
-    doc.patch(({snapshot}) => {
-      const currentValue = get(snapshot, node.path)
+    doc.patch(async ({getSnapshot}) => {
+      const snapshot = await getSnapshot()
+      const currentValue = get<string>(snapshot, node.path)
+      if (currentValue?.endsWith('!')) {
+        return []
+      }
       const newValue = `${currentValue}!`
       return [at(node.path, set(newValue))]
     })

--- a/apps/page-builder-demo/src/components/page/DnDCustomBehaviour.tsx
+++ b/apps/page-builder-demo/src/components/page/DnDCustomBehaviour.tsx
@@ -40,7 +40,8 @@ export function DnDCustomBehaviour() {
         // Don't patch if the keys match, as this means the item was only
         // dragged to its existing position, i.e. not moved
         if (arrayPath && referenceItemKey && referenceItemKey !== targetKey) {
-          doc.patch(({snapshot}) => {
+          doc.patch(async ({getSnapshot}) => {
+            const snapshot = await getSnapshot()
             // Get the current value of the element we dragged, as we will need
             // to clone this into the new position
             const elementValue = getFromPath(snapshot, target.path)

--- a/apps/remix/app/CustomControlsComponent.tsx
+++ b/apps/remix/app/CustomControlsComponent.tsx
@@ -11,8 +11,9 @@ export const CustomControlsComponent: OverlayComponent = (props) => {
       title: string
     }>(node.id)
 
-    doc.patch(({snapshot}) => {
-      const newValue = `${snapshot.title}!`
+    doc.patch(async ({getSnapshot}) => {
+      const snapshot = await getSnapshot()
+      const newValue = `${snapshot?.title}!`
       return [at(node.path, set(newValue))]
     })
   }

--- a/packages/visual-editing/src/index.ts
+++ b/packages/visual-editing/src/index.ts
@@ -58,6 +58,7 @@ export {
   type DocumentsGet,
   type DocumentsMutate,
   type OptimisticDocument,
+  type OptimisticDocumentPatches,
   type OptimisticReducer,
   type OptimisticReducerAction,
   type Path,

--- a/packages/visual-editing/src/ui/optimistic-state/index.ts
+++ b/packages/visual-editing/src/ui/optimistic-state/index.ts
@@ -3,6 +3,7 @@ export {
   type DocumentsGet,
   type DocumentsMutate,
   type OptimisticDocument,
+  type OptimisticDocumentPatches,
   type Path,
   type PathValue,
 } from './useDocuments'

--- a/packages/visual-editing/src/ui/optimistic-state/machines/createSharedListener.ts
+++ b/packages/visual-editing/src/ui/optimistic-state/machines/createSharedListener.ts
@@ -1,5 +1,5 @@
 import {type ListenEvent} from '@sanity/client'
-import {merge, Observable, ReplaySubject, Subject, type ObservedValueOf} from 'rxjs'
+import {merge, ReplaySubject, Subject, type Observable, type ObservedValueOf} from 'rxjs'
 import type {VisualEditingNode} from '../../../types'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/visual-editing/src/ui/optimistic-state/machines/datasetMutatorMachine.ts
+++ b/packages/visual-editing/src/ui/optimistic-state/machines/datasetMutatorMachine.ts
@@ -11,6 +11,7 @@ import {
   type DocumentMutatorMachineParentEvent,
 } from '@sanity/mutate/_unstable_machine'
 import {assertEvent, assign, emit, setup, stopChild, type ActorRefFrom} from 'xstate'
+import type {createDocumentMutator} from '../../comlink'
 
 export interface DatasetMutatorMachineInput extends Omit<DocumentMutatorMachineInput, 'id'> {
   client: SanityClient
@@ -24,7 +25,7 @@ export const datasetMutatorMachine = setup({
       client: SanityClient
       /** A shared listener can be provided, if not it'll be created using `client.listen()` */
       sharedListener?: ReturnType<typeof createSharedListener>
-      documents: Record<string, ActorRefFrom<typeof documentMutatorMachine>>
+      documents: Record<string, ActorRefFrom<ReturnType<typeof createDocumentMutator>>>
     }
     events:
       | {type: 'observe'; documentId: string}

--- a/packages/visual-editing/src/util/mutations.ts
+++ b/packages/visual-editing/src/util/mutations.ts
@@ -87,18 +87,17 @@ export function getArrayInsertPatches(
   return [at(arrayPath, insert([{_type: insertType, _key: insertKey}], position, referenceItem))]
 }
 
-export function getArrayMovePatches(
+export async function getArrayMovePatches(
   node: SanityNode,
   doc: OptimisticDocument,
   moveTo: 'previous' | 'next' | 'first' | 'last',
-): NodePatchList {
+): Promise<NodePatchList> {
   if (!node.type) throw new Error('Node type is missing')
   const {path: arrayPath, key: itemKey} = getArrayItemKeyAndParentPath(node)
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore - Type instantiation is excessively deep and possibly infinite.
-  const array = doc.get(arrayPath) as {_key: string}[]
-  const item = doc.get(node.path)
+  const snapshot = await doc.getSnapshot()
+  const array = get(snapshot, arrayPath) as {_key: string}[]
+  const item = get(snapshot, node.path)
   const currentIndex = array.findIndex((item) => item._key === itemKey)
 
   let nextIndex = -1

--- a/packages/visual-editing/src/util/useDragEvents.ts
+++ b/packages/visual-editing/src/util/useDragEvents.ts
@@ -46,7 +46,8 @@ export function useDragEndEvents(): {
         // Don't patch if the keys match, as this means the item was only
         // dragged to its existing position, i.e. not moved
         if (arrayPath && referenceItemKey && referenceItemKey !== targetKey) {
-          doc.patch(({snapshot}) => {
+          doc.patch(async ({getSnapshot}) => {
+            const snapshot = await getSnapshot()
             // Get the current value of the element we dragged, as we will need
             // to clone this into the new position
             const elementValue = getFromPath(snapshot, target.path)


### PR DESCRIPTION
This is kind of a fix dressed up as a feat.

Accessing optimistic document snapshots is currently error prone as it is assumed the snapshot will be available, in actual fact it may not be as snapshots have to be fetched from Content Lake via Presentation tool. In most situations this is fine as user interaction is required to trigger some document snapshot getter and so will _likely_ not occur immediately

`doc.get()` returns a snapshot and throws if the snapshot is unavailable. This is now deprecated.

`doc.getSnapshot()` replaces it. It returns a promise which is resolved when the snapshot is actually returned.

As a result the Context Menu now has a loading state (video below demonstrates this with an artificial 5s delay added to snapshot fetching), and interactions like drag and drop will await the snapshot resolution before patches are applied, rather than just throwing.

Similarly `doc.patch((context) => {...}` will currently throw if used before snapshots have been fetched. In this PR `snapshot` is deprecated but still available on this context object, however the property has been replaced with a getter so that it will not throw unless explicitly accessed. `snapshot` is replaced with `getSnapshot` which similarly returns a promise.

https://github.com/user-attachments/assets/38ad7c1b-68b8-4d17-95f9-da2ee5523ff3