### PR TITLE
fix(comlink): require data param if defined on post and fetch methods

### DIFF
--- a/packages/comlink/src/connection.ts
+++ b/packages/comlink/src/connection.ts
@@ -62,7 +62,9 @@ export type Connection<S extends Message = Message, R extends Message = Message>
     handler: (event: U['data']) => Promise<U['response']> | U['response'],
   ) => () => void
   onStatus: (handler: (status: Status) => void) => () => void
-  post: <T extends S['type'], U extends Extract<S, {type: T}>>(type: T, data?: U['data']) => void
+  post: <T extends S['type'], U extends Extract<S, {type: T}>>(
+    ...params: (U['data'] extends undefined ? [T] : never) | [T, U['data']]
+  ) => void
   setTarget: (target: MessageEventSource) => void
   start: () => () => void
   stop: () => void
@@ -510,7 +512,10 @@ export const createConnection = <S extends Message, R extends Message>(
     actor.send({type: 'target.set', target})
   }
 
-  const post = <T extends S['type'], U extends Extract<S, {type: T}>>(type: T, data: U['data']) => {
+  const post = <T extends S['type'], U extends Extract<S, {type: T}>>(
+    type: T,
+    data?: U['data'],
+  ) => {
     const _data = {type, data} as WithoutResponse<U>
     actor.send({type: 'post', data: _data})
   }

--- a/packages/comlink/src/controller.ts
+++ b/packages/comlink/src/controller.ts
@@ -29,7 +29,9 @@ export interface ChannelInstance<S extends Message, R extends Message> {
     handler: (event: U) => void,
   ) => () => void
   onStatus: (handler: (event: StatusEvent) => void) => void
-  post: <T extends S['type'], U extends Extract<S, {type: T}>>(type: T, data?: U['data']) => void
+  post: <T extends S['type'], U extends Extract<S, {type: T}>>(
+    ...params: (U['data'] extends undefined ? [T] : never) | [T, U['data']]
+  ) => void
   start: () => () => void
   stop: () => void
 }
@@ -198,7 +200,8 @@ export const createController = (input: {targetOrigin: string}): Controller => {
       connections.add(connection)
     }
 
-    const post: ChannelInstance<S, R>['post'] = (type, data) => {
+    const post: ChannelInstance<S, R>['post'] = (...params) => {
+      const [type, data] = params
       connections.forEach((connection) => {
         connection.post(type, data)
       })


### PR DESCRIPTION
Small fix for comlink that improves the types for `post` and `fetch` methods.

Previously, I added functionality to make the second/data param optional so that:
```ts
// Given a message type without data
type MsgWithoutData = {
  type: 'some-message-without-data'
  data: undefined
}
// You can call 
node.post('some-message-without-data')
// Instead of having to always explicitly pass two params
node.post('some-message-without-data', undefined)
```
But this has the unintended side effect that:
```ts
// Given a message type with data
type MsgWithData = {
  type: 'some-message-with-data'
  data: { foo: string }
}
// You could call this without an error
node.post('some-message-with-data')
```

These changes mean the second parameter is now required if the type's `data` param is not undefined
```ts
// So this will now error
node.post('some-message-with-data')
// And you have to do this
node.post('some-message-with-data', { foo: 'bar' })
```

