### PR TITLE
fix: use CSS view transition for viewport iframe toggling

### DIFF
--- a/apps/page-builder-demo/src/sanity.types.ts
+++ b/apps/page-builder-demo/src/sanity.types.ts
@@ -771,6 +771,104 @@ export type ProjectsPageQueryResult = Array<{
   slug?: Slug
 }>
 
+// Source: ./src/app/product/[slug]/page.tsx
+// Variable: productSlugsQuery
+// Query: *[_type == "product" && defined(slug.current)]{"slug": slug.current}
+export type ProductSlugsQueryResult = Array<{
+  slug: string | null
+}>
+// Variable: productPageQuery
+// Query: *[_type == "product" && slug.current == $slug][0]
+export type ProductPageQueryResult = {
+  _id: string
+  _type: 'product'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+  slug?: Slug
+  media?: Array<{
+    asset?: {
+      _ref: string
+      _type: 'reference'
+      _weak?: boolean
+      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
+    }
+    hotspot?: SanityImageHotspot
+    crop?: SanityImageCrop
+    alt?: string
+    _type: 'image'
+    _key: string
+  }>
+  description?: Array<{
+    children?: Array<{
+      marks?: Array<string>
+      text?: string
+      _type: 'span'
+      _key: string
+    }>
+    style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
+    listItem?: 'bullet' | 'number'
+    markDefs?: Array<{
+      href?: string
+      _type: 'link'
+      _key: string
+    }>
+    level?: number
+    _type: 'block'
+    _key: string
+  }>
+  brandReference?: unknown
+  details?: {
+    materials?: string
+    collectionNotes?: Array<{
+      children?: Array<{
+        marks?: Array<string>
+        text?: string
+        _type: 'span'
+        _key: string
+      }>
+      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
+      listItem?: 'bullet' | 'number'
+      markDefs?: Array<{
+        href?: string
+        _type: 'link'
+        _key: string
+      }>
+      level?: number
+      _type: 'block'
+      _key: string
+    }>
+    performance?: Array<{
+      children?: Array<{
+        marks?: Array<string>
+        text?: string
+        _type: 'span'
+        _key: string
+      }>
+      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
+      listItem?: 'bullet' | 'number'
+      markDefs?: Array<{
+        href?: string
+        _type: 'link'
+        _key: string
+      }>
+      level?: number
+      _type: 'block'
+      _key: string
+    }>
+    ledLifespan?: string
+    certifications?: Array<string>
+  }
+  variants?: Array<{
+    title?: string
+    price?: string
+    sku?: string
+    _type: 'variant'
+    _key: string
+  }>
+} | null
+
 // Source: ./src/app/pages/[slug]/page.tsx
 // Variable: pageQuery
 // Query: *[_type == "page" && slug.current == $slug][0]{    _type,    _id,    title,    sections[]{      ...,      symbol->{_type},      'headline': coalesce(headline, symbol->headline),      'tagline': coalesce(tagline, symbol->tagline),      'subline': coalesce(subline, symbol->subline),      'image': coalesce(image, symbol->image),      product->{        _type,        _id,        title,        slug,        "media": media[0]      },      products[]{        _key,        ...(@->{          _type,          _id,          title,          slug,          "media": media[0]        })      }    },    style  }
@@ -919,104 +1017,6 @@ export type PageSlugsResult = Array<{
   slug: string | null
 }>
 
-// Source: ./src/app/product/[slug]/page.tsx
-// Variable: productSlugsQuery
-// Query: *[_type == "product" && defined(slug.current)]{"slug": slug.current}
-export type ProductSlugsQueryResult = Array<{
-  slug: string | null
-}>
-// Variable: productPageQuery
-// Query: *[_type == "product" && slug.current == $slug][0]
-export type ProductPageQueryResult = {
-  _id: string
-  _type: 'product'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  title?: string
-  slug?: Slug
-  media?: Array<{
-    asset?: {
-      _ref: string
-      _type: 'reference'
-      _weak?: boolean
-      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
-    }
-    hotspot?: SanityImageHotspot
-    crop?: SanityImageCrop
-    alt?: string
-    _type: 'image'
-    _key: string
-  }>
-  description?: Array<{
-    children?: Array<{
-      marks?: Array<string>
-      text?: string
-      _type: 'span'
-      _key: string
-    }>
-    style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
-    listItem?: 'bullet' | 'number'
-    markDefs?: Array<{
-      href?: string
-      _type: 'link'
-      _key: string
-    }>
-    level?: number
-    _type: 'block'
-    _key: string
-  }>
-  brandReference?: unknown
-  details?: {
-    materials?: string
-    collectionNotes?: Array<{
-      children?: Array<{
-        marks?: Array<string>
-        text?: string
-        _type: 'span'
-        _key: string
-      }>
-      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
-      listItem?: 'bullet' | 'number'
-      markDefs?: Array<{
-        href?: string
-        _type: 'link'
-        _key: string
-      }>
-      level?: number
-      _type: 'block'
-      _key: string
-    }>
-    performance?: Array<{
-      children?: Array<{
-        marks?: Array<string>
-        text?: string
-        _type: 'span'
-        _key: string
-      }>
-      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
-      listItem?: 'bullet' | 'number'
-      markDefs?: Array<{
-        href?: string
-        _type: 'link'
-        _key: string
-      }>
-      level?: number
-      _type: 'block'
-      _key: string
-    }>
-    ledLifespan?: string
-    certifications?: Array<string>
-  }
-  variants?: Array<{
-    title?: string
-    price?: string
-    sku?: string
-    _type: 'variant'
-    _key: string
-  }>
-} | null
-
 // Source: ./src/app/project/[slug]/page.tsx
 // Variable: projectSlugsQuery
 // Query: *[_type == "project" && defined(slug.current)]{"slug": slug.current}
@@ -1042,10 +1042,10 @@ declare module '@sanity/client' {
     '\n  *[_type == "dndTestPage"]{\n    _id,\n    title,\n    children\n  }[0]\n': DndPageQueryResult
     '\n  *[_type == "product" && defined(slug.current)]{\n    _id,\n    title,\n    description,\n    slug,\n    "media": media[0]\n  }\n': ProductsPageQueryResult
     '*[_type == "project" && defined(slug.current)]': ProjectsPageQueryResult
-    "\n  *[_type == \"page\" && slug.current == $slug][0]{\n    _type,\n    _id,\n    title,\n    sections[]{\n      ...,\n      symbol->{_type},\n      'headline': coalesce(headline, symbol->headline),\n      'tagline': coalesce(tagline, symbol->tagline),\n      'subline': coalesce(subline, symbol->subline),\n      'image': coalesce(image, symbol->image),\n      product->{\n        _type,\n        _id,\n        title,\n        slug,\n        \"media\": media[0]\n      },\n      products[]{\n        _key,\n        ...(@->{\n          _type,\n          _id,\n          title,\n          slug,\n          \"media\": media[0]\n        })\n      }\n    },\n    style\n  }\n": PageQueryResult
-    '*[_type == "page" && defined(slug.current)]{"slug": slug.current}': PageSlugsResult
     '*[_type == "product" && defined(slug.current)]{"slug": slug.current}': ProductSlugsQueryResult
     '*[_type == "product" && slug.current == $slug][0]': ProductPageQueryResult
+    "\n  *[_type == \"page\" && slug.current == $slug][0]{\n    _type,\n    _id,\n    title,\n    sections[]{\n      ...,\n      symbol->{_type},\n      'headline': coalesce(headline, symbol->headline),\n      'tagline': coalesce(tagline, symbol->tagline),\n      'subline': coalesce(subline, symbol->subline),\n      'image': coalesce(image, symbol->image),\n      product->{\n        _type,\n        _id,\n        title,\n        slug,\n        \"media\": media[0]\n      },\n      products[]{\n        _key,\n        ...(@->{\n          _type,\n          _id,\n          title,\n          slug,\n          \"media\": media[0]\n        })\n      }\n    },\n    style\n  }\n": PageQueryResult
+    '*[_type == "page" && defined(slug.current)]{"slug": slug.current}': PageSlugsResult
     '*[_type == "project" && defined(slug.current)]{"slug": slug.current}': ProjectSlugsQueryResult
     '*[_type == "project" && slug.current == $slug][0]': ProjectPageQueryResult
   }

--- a/packages/presentation/src/preview/IFrame.tsx
+++ b/packages/presentation/src/preview/IFrame.tsx
@@ -1,16 +1,14 @@
 import {Box} from '@sanity/ui'
 import {motion, type VariantLabels, type Variants} from 'framer-motion'
-import {forwardRef, type ReactEventHandler} from 'react'
+import {forwardRef, useId, type ReactEventHandler} from 'react'
 import {styled} from 'styled-components'
 
 const IFrameElement = motion(styled.iframe`
   box-shadow: 0 0 0 1px var(--card-border-color);
-  border-top: 1px solid transparent;
-  border-bottom: 0;
-  border-right: 0;
-  border-left: 0;
+  border: 0;
   max-height: 100%;
   width: 100%;
+  view-transition-class: presentation-tool-iframe;
 `)
 
 const IFrameOverlay = styled(Box)`
@@ -26,14 +24,22 @@ interface IFrameProps {
   preventClick: boolean
   src: string
   variants: Variants
+  style: React.CSSProperties
 }
 
 export const IFrame = forwardRef<HTMLIFrameElement, IFrameProps>(function IFrame(props, ref) {
-  const {animate, initial, onLoad, preventClick, src, variants} = props
+  const {animate, initial, onLoad, preventClick, src, variants, style} = props
+  const id = useId()
 
   return (
     <>
       <IFrameElement
+        style={{
+          ...style,
+          // useId() guarantees that the ID will be unique, even if we add support for multiple iframe instances,
+          // while `view-transition-class: presentation-tool-iframe` provides userland a way to customize the transition with CSS if they wish
+          viewTransitionName: `presentation-tool-iframe-${id.replace(/[^a-zA-Z0-9-_]/g, '_')}`,
+        }}
         animate={animate}
         initial={initial}
         onLoad={onLoad}

--- a/packages/presentation/src/preview/PreviewHeader.tsx
+++ b/packages/presentation/src/preview/PreviewHeader.tsx
@@ -390,7 +390,7 @@ const PreviewHeader: FunctionComponent<
     : renderDefault(props)
 
   return (
-    <Card flex="none" padding={2} shadow={1} style={{position: 'relative'}}>
+    <Card flex="none" padding={2} borderBottom style={{position: 'relative'}}>
       <Flex align="center" style={{minHeight: 0}}>
         {header}
       </Flex>


### PR DESCRIPTION
Whenever the preview is showing a layout that isn't super simple the viewport transition is quite janky and jarring:


https://github.com/user-attachments/assets/c11f4d32-7b9c-4199-89f8-2cef21658f4f

By moving it to CSS View Transitions instead of having Framer Motion animate the `<iframe>` `width` and `height` it's much smoother:


https://github.com/user-attachments/assets/def0e72b-360a-4649-b65f-fe374c196ff2

