### PR TITLE
fix(open-in-studio): set `preview` correctly for hash router studios

### DIFF
--- a/packages/visual-editing/package.json
+++ b/packages/visual-editing/package.json
@@ -102,6 +102,9 @@
     "src",
     "!src/**/stories/",
     "!src/**/*.md",
+    "!src/**/__tests__/",
+    "!src/**/*.test.ts",
+    "!src/**/*.test.tsx",
     "CHANGELOG.md"
   ],
   "scripts": {
@@ -112,8 +115,9 @@
     "dev": "pnpm run build:main && pnpm run build:svelte",
     "lint": "eslint --cache .",
     "prepack": "turbo run build",
+    "react-compiler-healthcheck": "(cd src && pnpx react-compiler-healthcheck@latest)",
     "storybook": "storybook dev -p 6006",
-    "test": "vitest --pass-with-no-tests --typecheck"
+    "test": "vitest --typecheck"
   },
   "browserslist": "extends @sanity/browserslist-config",
   "eslintConfig": {
@@ -121,6 +125,14 @@
       "@repo/eslint-config",
       "plugin:storybook/recommended"
     ],
+    "rules": {
+      "react-compiler/react-compiler": [
+        "error",
+        {
+          "__unstable_donotuse_reportAllBailouts": true
+        }
+      ]
+    },
     "root": true
   },
   "dependencies": {

--- a/packages/visual-editing/src/ui/ElementOverlay.tsx
+++ b/packages/visual-editing/src/ui/ElementOverlay.tsx
@@ -27,6 +27,7 @@ import type {
   SanityNode,
   SanityStegaNode,
 } from '../types'
+import {getLinkHref} from '../util/getLinkHref'
 import {usePreviewSnapshots} from './preview/usePreviewSnapshots'
 import {useSchema} from './schema/useSchema'
 
@@ -324,7 +325,7 @@ const Link = memo(function Link(props: {href: string}) {
     }, []),
     () => window.location.href,
   )
-  const href = useLinkHref(props.href, referer)
+  const href = useMemo(() => getLinkHref(props.href, referer), [props.href, referer])
 
   return (
     <Box as="a" href={href} target="_blank" rel="noopener noreferrer">
@@ -336,15 +337,3 @@ const Link = memo(function Link(props: {href: string}) {
     </Box>
   )
 })
-
-function useLinkHref(href: string, referer: string) {
-  return useMemo(() => {
-    try {
-      const parsed = new URL(href, typeof location === 'undefined' ? undefined : location.origin)
-      parsed.searchParams.set('preview', referer)
-      return parsed.toString()
-    } catch {
-      return href
-    }
-  }, [href, referer])
-}

--- a/packages/visual-editing/src/util/__tests__/getLinkHref.test.ts
+++ b/packages/visual-editing/src/util/__tests__/getLinkHref.test.ts
@@ -1,0 +1,50 @@
+import {createEditUrl} from '@sanity/client/csm'
+import {expect, test} from 'vitest'
+import {getLinkHref} from '../getLinkHref'
+
+const baseUrl = '/studio'
+const id = 'homepage'
+const type = 'page'
+const path = 'title'
+const preview = location.href
+const defaults = {baseUrl, id, type, path, preview}
+
+const absoluteBaseUrl = 'https://my.sanity.studio'
+const hashBaseUrl = '/studio#'
+const complexAbsoluteHashBaseUrl = 'https://example.com/studio?variant=abc#'
+
+const complexPreviewWithHash = `https://example.com/search?${new URLSearchParams({foo: 'bar'})}#/path?${new URLSearchParams({bar: 'foo'})}`
+
+const cases = [
+  {
+    expected: `http://localhost:3000/studio/intent/edit/mode=presentation;id=homepage;type=page;path=title?${new URLSearchParams({baseUrl, id, type, path, preview})}`,
+  },
+  {
+    baseUrl: absoluteBaseUrl,
+    expected: `https://my.sanity.studio/intent/edit/mode=presentation;id=homepage;type=page;path=title?${new URLSearchParams({baseUrl: absoluteBaseUrl, id, type, path, preview})}`,
+  },
+  {
+    baseUrl: hashBaseUrl,
+    expected: `http://localhost:3000/studio#/intent/edit/mode=presentation;id=homepage;type=page;path=title?${new URLSearchParams({baseUrl: hashBaseUrl, id, type, path, preview})}`,
+  },
+
+  {
+    baseUrl: complexAbsoluteHashBaseUrl,
+    expected: `https://example.com/studio?variant=abc#/intent/edit/mode=presentation;id=homepage;type=page;path=title?${new URLSearchParams({baseUrl: complexAbsoluteHashBaseUrl, id, type, path, preview})}`,
+  },
+  {
+    preview: complexPreviewWithHash,
+    expected: `http://localhost:3000/studio/intent/edit/mode=presentation;id=homepage;type=page;path=title?${new URLSearchParams({baseUrl, id, type, path, preview: complexPreviewWithHash})}`,
+  },
+  {
+    baseUrl: hashBaseUrl,
+    preview: complexPreviewWithHash,
+    expected: `http://localhost:3000/studio#/intent/edit/mode=presentation;id=homepage;type=page;path=title?${new URLSearchParams({baseUrl: hashBaseUrl, id, type, path, preview: complexPreviewWithHash})}`,
+  },
+] satisfies (Partial<typeof defaults> & {expected: string})[]
+
+test.each(cases)('$expected', ({expected, ...rest}) => {
+  const {baseUrl, type, id, path, preview} = {...defaults, ...rest}
+  const actual = getLinkHref(createEditUrl({baseUrl, type, id, path}), preview)
+  expect(actual).toEqual(expected)
+})

--- a/packages/visual-editing/src/util/getLinkHref.ts
+++ b/packages/visual-editing/src/util/getLinkHref.ts
@@ -1,0 +1,13 @@
+export function getLinkHref(href: string, referer: string): string {
+  try {
+    const parsed = new URL(href, typeof location === 'undefined' ? undefined : location.origin)
+    if (parsed.hash) {
+      const hash = new URL(getLinkHref(parsed.hash.slice(1), referer))
+      return `${parsed.origin}${parsed.pathname}${parsed.search}#${hash.pathname}${hash.search}`
+    }
+    parsed.searchParams.set('preview', referer)
+    return parsed.toString()
+  } catch {
+    return href
+  }
+}


### PR DESCRIPTION
When using a hash router setup:
```ts

```