### PR TITLE
fix: make `<VisualEditing>` render in portals consistently

### DIFF
--- a/packages/visual-editing/src/constants.ts
+++ b/packages/visual-editing/src/constants.ts
@@ -1,7 +1,5 @@
 export {VERCEL_STEGA_REGEX} from '@vercel/stega'
 
-export const OVERLAY_ID = 'sanity-visual-editing'
-
 /**
  * How long to wait after the last subscriber has unsubscribed before resetting the observable and disconnecting the listener
  * We want to keep the listener alive for a short while after the last subscriber has unsubscribed to avoid unnecessary reconnects

--- a/packages/visual-editing/src/ui/renderVisualEditing.tsx
+++ b/packages/visual-editing/src/ui/renderVisualEditing.tsx
@@ -5,7 +5,6 @@
 
 import {StrictMode} from 'react'
 import {createRoot, type Root} from 'react-dom/client'
-import {OVERLAY_ID} from '../constants'
 import type {VisualEditingOptions} from '../types'
 import {VisualEditing} from './VisualEditing'
 
@@ -36,13 +35,7 @@ export function renderVisualEditing(
   })
 
   if (!node) {
-    // eslint-disable-next-line no-warning-comments
-    // @TODO use 'sanity-visual-editing' instead of 'div'
-    node = document.createElement('div')
-    // eslint-disable-next-line no-warning-comments
-    // @TODO after the element is `sanity-visual-editing` instead of `div`, stop setting this ID
-    node.id = OVERLAY_ID
-
+    node = document.createElement('sanity-visual-editing')
     // render sanity-visual-editing after closing </body> tag
     document.body.parentNode!.insertBefore(node, document.body.nextSibling)
   }
@@ -53,7 +46,14 @@ export function renderVisualEditing(
 
   root.render(
     <StrictMode>
-      <VisualEditing components={components} history={history} refresh={refresh} zIndex={zIndex} />
+      <VisualEditing
+        components={components}
+        history={history}
+        refresh={refresh}
+        zIndex={zIndex}
+        // Disabling the portal, as this function is already making sure the overlays render in the right spot
+        portal={false}
+      />
     </StrictMode>,
   )
 }

--- a/packages/visual-editing/src/util/findSanityNodes.ts
+++ b/packages/visual-editing/src/util/findSanityNodes.ts
@@ -1,5 +1,4 @@
 import {decodeSanityNodeData} from '@repo/visual-editing-helpers/csm'
-import {OVERLAY_ID} from '../constants'
 import type {
   ElementNode,
   OverlayElement,
@@ -148,7 +147,7 @@ export function findSanityNodes(
       else if (isElementNode(node)) {
         // Do not traverse script tags
         // Do not traverse the visual editing overlay
-        if (node.tagName === 'SCRIPT' || node.id === OVERLAY_ID) {
+        if (node.tagName === 'SCRIPT' || node.tagName === 'SANITY-VISUAL-EDITING') {
           continue
         }
 


### PR DESCRIPTION
Allows us to remove this logic from libraries like `next-sanity` https://github.com/sanity-io/next-sanity/blob/5aa90df441f4b6f8070ea36645ffe5c19a2925b3/packages/next-sanity/src/visual-editing/client-component/VisualEditing.tsx#L134-L151