### PR TITLE
fix(visual-editing): unset overlay applied cursor on mouseleave

### DIFF
--- a/apps/page-builder-demo/src/components/page/sections/Hero.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/Hero.tsx
@@ -14,6 +14,7 @@ export function Hero(props: {page: PageData; section: HeroSectionData}) {
         path: `sections[_key=="${section._key}"]`,
       }).toString()}
       className="relative flex items-center justify-center px-4 py-6 sm:px-5 sm:py-7 md:px-7 md:py-9"
+      style={{cursor: 'crosshair'}} // Useful for testing overlay cursor overrides
       variant={section.style?.variant}
     >
       <div className="relative z-10 p-5 text-center backdrop-blur-xl">

--- a/packages/visual-editing/src/controller.ts
+++ b/packages/visual-editing/src/controller.ts
@@ -127,7 +127,17 @@ export function createOverlayController({
     })
   }
 
-  function setOverlayCursor() {
+  function setOverlayCursor(element: ElementNode, remove?: boolean) {
+    if (remove) {
+      handler({
+        type: 'overlay/setCursor',
+        element,
+        cursor: undefined,
+      })
+
+      return
+    }
+
     if (!inFrame || !optimisticActorReady) return
 
     const hoveredElement = getHoveredElement()
@@ -149,7 +159,7 @@ export function createOverlayController({
 
     handler({
       type: 'overlay/setCursor',
-      element: hoveredElement,
+      element,
       cursor,
     })
   }
@@ -272,7 +282,7 @@ export function createOverlayController({
           rect: getRect(element),
         })
 
-        setOverlayCursor()
+        setOverlayCursor(element)
       },
       mouseleave(e) {
         function leave() {
@@ -295,7 +305,7 @@ export function createOverlayController({
             }
           }
 
-          setOverlayCursor()
+          setOverlayCursor(element, true)
         }
 
         /**

--- a/packages/visual-editing/src/controller.ts
+++ b/packages/visual-editing/src/controller.ts
@@ -171,7 +171,7 @@ export function createOverlayController({
     }
   }
 
-  function removeOverlayCursor(element: ElementNode) {
+  function restoreOverlayCursor(element: ElementNode) {
     // Restore any previously stored cursor (if it exists)
     const previousCursor = cursorMap.get(element)
 
@@ -323,7 +323,7 @@ export function createOverlayController({
             }
           }
 
-          removeOverlayCursor(element)
+          restoreOverlayCursor(element)
         }
 
         /**

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -122,7 +122,7 @@ export type OverlayMsgDeactivate = Msg<'overlay/deactivate'>
 /** @public */
 export type OverlayMsgSetCursor = Msg<'overlay/setCursor'> & {
   element: ElementNode
-  cursor: string
+  cursor: string | undefined
 }
 
 /** @public */

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -136,7 +136,11 @@ const OverlaysController: FunctionComponent<{
       } else if (message.type === 'overlay/setCursor') {
         const {element, cursor} = message
 
-        element.style.cursor = cursor
+        if (cursor) {
+          element.style.cursor = cursor
+        } else {
+          element.style.removeProperty('cursor')
+        }
       }
 
       dispatch(message)


### PR DESCRIPTION
Fix for #2179. This unsets the cursor style when `mouseleave`-ing an overlay element.  Previously on `mouseleave` the element was specified as the `hoveredElement`, which I think would be the element that the cursor was entering after leaving the one we want to reset?

Two questions:
1. Should we only set cursor to `auto` on child elements of drag groups?
2. As this manipulates the DOM outside of our visual editing element, should we store and revert to any user set cursor style value?

@georgedoescode I've assigned this to you as you'll know the original intention!