### PR TITLE
fix(visual-editing): Don't show "Open in Studio" offscreen when at top of screen

### DIFF
--- a/packages/visual-editing/src/ui/ElementOverlay.tsx
+++ b/packages/visual-editing/src/ui/ElementOverlay.tsx
@@ -101,7 +101,6 @@ const Root = styled(Card)`
 `
 
 const Actions = styled(Flex)`
-  bottom: 100%;
   cursor: pointer;
   pointer-events: none;
   position: absolute;
@@ -124,7 +123,6 @@ const ActionOpen = styled(Card)`
 `
 
 const Tab = styled(Flex)`
-  bottom: 100%;
   cursor: pointer;
   pointer-events: none;
   position: absolute;
@@ -158,7 +156,7 @@ function createIntentLink(node: SanityNode) {
 }
 
 const ElementOverlayInner: FunctionComponent<ElementOverlayProps> = (props) => {
-  const {element, focused, componentResolver, node, showActions, draggable} = props
+  const {element, focused, componentResolver, node, showActions, draggable, rect} = props
 
   const {getField, getType} = useSchema()
   const schemaType = getType(node)
@@ -197,16 +195,27 @@ const ElementOverlayInner: FunctionComponent<ElementOverlayProps> = (props) => {
     <DocumentIcon />
   )
 
+  const floatingStyle = useMemo(() => {
+    // If the element is close to the top of the screen, we want to show the actions below it
+    const isNearTop = rect.y < 20
+    return {
+      top: isNearTop ? '100%' : 0,
+      bottom: isNearTop ? 0 : '100%',
+      paddingTop: isNearTop ? 4 : 0,
+      paddingBottom: isNearTop ? 0 : 4,
+    }
+  }, [rect])
+
   return (
     <>
       {showActions ? (
-        <Actions gap={1} paddingBottom={1} data-sanity-overlay-element>
+        <Actions gap={1} style={floatingStyle} data-sanity-overlay-element>
           <Link href={href} />
         </Actions>
       ) : null}
 
       {title && (
-        <Tab gap={1} paddingBottom={1}>
+        <Tab gap={1} style={floatingStyle}>
           <Labels gap={2} padding={2}>
             {draggable && (
               <Box marginRight={1}>


### PR DESCRIPTION
For things like navbars or logos that might appear on the top of the screen, the overlay could be cut off. This moves the "Open in Studio" below the element in that case.

Supplants #1868 

Before:
![image](https://github.com/user-attachments/assets/00444cd7-b8d3-43d2-b01f-5d29e6183f79)
After:
![image](https://github.com/user-attachments/assets/5eca25c2-74ca-4a6f-8011-ebf6f15e8d03)
