### PR TITLE
fix: prevent disconnect on window context close

### DIFF
--- a/packages/comlink/src/channel.ts
+++ b/packages/comlink/src/channel.ts
@@ -50,7 +50,7 @@ export type ChannelActor<R extends Message, S extends Message> = ActorRefFrom<
 /**
  * @public
  */
-export type Channel<R extends Message, S extends Message> = {
+export type Channel<R extends Message = Message, S extends Message = Message> = {
   actor: ChannelActor<R, S>
   connect: () => void
   disconnect: () => void
@@ -540,4 +540,14 @@ export const createChannel = <R extends Message, S extends Message>(
       return actor.getSnapshot().context.target
     },
   }
+}
+
+// Helper function to cleanup a channel
+export const cleanupChannel: (channel: Channel<Message, Message>) => void = (channel) => {
+  channel.disconnect()
+  // Necessary to allow disconnect messages to be sent before the channel
+  // actor is stopped
+  setTimeout(() => {
+    channel.stop()
+  }, 0)
 }

--- a/packages/presentation/src/PresentationTool.tsx
+++ b/packages/presentation/src/PresentationTool.tsx
@@ -66,6 +66,7 @@ import type {
 import {useDocumentsOnPage} from './useDocumentsOnPage'
 import {useMainDocument} from './useMainDocument'
 import {useParams} from './useParams'
+import {usePopups} from './usePopups'
 import {usePreviewUrl} from './usePreviewUrl'
 import {useStatus} from './useStatus'
 
@@ -194,20 +195,11 @@ export default function PresentationTool(props: {
     resolvers: tool.options?.resolve?.mainDocuments,
   })
 
-  // const [overlaysConnection, setOverlaysConnection] = useState<Status>('connecting')
   const [overlaysConnection, setOverlaysConnection] = useStatus()
-  // const [loadersConnection, setLoadersConnection] = useState<Status>('connecting')
   const [loadersConnection, setLoadersConnection] = useStatus()
-  // const [previewKitConnection, setPreviewKitConnection] = useState<Status>('connecting')
   const [previewKitConnection, setPreviewKitConnection] = useStatus()
 
-  const [popups, setPopups] = useState<Set<Window>>(() => new Set())
-  const handleOpenPopup = useCallback((url: string) => {
-    const source = window.open(url, '_blank')
-    if (source) {
-      setPopups((prev) => new Set(prev).add(source))
-    }
-  }, [])
+  const {open: handleOpenPopup} = usePopups(controller)
 
   const isLoading = state.iframe.status === 'loading'
 
@@ -225,21 +217,6 @@ export default function PresentationTool(props: {
       setController(undefined)
     }
   }, [targetOrigin, isLoading])
-
-  useEffect(() => {
-    const unsubs: Array<() => void> = []
-    if (popups.size && controller) {
-      // loop popups and add targets
-      for (const source of popups) {
-        if (source && 'closed' in source && !source.closed) {
-          unsubs.push(controller.addTarget(source))
-        }
-      }
-    }
-    return () => {
-      unsubs.forEach((unsub) => unsub())
-    }
-  }, [controller, popups])
 
   useEffect(() => {
     if (!controller) return

--- a/packages/presentation/src/constants.ts
+++ b/packages/presentation/src/constants.ts
@@ -24,6 +24,9 @@ export const LIVE_QUERY_CACHE_BATCH_SIZE = 100
 // Total cache size for documents that are live queried
 export const LIVE_QUERY_CACHE_SIZE = 2048
 
+// The interval at which we check if existing popups have been closed
+export const POPUP_CHECK_INTERVAL = 1000 // ms
+
 declare global {
   const PRESENTATION_ENABLE_LIVE_DRAFT_EVENTS: unknown
 }

--- a/packages/presentation/src/usePopups.ts
+++ b/packages/presentation/src/usePopups.ts
@@ -1,0 +1,83 @@
+import type {Controller} from '@sanity/comlink'
+import {useCallback, useEffect, useState} from 'react'
+import {POPUP_CHECK_INTERVAL} from './constants'
+
+/**
+ * A hook for managing popup Window contexts
+ *
+ * This hook handles:
+ * - Opening new popup Windows, and adding them as targets to the controller
+ * - Tracking existing popup windows, and cleaning up closed popups
+ *
+ * @param controller - Comlink controller instance that manages communication
+ * between Window contexts
+ *
+ * @returns An object containing:
+ * - popups: A Set of currently open popup Window objects
+ * - open: Function to open a new popup Window with the specified URL
+ *
+ */
+export const usePopups = (
+  controller?: Controller,
+): {
+  popups: Set<Window>
+  open: (url: string) => void
+} => {
+  // State to keep track of open popup windows
+  const [popups, setPopups] = useState<Set<Window>>(() => new Set())
+
+  // Function to open a new popup window
+  const open = useCallback((url: string) => {
+    const source = window.open(url, '_blank')
+    if (source) {
+      setPopups((prev) => new Set(prev).add(source))
+    }
+  }, [])
+
+  // Handles syncing the existing popups with the controller
+  useEffect(() => {
+    const unsubs: Array<() => void> = []
+    if (popups.size && controller) {
+      // loop popups and add targets
+      for (const source of popups) {
+        if (source && 'closed' in source && !source.closed) {
+          unsubs.push(controller.addTarget(source))
+        }
+      }
+    }
+    return () => {
+      unsubs.forEach((unsub) => unsub())
+    }
+  }, [controller, popups])
+
+  // Checks for closed popups and removes them from the tracked Set
+  useEffect(() => {
+    if (popups.size) {
+      const interval = setInterval(() => {
+        const closed = new Set<Window>()
+        for (const source of popups) {
+          if (source && 'closed' in source && source.closed) {
+            closed.add(source)
+          }
+        }
+        if (closed.size) {
+          setPopups((prev) => {
+            const next = new Set(prev)
+            for (const source of closed) {
+              next.delete(source)
+            }
+            return next
+          })
+        }
+      }, POPUP_CHECK_INTERVAL)
+
+      return () => {
+        clearInterval(interval)
+      }
+    }
+
+    return
+  }, [popups])
+
+  return {popups, open}
+}

--- a/packages/presentation/src/useStatus.ts
+++ b/packages/presentation/src/useStatus.ts
@@ -1,29 +1,52 @@
 import type {Status, StatusEvent} from '@sanity/comlink'
 import {useCallback, useMemo, useState} from 'react'
 
+/**
+ * A hook that manages and returns the connection status of multiple channels
+ *
+ * @returns {[string, (event: StatusEvent) => void]} - An array containing the
+ * current status and a function to update the status based on incoming events
+ *
+ * The status can be one of the following:
+ * - 'connected': If any channel is connected
+ * - 'connecting': If the first connection is being established
+ * - 'reconnecting': If a reconnection is in progress
+ * - 'idle': If no connections have been made yet
+ *
+ * The function to update the status takes a `StatusEvent` object which includes
+ * the channel and the status
+ */
 export function useStatus(): [string, (event: StatusEvent) => void] {
+  // State to keep track of the status of each channel
   const [statusMap, setStatusMap] = useState(
     new Map<string, {status: Status; hasConnected: boolean}>(),
   )
 
+  // Memoized computation of the overall status based on the status of individual channels
   const status = useMemo(() => {
     const values = Array.from(statusMap.values())
+    // If any channel is connected, return the `connected` status
+    if (values.find(({status}) => status === 'connected')) {
+      return 'connected'
+    }
+    // If the initial connection is being established, return `connecting` status
     const handshaking = values.filter(({status}) => status === 'handshaking')
     if (handshaking.length) {
       return handshaking.some(({hasConnected}) => !hasConnected) ? 'connecting' : 'reconnecting'
     }
-    if (values.find(({status}) => status === 'connected')) {
-      return 'connected'
-    }
+    // If nothing has happened yet, return `idle` status
     return 'idle'
   }, [statusMap])
 
+  // Callback to update the status map based on the received event
   const setStatusFromEvent = useCallback((event: StatusEvent) => {
     setStatusMap((prev) => {
       const next = new Map(prev)
       if (event.status === 'disconnected') {
+        // Remove the channel from the map if a disconnect event is received
         next.delete(event.channel)
       } else {
+        // Update the status and connection flag for the channel
         const hasConnected = next.get(event.channel)?.hasConnected || event.status === 'connected'
         next.set(event.channel, {status: event.status, hasConnected})
       }
@@ -31,5 +54,6 @@ export function useStatus(): [string, (event: StatusEvent) => void] {
     })
   }, [])
 
+  // Return the overall status and the function to update the status
   return [status, setStatusFromEvent]
 }


### PR DESCRIPTION
To address this issue: https://github.com/sanity-io/next-sanity/issues/1950

Uses a `setInterval` to detect when opened window contexts have closed, so that we don't try to maintain connections to closed popups.

Also includes a small comlink improvement to correctly cleanup unused connections.