### PR TITLE
chore: add extended telemetry, useTelemetry hook

### DIFF
--- a/apps/page-builder-demo/src/sanity.types.ts
+++ b/apps/page-builder-demo/src/sanity.types.ts
@@ -747,6 +747,104 @@ export type ProjectsPageQueryResult = Array<{
   slug?: Slug
 }>
 
+// Source: ./src/app/product/[slug]/page.tsx
+// Variable: productSlugsQuery
+// Query: *[_type == "product" && defined(slug.current)]{"slug": slug.current}
+export type ProductSlugsQueryResult = Array<{
+  slug: string | null
+}>
+// Variable: productPageQuery
+// Query: *[_type == "product" && slug.current == $slug][0]
+export type ProductPageQueryResult = {
+  _id: string
+  _type: 'product'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+  slug?: Slug
+  media?: Array<{
+    asset?: {
+      _ref: string
+      _type: 'reference'
+      _weak?: boolean
+      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
+    }
+    hotspot?: SanityImageHotspot
+    crop?: SanityImageCrop
+    alt?: string
+    _type: 'image'
+    _key: string
+  }>
+  description?: Array<{
+    children?: Array<{
+      marks?: Array<string>
+      text?: string
+      _type: 'span'
+      _key: string
+    }>
+    style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
+    listItem?: 'bullet' | 'number'
+    markDefs?: Array<{
+      href?: string
+      _type: 'link'
+      _key: string
+    }>
+    level?: number
+    _type: 'block'
+    _key: string
+  }>
+  brandReference?: unknown
+  details?: {
+    materials?: string
+    collectionNotes?: Array<{
+      children?: Array<{
+        marks?: Array<string>
+        text?: string
+        _type: 'span'
+        _key: string
+      }>
+      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
+      listItem?: 'bullet' | 'number'
+      markDefs?: Array<{
+        href?: string
+        _type: 'link'
+        _key: string
+      }>
+      level?: number
+      _type: 'block'
+      _key: string
+    }>
+    performance?: Array<{
+      children?: Array<{
+        marks?: Array<string>
+        text?: string
+        _type: 'span'
+        _key: string
+      }>
+      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
+      listItem?: 'bullet' | 'number'
+      markDefs?: Array<{
+        href?: string
+        _type: 'link'
+        _key: string
+      }>
+      level?: number
+      _type: 'block'
+      _key: string
+    }>
+    ledLifespan?: string
+    certifications?: Array<string>
+  }
+  variants?: Array<{
+    title?: string
+    price?: string
+    sku?: string
+    _type: 'variant'
+    _key: string
+  }>
+} | null
+
 // Source: ./src/app/pages/[slug]/page.tsx
 // Variable: pageQuery
 // Query: *[_type == "page" && slug.current == $slug][0]{    _type,    _id,    title,    sections[]{  _key,  _type,  _type == 'section' => {    'headline': coalesce(headline, symbol->headline),    'tagline': coalesce(tagline, symbol->tagline),    'subline': coalesce(subline, symbol->subline),  },  _type == 'featureHighlight' => {    headline,    description,    image,    product->{      _type,      _id,      title,      slug,      "media": media[0]    },    style,    ctas  },  _type == 'featuredProducts' => {    headline,    description,    products[]{      _key,      ...(@->{        _type,        _id,        title,        slug,        "media": media[0]      })    },    style  },  _type == 'intro' => {    headline,    intro,    style,    rotations  },  _type == 'hero' => {    headline,    tagline,    subline,    image,    style  }},    style  }

--- a/apps/page-builder-demo/src/sanity.types.ts
+++ b/apps/page-builder-demo/src/sanity.types.ts
@@ -747,104 +747,6 @@ export type ProjectsPageQueryResult = Array<{
   slug?: Slug
 }>
 
-// Source: ./src/app/product/[slug]/page.tsx
-// Variable: productSlugsQuery
-// Query: *[_type == "product" && defined(slug.current)]{"slug": slug.current}
-export type ProductSlugsQueryResult = Array<{
-  slug: string | null
-}>
-// Variable: productPageQuery
-// Query: *[_type == "product" && slug.current == $slug][0]
-export type ProductPageQueryResult = {
-  _id: string
-  _type: 'product'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  title?: string
-  slug?: Slug
-  media?: Array<{
-    asset?: {
-      _ref: string
-      _type: 'reference'
-      _weak?: boolean
-      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
-    }
-    hotspot?: SanityImageHotspot
-    crop?: SanityImageCrop
-    alt?: string
-    _type: 'image'
-    _key: string
-  }>
-  description?: Array<{
-    children?: Array<{
-      marks?: Array<string>
-      text?: string
-      _type: 'span'
-      _key: string
-    }>
-    style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
-    listItem?: 'bullet' | 'number'
-    markDefs?: Array<{
-      href?: string
-      _type: 'link'
-      _key: string
-    }>
-    level?: number
-    _type: 'block'
-    _key: string
-  }>
-  brandReference?: unknown
-  details?: {
-    materials?: string
-    collectionNotes?: Array<{
-      children?: Array<{
-        marks?: Array<string>
-        text?: string
-        _type: 'span'
-        _key: string
-      }>
-      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
-      listItem?: 'bullet' | 'number'
-      markDefs?: Array<{
-        href?: string
-        _type: 'link'
-        _key: string
-      }>
-      level?: number
-      _type: 'block'
-      _key: string
-    }>
-    performance?: Array<{
-      children?: Array<{
-        marks?: Array<string>
-        text?: string
-        _type: 'span'
-        _key: string
-      }>
-      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
-      listItem?: 'bullet' | 'number'
-      markDefs?: Array<{
-        href?: string
-        _type: 'link'
-        _key: string
-      }>
-      level?: number
-      _type: 'block'
-      _key: string
-    }>
-    ledLifespan?: string
-    certifications?: Array<string>
-  }
-  variants?: Array<{
-    title?: string
-    price?: string
-    sku?: string
-    _type: 'variant'
-    _key: string
-  }>
-} | null
-
 // Source: ./src/app/pages/[slug]/page.tsx
 // Variable: pageQuery
 // Query: *[_type == "page" && slug.current == $slug][0]{    _type,    _id,    title,    sections[]{  _key,  _type,  _type == 'section' => {    'headline': coalesce(headline, symbol->headline),    'tagline': coalesce(tagline, symbol->tagline),    'subline': coalesce(subline, symbol->subline),  },  _type == 'featureHighlight' => {    headline,    description,    image,    product->{      _type,      _id,      title,      slug,      "media": media[0]    },    style,    ctas  },  _type == 'featuredProducts' => {    headline,    description,    products[]{      _key,      ...(@->{        _type,        _id,        title,        slug,        "media": media[0]      })    },    style  },  _type == 'intro' => {    headline,    intro,    style,    rotations  },  _type == 'hero' => {    headline,    tagline,    subline,    image,    style  }},    style  }
@@ -987,6 +889,104 @@ export type ProjectPageQueryResult = {
   slug?: Slug
 } | null
 
+// Source: ./src/app/product/[slug]/page.tsx
+// Variable: productSlugsQuery
+// Query: *[_type == "product" && defined(slug.current)]{"slug": slug.current}
+export type ProductSlugsQueryResult = Array<{
+  slug: string | null
+}>
+// Variable: productPageQuery
+// Query: *[_type == "product" && slug.current == $slug][0]
+export type ProductPageQueryResult = {
+  _id: string
+  _type: 'product'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+  slug?: Slug
+  media?: Array<{
+    asset?: {
+      _ref: string
+      _type: 'reference'
+      _weak?: boolean
+      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
+    }
+    hotspot?: SanityImageHotspot
+    crop?: SanityImageCrop
+    alt?: string
+    _type: 'image'
+    _key: string
+  }>
+  description?: Array<{
+    children?: Array<{
+      marks?: Array<string>
+      text?: string
+      _type: 'span'
+      _key: string
+    }>
+    style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
+    listItem?: 'bullet' | 'number'
+    markDefs?: Array<{
+      href?: string
+      _type: 'link'
+      _key: string
+    }>
+    level?: number
+    _type: 'block'
+    _key: string
+  }>
+  brandReference?: unknown
+  details?: {
+    materials?: string
+    collectionNotes?: Array<{
+      children?: Array<{
+        marks?: Array<string>
+        text?: string
+        _type: 'span'
+        _key: string
+      }>
+      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
+      listItem?: 'bullet' | 'number'
+      markDefs?: Array<{
+        href?: string
+        _type: 'link'
+        _key: string
+      }>
+      level?: number
+      _type: 'block'
+      _key: string
+    }>
+    performance?: Array<{
+      children?: Array<{
+        marks?: Array<string>
+        text?: string
+        _type: 'span'
+        _key: string
+      }>
+      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
+      listItem?: 'bullet' | 'number'
+      markDefs?: Array<{
+        href?: string
+        _type: 'link'
+        _key: string
+      }>
+      level?: number
+      _type: 'block'
+      _key: string
+    }>
+    ledLifespan?: string
+    certifications?: Array<string>
+  }
+  variants?: Array<{
+    title?: string
+    price?: string
+    sku?: string
+    _type: 'variant'
+    _key: string
+  }>
+} | null
+
 declare module '@sanity/client' {
   interface SanityQueries {
     '\n  *[_id == "siteSettings"][0]{\n  title,\n  description,\n  copyrightText\n}': LayoutQueryResult
@@ -994,11 +994,11 @@ declare module '@sanity/client' {
     '\n  *[_type == "dndTestPage"]{\n    _id,\n    title,\n    children\n  }[0]\n': DndPageQueryResult
     '\n  *[_type == "product" && defined(slug.current)]{\n    _id,\n    title,\n    description,\n    slug,\n    "media": media[0]\n  }\n': ProductsPageQueryResult
     '*[_type == "project" && defined(slug.current)]': ProjectsPageQueryResult
-    '*[_type == "product" && defined(slug.current)]{"slug": slug.current}': ProductSlugsQueryResult
-    '*[_type == "product" && slug.current == $slug][0]': ProductPageQueryResult
     "\n  *[_type == \"page\" && slug.current == $slug][0]{\n    _type,\n    _id,\n    title,\n    \nsections[]{\n  _key,\n  _type,\n  _type == 'section' => {\n    'headline': coalesce(headline, symbol->headline),\n    'tagline': coalesce(tagline, symbol->tagline),\n    'subline': coalesce(subline, symbol->subline),\n  },\n  _type == 'featureHighlight' => {\n    headline,\n    description,\n    image,\n    product->{\n      _type,\n      _id,\n      title,\n      slug,\n      \"media\": media[0]\n    },\n    style,\n    ctas\n  },\n  _type == 'featuredProducts' => {\n    headline,\n    description,\n    products[]{\n      _key,\n      ...(@->{\n        _type,\n        _id,\n        title,\n        slug,\n        \"media\": media[0]\n      })\n    },\n    style\n  },\n  _type == 'intro' => {\n    headline,\n    intro,\n    style,\n    rotations\n  },\n  _type == 'hero' => {\n    headline,\n    tagline,\n    subline,\n    image,\n    style\n  }\n},\n    style\n  }\n": PageQueryResult
     '*[_type == "page" && defined(slug.current)]{"slug": slug.current}': PageSlugsResult
     '*[_type == "project" && defined(slug.current)]{"slug": slug.current}': ProjectSlugsQueryResult
     '*[_type == "project" && slug.current == $slug][0]': ProjectPageQueryResult
+    '*[_type == "product" && defined(slug.current)]{"slug": slug.current}': ProductSlugsQueryResult
+    '*[_type == "product" && slug.current == $slug][0]': ProductPageQueryResult
   }
 }

--- a/apps/page-builder-demo/src/sanity.types.ts
+++ b/apps/page-builder-demo/src/sanity.types.ts
@@ -694,6 +694,19 @@ export type DndPageQueryResult = {
   }> | null
 } | null
 
+// Source: ./src/app/projects/page.tsx
+// Variable: projectsPageQuery
+// Query: *[_type == "project" && defined(slug.current)]
+export type ProjectsPageQueryResult = Array<{
+  _id: string
+  _type: 'project'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+  slug?: Slug
+}>
+
 // Source: ./src/app/products/page.tsx
 // Variable: productsPageQuery
 // Query: *[_type == "product" && defined(slug.current)]{    _id,    title,    description,    slug,    "media": media[0]  }
@@ -732,19 +745,6 @@ export type ProductsPageQueryResult = Array<{
     _type: 'image'
     _key: string
   } | null
-}>
-
-// Source: ./src/app/projects/page.tsx
-// Variable: projectsPageQuery
-// Query: *[_type == "project" && defined(slug.current)]
-export type ProjectsPageQueryResult = Array<{
-  _id: string
-  _type: 'project'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  title?: string
-  slug?: Slug
 }>
 
 // Source: ./src/app/pages/[slug]/page.tsx
@@ -1090,8 +1090,8 @@ declare module '@sanity/client' {
     '\n  *[_id == "siteSettings"][0]{\n  title,\n  description,\n  copyrightText\n}': LayoutQueryResult
     "\n  *[_id == \"siteSettings\"][0]{\n    frontPage->{\n      _type,\n      _id,\n      title,\n      \nsections[]{\n  _key,\n  _type,\n  _type == 'section' => {\n    'headline': coalesce(headline, symbol->headline),\n    'tagline': coalesce(tagline, symbol->tagline),\n    'subline': coalesce(subline, symbol->subline),\n  },\n  _type == 'featureHighlight' => {\n    headline,\n    description,\n    image,\n    product->{\n      _type,\n      _id,\n      title,\n      slug,\n      \"media\": media[0]\n    },\n    style,\n    ctas\n  },\n  _type == 'featuredProducts' => {\n    headline,\n    description,\n    products[]{\n      _key,\n      ...(@->{\n        _type,\n        _id,\n        title,\n        slug,\n        \"media\": media[0]\n      })\n    },\n    style\n  },\n  _type == 'intro' => {\n    headline,\n    intro,\n    style,\n    rotations\n  },\n  _type == 'hero' => {\n    headline,\n    tagline,\n    subline,\n    image,\n    style\n  }\n},\n      style\n    }\n  }.frontPage\n": FrontPageQueryResult
     '\n  *[_type == "dndTestPage"]{\n    _id,\n    title,\n    children\n  }[0]\n': DndPageQueryResult
-    '\n  *[_type == "product" && defined(slug.current)]{\n    _id,\n    title,\n    description,\n    slug,\n    "media": media[0]\n  }\n': ProductsPageQueryResult
     '*[_type == "project" && defined(slug.current)]': ProjectsPageQueryResult
+    '\n  *[_type == "product" && defined(slug.current)]{\n    _id,\n    title,\n    description,\n    slug,\n    "media": media[0]\n  }\n': ProductsPageQueryResult
     "\n  *[_type == \"page\" && slug.current == $slug][0]{\n    _type,\n    _id,\n    title,\n    \nsections[]{\n  _key,\n  _type,\n  _type == 'section' => {\n    'headline': coalesce(headline, symbol->headline),\n    'tagline': coalesce(tagline, symbol->tagline),\n    'subline': coalesce(subline, symbol->subline),\n  },\n  _type == 'featureHighlight' => {\n    headline,\n    description,\n    image,\n    product->{\n      _type,\n      _id,\n      title,\n      slug,\n      \"media\": media[0]\n    },\n    style,\n    ctas\n  },\n  _type == 'featuredProducts' => {\n    headline,\n    description,\n    products[]{\n      _key,\n      ...(@->{\n        _type,\n        _id,\n        title,\n        slug,\n        \"media\": media[0]\n      })\n    },\n    style\n  },\n  _type == 'intro' => {\n    headline,\n    intro,\n    style,\n    rotations\n  },\n  _type == 'hero' => {\n    headline,\n    tagline,\n    subline,\n    image,\n    style\n  }\n},\n    style\n  }\n": PageQueryResult
     '*[_type == "page" && defined(slug.current)]{"slug": slug.current}': PageSlugsResult
     '*[_type == "product" && defined(slug.current)]{"slug": slug.current}': ProductSlugsQueryResult

--- a/apps/page-builder-demo/src/sanity.types.ts
+++ b/apps/page-builder-demo/src/sanity.types.ts
@@ -747,6 +747,104 @@ export type ProjectsPageQueryResult = Array<{
   slug?: Slug
 }>
 
+// Source: ./src/app/product/[slug]/page.tsx
+// Variable: productSlugsQuery
+// Query: *[_type == "product" && defined(slug.current)]{"slug": slug.current}
+export type ProductSlugsQueryResult = Array<{
+  slug: string | null
+}>
+// Variable: productPageQuery
+// Query: *[_type == "product" && slug.current == $slug][0]
+export type ProductPageQueryResult = {
+  _id: string
+  _type: 'product'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+  slug?: Slug
+  media?: Array<{
+    asset?: {
+      _ref: string
+      _type: 'reference'
+      _weak?: boolean
+      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
+    }
+    hotspot?: SanityImageHotspot
+    crop?: SanityImageCrop
+    alt?: string
+    _type: 'image'
+    _key: string
+  }>
+  description?: Array<{
+    children?: Array<{
+      marks?: Array<string>
+      text?: string
+      _type: 'span'
+      _key: string
+    }>
+    style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
+    listItem?: 'bullet' | 'number'
+    markDefs?: Array<{
+      href?: string
+      _type: 'link'
+      _key: string
+    }>
+    level?: number
+    _type: 'block'
+    _key: string
+  }>
+  brandReference?: unknown
+  details?: {
+    materials?: string
+    collectionNotes?: Array<{
+      children?: Array<{
+        marks?: Array<string>
+        text?: string
+        _type: 'span'
+        _key: string
+      }>
+      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
+      listItem?: 'bullet' | 'number'
+      markDefs?: Array<{
+        href?: string
+        _type: 'link'
+        _key: string
+      }>
+      level?: number
+      _type: 'block'
+      _key: string
+    }>
+    performance?: Array<{
+      children?: Array<{
+        marks?: Array<string>
+        text?: string
+        _type: 'span'
+        _key: string
+      }>
+      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
+      listItem?: 'bullet' | 'number'
+      markDefs?: Array<{
+        href?: string
+        _type: 'link'
+        _key: string
+      }>
+      level?: number
+      _type: 'block'
+      _key: string
+    }>
+    ledLifespan?: string
+    certifications?: Array<string>
+  }
+  variants?: Array<{
+    title?: string
+    price?: string
+    sku?: string
+    _type: 'variant'
+    _key: string
+  }>
+} | null
+
 // Source: ./src/app/pages/[slug]/page.tsx
 // Variable: pageQuery
 // Query: *[_type == "page" && slug.current == $slug][0]{    _type,    _id,    title,    sections[]{  _key,  _type,  _type == 'section' => {    'headline': coalesce(headline, symbol->headline),    'tagline': coalesce(tagline, symbol->tagline),    'subline': coalesce(subline, symbol->subline),  },  _type == 'featureHighlight' => {    headline,    description,    image,    product->{      _type,      _id,      title,      slug,      "media": media[0]    },    style,    ctas  },  _type == 'featuredProducts' => {    headline,    description,    products[]{      _key,      ...(@->{        _type,        _id,        title,        slug,        "media": media[0]      })    },    style  },  _type == 'intro' => {    headline,    intro,    style,    rotations  },  _type == 'hero' => {    headline,    tagline,    subline,    image,    style  }},    style  }
@@ -871,104 +969,6 @@ export type PageSlugsResult = Array<{
   slug: string | null
 }>
 
-// Source: ./src/app/product/[slug]/page.tsx
-// Variable: productSlugsQuery
-// Query: *[_type == "product" && defined(slug.current)]{"slug": slug.current}
-export type ProductSlugsQueryResult = Array<{
-  slug: string | null
-}>
-// Variable: productPageQuery
-// Query: *[_type == "product" && slug.current == $slug][0]
-export type ProductPageQueryResult = {
-  _id: string
-  _type: 'product'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  title?: string
-  slug?: Slug
-  media?: Array<{
-    asset?: {
-      _ref: string
-      _type: 'reference'
-      _weak?: boolean
-      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
-    }
-    hotspot?: SanityImageHotspot
-    crop?: SanityImageCrop
-    alt?: string
-    _type: 'image'
-    _key: string
-  }>
-  description?: Array<{
-    children?: Array<{
-      marks?: Array<string>
-      text?: string
-      _type: 'span'
-      _key: string
-    }>
-    style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
-    listItem?: 'bullet' | 'number'
-    markDefs?: Array<{
-      href?: string
-      _type: 'link'
-      _key: string
-    }>
-    level?: number
-    _type: 'block'
-    _key: string
-  }>
-  brandReference?: unknown
-  details?: {
-    materials?: string
-    collectionNotes?: Array<{
-      children?: Array<{
-        marks?: Array<string>
-        text?: string
-        _type: 'span'
-        _key: string
-      }>
-      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
-      listItem?: 'bullet' | 'number'
-      markDefs?: Array<{
-        href?: string
-        _type: 'link'
-        _key: string
-      }>
-      level?: number
-      _type: 'block'
-      _key: string
-    }>
-    performance?: Array<{
-      children?: Array<{
-        marks?: Array<string>
-        text?: string
-        _type: 'span'
-        _key: string
-      }>
-      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
-      listItem?: 'bullet' | 'number'
-      markDefs?: Array<{
-        href?: string
-        _type: 'link'
-        _key: string
-      }>
-      level?: number
-      _type: 'block'
-      _key: string
-    }>
-    ledLifespan?: string
-    certifications?: Array<string>
-  }
-  variants?: Array<{
-    title?: string
-    price?: string
-    sku?: string
-    _type: 'variant'
-    _key: string
-  }>
-} | null
-
 // Source: ./src/app/project/[slug]/page.tsx
 // Variable: projectSlugsQuery
 // Query: *[_type == "project" && defined(slug.current)]{"slug": slug.current}
@@ -987,104 +987,6 @@ export type ProjectPageQueryResult = {
   slug?: Slug
 } | null
 
-// Source: ./src/app/product/[slug]/page.tsx
-// Variable: productSlugsQuery
-// Query: *[_type == "product" && defined(slug.current)]{"slug": slug.current}
-export type ProductSlugsQueryResult = Array<{
-  slug: string | null
-}>
-// Variable: productPageQuery
-// Query: *[_type == "product" && slug.current == $slug][0]
-export type ProductPageQueryResult = {
-  _id: string
-  _type: 'product'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  title?: string
-  slug?: Slug
-  media?: Array<{
-    asset?: {
-      _ref: string
-      _type: 'reference'
-      _weak?: boolean
-      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
-    }
-    hotspot?: SanityImageHotspot
-    crop?: SanityImageCrop
-    alt?: string
-    _type: 'image'
-    _key: string
-  }>
-  description?: Array<{
-    children?: Array<{
-      marks?: Array<string>
-      text?: string
-      _type: 'span'
-      _key: string
-    }>
-    style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
-    listItem?: 'bullet' | 'number'
-    markDefs?: Array<{
-      href?: string
-      _type: 'link'
-      _key: string
-    }>
-    level?: number
-    _type: 'block'
-    _key: string
-  }>
-  brandReference?: unknown
-  details?: {
-    materials?: string
-    collectionNotes?: Array<{
-      children?: Array<{
-        marks?: Array<string>
-        text?: string
-        _type: 'span'
-        _key: string
-      }>
-      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
-      listItem?: 'bullet' | 'number'
-      markDefs?: Array<{
-        href?: string
-        _type: 'link'
-        _key: string
-      }>
-      level?: number
-      _type: 'block'
-      _key: string
-    }>
-    performance?: Array<{
-      children?: Array<{
-        marks?: Array<string>
-        text?: string
-        _type: 'span'
-        _key: string
-      }>
-      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
-      listItem?: 'bullet' | 'number'
-      markDefs?: Array<{
-        href?: string
-        _type: 'link'
-        _key: string
-      }>
-      level?: number
-      _type: 'block'
-      _key: string
-    }>
-    ledLifespan?: string
-    certifications?: Array<string>
-  }
-  variants?: Array<{
-    title?: string
-    price?: string
-    sku?: string
-    _type: 'variant'
-    _key: string
-  }>
-} | null
-
 declare module '@sanity/client' {
   interface SanityQueries {
     '\n  *[_id == "siteSettings"][0]{\n  title,\n  description,\n  copyrightText\n}': LayoutQueryResult
@@ -1092,13 +994,11 @@ declare module '@sanity/client' {
     '\n  *[_type == "dndTestPage"]{\n    _id,\n    title,\n    children\n  }[0]\n': DndPageQueryResult
     '\n  *[_type == "product" && defined(slug.current)]{\n    _id,\n    title,\n    description,\n    slug,\n    "media": media[0]\n  }\n': ProductsPageQueryResult
     '*[_type == "project" && defined(slug.current)]': ProjectsPageQueryResult
+    '*[_type == "product" && defined(slug.current)]{"slug": slug.current}': ProductSlugsQueryResult
+    '*[_type == "product" && slug.current == $slug][0]': ProductPageQueryResult
     "\n  *[_type == \"page\" && slug.current == $slug][0]{\n    _type,\n    _id,\n    title,\n    \nsections[]{\n  _key,\n  _type,\n  _type == 'section' => {\n    'headline': coalesce(headline, symbol->headline),\n    'tagline': coalesce(tagline, symbol->tagline),\n    'subline': coalesce(subline, symbol->subline),\n  },\n  _type == 'featureHighlight' => {\n    headline,\n    description,\n    image,\n    product->{\n      _type,\n      _id,\n      title,\n      slug,\n      \"media\": media[0]\n    },\n    style,\n    ctas\n  },\n  _type == 'featuredProducts' => {\n    headline,\n    description,\n    products[]{\n      _key,\n      ...(@->{\n        _type,\n        _id,\n        title,\n        slug,\n        \"media\": media[0]\n      })\n    },\n    style\n  },\n  _type == 'intro' => {\n    headline,\n    intro,\n    style,\n    rotations\n  },\n  _type == 'hero' => {\n    headline,\n    tagline,\n    subline,\n    image,\n    style\n  }\n},\n    style\n  }\n": PageQueryResult
     '*[_type == "page" && defined(slug.current)]{"slug": slug.current}': PageSlugsResult
-    '*[_type == "product" && defined(slug.current)]{"slug": slug.current}': ProductSlugsQueryResult
-    '*[_type == "product" && slug.current == $slug][0]': ProductPageQueryResult
     '*[_type == "project" && defined(slug.current)]{"slug": slug.current}': ProjectSlugsQueryResult
     '*[_type == "project" && slug.current == $slug][0]': ProjectPageQueryResult
-    '*[_type == "product" && defined(slug.current)]{"slug": slug.current}': ProductSlugsQueryResult
-    '*[_type == "product" && slug.current == $slug][0]': ProductPageQueryResult
   }
 }

--- a/apps/page-builder-demo/src/sanity.types.ts
+++ b/apps/page-builder-demo/src/sanity.types.ts
@@ -694,19 +694,6 @@ export type DndPageQueryResult = {
   }> | null
 } | null
 
-// Source: ./src/app/projects/page.tsx
-// Variable: projectsPageQuery
-// Query: *[_type == "project" && defined(slug.current)]
-export type ProjectsPageQueryResult = Array<{
-  _id: string
-  _type: 'project'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  title?: string
-  slug?: Slug
-}>
-
 // Source: ./src/app/products/page.tsx
 // Variable: productsPageQuery
 // Query: *[_type == "product" && defined(slug.current)]{    _id,    title,    description,    slug,    "media": media[0]  }
@@ -745,6 +732,19 @@ export type ProductsPageQueryResult = Array<{
     _type: 'image'
     _key: string
   } | null
+}>
+
+// Source: ./src/app/projects/page.tsx
+// Variable: projectsPageQuery
+// Query: *[_type == "project" && defined(slug.current)]
+export type ProjectsPageQueryResult = Array<{
+  _id: string
+  _type: 'project'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+  slug?: Slug
 }>
 
 // Source: ./src/app/pages/[slug]/page.tsx
@@ -1090,8 +1090,8 @@ declare module '@sanity/client' {
     '\n  *[_id == "siteSettings"][0]{\n  title,\n  description,\n  copyrightText\n}': LayoutQueryResult
     "\n  *[_id == \"siteSettings\"][0]{\n    frontPage->{\n      _type,\n      _id,\n      title,\n      \nsections[]{\n  _key,\n  _type,\n  _type == 'section' => {\n    'headline': coalesce(headline, symbol->headline),\n    'tagline': coalesce(tagline, symbol->tagline),\n    'subline': coalesce(subline, symbol->subline),\n  },\n  _type == 'featureHighlight' => {\n    headline,\n    description,\n    image,\n    product->{\n      _type,\n      _id,\n      title,\n      slug,\n      \"media\": media[0]\n    },\n    style,\n    ctas\n  },\n  _type == 'featuredProducts' => {\n    headline,\n    description,\n    products[]{\n      _key,\n      ...(@->{\n        _type,\n        _id,\n        title,\n        slug,\n        \"media\": media[0]\n      })\n    },\n    style\n  },\n  _type == 'intro' => {\n    headline,\n    intro,\n    style,\n    rotations\n  },\n  _type == 'hero' => {\n    headline,\n    tagline,\n    subline,\n    image,\n    style\n  }\n},\n      style\n    }\n  }.frontPage\n": FrontPageQueryResult
     '\n  *[_type == "dndTestPage"]{\n    _id,\n    title,\n    children\n  }[0]\n': DndPageQueryResult
-    '*[_type == "project" && defined(slug.current)]': ProjectsPageQueryResult
     '\n  *[_type == "product" && defined(slug.current)]{\n    _id,\n    title,\n    description,\n    slug,\n    "media": media[0]\n  }\n': ProductsPageQueryResult
+    '*[_type == "project" && defined(slug.current)]': ProjectsPageQueryResult
     "\n  *[_type == \"page\" && slug.current == $slug][0]{\n    _type,\n    _id,\n    title,\n    \nsections[]{\n  _key,\n  _type,\n  _type == 'section' => {\n    'headline': coalesce(headline, symbol->headline),\n    'tagline': coalesce(tagline, symbol->tagline),\n    'subline': coalesce(subline, symbol->subline),\n  },\n  _type == 'featureHighlight' => {\n    headline,\n    description,\n    image,\n    product->{\n      _type,\n      _id,\n      title,\n      slug,\n      \"media\": media[0]\n    },\n    style,\n    ctas\n  },\n  _type == 'featuredProducts' => {\n    headline,\n    description,\n    products[]{\n      _key,\n      ...(@->{\n        _type,\n        _id,\n        title,\n        slug,\n        \"media\": media[0]\n      })\n    },\n    style\n  },\n  _type == 'intro' => {\n    headline,\n    intro,\n    style,\n    rotations\n  },\n  _type == 'hero' => {\n    headline,\n    tagline,\n    subline,\n    image,\n    style\n  }\n},\n    style\n  }\n": PageQueryResult
     '*[_type == "page" && defined(slug.current)]{"slug": slug.current}': PageSlugsResult
     '*[_type == "product" && defined(slug.current)]{"slug": slug.current}': ProductSlugsQueryResult

--- a/apps/page-builder-demo/src/sanity.types.ts
+++ b/apps/page-builder-demo/src/sanity.types.ts
@@ -747,104 +747,6 @@ export type ProjectsPageQueryResult = Array<{
   slug?: Slug
 }>
 
-// Source: ./src/app/product/[slug]/page.tsx
-// Variable: productSlugsQuery
-// Query: *[_type == "product" && defined(slug.current)]{"slug": slug.current}
-export type ProductSlugsQueryResult = Array<{
-  slug: string | null
-}>
-// Variable: productPageQuery
-// Query: *[_type == "product" && slug.current == $slug][0]
-export type ProductPageQueryResult = {
-  _id: string
-  _type: 'product'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  title?: string
-  slug?: Slug
-  media?: Array<{
-    asset?: {
-      _ref: string
-      _type: 'reference'
-      _weak?: boolean
-      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
-    }
-    hotspot?: SanityImageHotspot
-    crop?: SanityImageCrop
-    alt?: string
-    _type: 'image'
-    _key: string
-  }>
-  description?: Array<{
-    children?: Array<{
-      marks?: Array<string>
-      text?: string
-      _type: 'span'
-      _key: string
-    }>
-    style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
-    listItem?: 'bullet' | 'number'
-    markDefs?: Array<{
-      href?: string
-      _type: 'link'
-      _key: string
-    }>
-    level?: number
-    _type: 'block'
-    _key: string
-  }>
-  brandReference?: unknown
-  details?: {
-    materials?: string
-    collectionNotes?: Array<{
-      children?: Array<{
-        marks?: Array<string>
-        text?: string
-        _type: 'span'
-        _key: string
-      }>
-      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
-      listItem?: 'bullet' | 'number'
-      markDefs?: Array<{
-        href?: string
-        _type: 'link'
-        _key: string
-      }>
-      level?: number
-      _type: 'block'
-      _key: string
-    }>
-    performance?: Array<{
-      children?: Array<{
-        marks?: Array<string>
-        text?: string
-        _type: 'span'
-        _key: string
-      }>
-      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
-      listItem?: 'bullet' | 'number'
-      markDefs?: Array<{
-        href?: string
-        _type: 'link'
-        _key: string
-      }>
-      level?: number
-      _type: 'block'
-      _key: string
-    }>
-    ledLifespan?: string
-    certifications?: Array<string>
-  }
-  variants?: Array<{
-    title?: string
-    price?: string
-    sku?: string
-    _type: 'variant'
-    _key: string
-  }>
-} | null
-
 // Source: ./src/app/pages/[slug]/page.tsx
 // Variable: pageQuery
 // Query: *[_type == "page" && slug.current == $slug][0]{    _type,    _id,    title,    sections[]{  _key,  _type,  _type == 'section' => {    'headline': coalesce(headline, symbol->headline),    'tagline': coalesce(tagline, symbol->tagline),    'subline': coalesce(subline, symbol->subline),  },  _type == 'featureHighlight' => {    headline,    description,    image,    product->{      _type,      _id,      title,      slug,      "media": media[0]    },    style,    ctas  },  _type == 'featuredProducts' => {    headline,    description,    products[]{      _key,      ...(@->{        _type,        _id,        title,        slug,        "media": media[0]      })    },    style  },  _type == 'intro' => {    headline,    intro,    style,    rotations  },  _type == 'hero' => {    headline,    tagline,    subline,    image,    style  }},    style  }
@@ -968,6 +870,104 @@ export type PageQueryResult = {
 export type PageSlugsResult = Array<{
   slug: string | null
 }>
+
+// Source: ./src/app/product/[slug]/page.tsx
+// Variable: productSlugsQuery
+// Query: *[_type == "product" && defined(slug.current)]{"slug": slug.current}
+export type ProductSlugsQueryResult = Array<{
+  slug: string | null
+}>
+// Variable: productPageQuery
+// Query: *[_type == "product" && slug.current == $slug][0]
+export type ProductPageQueryResult = {
+  _id: string
+  _type: 'product'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+  slug?: Slug
+  media?: Array<{
+    asset?: {
+      _ref: string
+      _type: 'reference'
+      _weak?: boolean
+      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
+    }
+    hotspot?: SanityImageHotspot
+    crop?: SanityImageCrop
+    alt?: string
+    _type: 'image'
+    _key: string
+  }>
+  description?: Array<{
+    children?: Array<{
+      marks?: Array<string>
+      text?: string
+      _type: 'span'
+      _key: string
+    }>
+    style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
+    listItem?: 'bullet' | 'number'
+    markDefs?: Array<{
+      href?: string
+      _type: 'link'
+      _key: string
+    }>
+    level?: number
+    _type: 'block'
+    _key: string
+  }>
+  brandReference?: unknown
+  details?: {
+    materials?: string
+    collectionNotes?: Array<{
+      children?: Array<{
+        marks?: Array<string>
+        text?: string
+        _type: 'span'
+        _key: string
+      }>
+      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
+      listItem?: 'bullet' | 'number'
+      markDefs?: Array<{
+        href?: string
+        _type: 'link'
+        _key: string
+      }>
+      level?: number
+      _type: 'block'
+      _key: string
+    }>
+    performance?: Array<{
+      children?: Array<{
+        marks?: Array<string>
+        text?: string
+        _type: 'span'
+        _key: string
+      }>
+      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal'
+      listItem?: 'bullet' | 'number'
+      markDefs?: Array<{
+        href?: string
+        _type: 'link'
+        _key: string
+      }>
+      level?: number
+      _type: 'block'
+      _key: string
+    }>
+    ledLifespan?: string
+    certifications?: Array<string>
+  }
+  variants?: Array<{
+    title?: string
+    price?: string
+    sku?: string
+    _type: 'variant'
+    _key: string
+  }>
+} | null
 
 // Source: ./src/app/project/[slug]/page.tsx
 // Variable: projectSlugsQuery
@@ -1094,6 +1094,8 @@ declare module '@sanity/client' {
     '*[_type == "project" && defined(slug.current)]': ProjectsPageQueryResult
     "\n  *[_type == \"page\" && slug.current == $slug][0]{\n    _type,\n    _id,\n    title,\n    \nsections[]{\n  _key,\n  _type,\n  _type == 'section' => {\n    'headline': coalesce(headline, symbol->headline),\n    'tagline': coalesce(tagline, symbol->tagline),\n    'subline': coalesce(subline, symbol->subline),\n  },\n  _type == 'featureHighlight' => {\n    headline,\n    description,\n    image,\n    product->{\n      _type,\n      _id,\n      title,\n      slug,\n      \"media\": media[0]\n    },\n    style,\n    ctas\n  },\n  _type == 'featuredProducts' => {\n    headline,\n    description,\n    products[]{\n      _key,\n      ...(@->{\n        _type,\n        _id,\n        title,\n        slug,\n        \"media\": media[0]\n      })\n    },\n    style\n  },\n  _type == 'intro' => {\n    headline,\n    intro,\n    style,\n    rotations\n  },\n  _type == 'hero' => {\n    headline,\n    tagline,\n    subline,\n    image,\n    style\n  }\n},\n    style\n  }\n": PageQueryResult
     '*[_type == "page" && defined(slug.current)]{"slug": slug.current}': PageSlugsResult
+    '*[_type == "product" && defined(slug.current)]{"slug": slug.current}': ProductSlugsQueryResult
+    '*[_type == "product" && slug.current == $slug][0]': ProductPageQueryResult
     '*[_type == "project" && defined(slug.current)]{"slug": slug.current}': ProjectSlugsQueryResult
     '*[_type == "project" && slug.current == $slug][0]': ProjectPageQueryResult
     '*[_type == "product" && defined(slug.current)]{"slug": slug.current}': ProductSlugsQueryResult

--- a/packages/visual-editing/src/overlay-components/components/UnionInsertMenuOverlay.tsx
+++ b/packages/visual-editing/src/overlay-components/components/UnionInsertMenuOverlay.tsx
@@ -108,7 +108,7 @@ const HoverArea: FunctionComponent<{
 
       sendTelemetry('Visual Editing Insert Menu Item Inserted', null)
     },
-    [onAddUnion, position],
+    [onAddUnion, position, sendTelemetry],
   )
 
   const align = position === 'top' ? 'flex-start' : position === 'bottom' ? 'flex-end' : 'center'

--- a/packages/visual-editing/src/overlay-components/components/UnionInsertMenuOverlay.tsx
+++ b/packages/visual-editing/src/overlay-components/components/UnionInsertMenuOverlay.tsx
@@ -13,6 +13,7 @@ import {
 import {styled} from 'styled-components'
 import {useDocuments} from '../../react/useDocuments'
 import type {ElementNode, OverlayComponent} from '../../types'
+import {useTelemetry} from '../../ui/telemetry/useTelemetry'
 import {getArrayInsertPatches} from '../../util/mutations'
 import {InsertMenuPopover} from './InsertMenu'
 
@@ -68,6 +69,8 @@ const HoverArea: FunctionComponent<{
   }, [])
   const ref = useRef<HTMLDivElement | null>(null)
 
+  const sendTelemetry = useTelemetry()
+
   // This function clones and dispatches MouseEvents so that they can be handled
   // by the underlying element. This is useful because we want to handle hover
   // events on the overlay element to display the add button, but let the
@@ -102,6 +105,8 @@ const HoverArea: FunctionComponent<{
       setMenuVisible(false)
       const insertPosition = position === 'top' || position === 'left' ? 'before' : 'after'
       onAddUnion(insertPosition, schemaType.name)
+
+      sendTelemetry('Visual Editing Insert Menu Item Inserted', null)
     },
     [onAddUnion, position],
   )

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -20,7 +20,7 @@ import type {
   PropsWithChildren,
   ReactElement,
 } from 'react'
-import type {TelemetryContextValue} from './ui/telemetry/TelemetryContext'
+import type {TelemetryContextValue, TelemetryEventNames} from './ui/telemetry/TelemetryContext'
 
 export type {
   HistoryRefresh,
@@ -467,6 +467,7 @@ export interface ContextMenuActionNode {
   label: string
   hotkeys?: string[]
   action?: () => void
+  telemetryEvent: TelemetryEventNames
 }
 
 /**

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -20,6 +20,7 @@ import type {
   PropsWithChildren,
   ReactElement,
 } from 'react'
+import type {TelemetryContextValue} from './ui/telemetry/TelemetryContext'
 
 export type {
   HistoryRefresh,
@@ -490,7 +491,10 @@ export interface ContextMenuGroupNode {
  */
 export interface ContextMenuCustomNode {
   type: 'custom'
-  component: ComponentType<{boundaryElement: HTMLDivElement | null}>
+  component: ComponentType<{
+    boundaryElement: HTMLDivElement | null
+    sendTelemetry: TelemetryContextValue
+  }>
 }
 
 /**

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -142,6 +142,8 @@ const OverlaysController: FunctionComponent<{
         onDrag(message.x, message.y)
 
         return
+      } else if (message.type === 'overlay/dragToggleMinimap' && message.display === true) {
+        sendTelemetry('Visual Editing Drag Minimap Enabled', null)
       } else if (message.type === 'overlay/setCursor') {
         const {element, cursor} = message
 

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -126,6 +126,8 @@ const OverlaysController: FunctionComponent<{
       if (message.type === 'element/click') {
         const {sanity} = message
         comlink?.post('visual-editing/focus', sanity)
+
+        sendTelemetry('Visual Editing Overlay Clicked', null)
       } else if (message.type === 'overlay/activate') {
         comlink?.post('visual-editing/toggle', {enabled: true})
       } else if (message.type === 'overlay/deactivate') {

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -11,7 +11,6 @@ import {
   usePrefersDark,
 } from '@sanity/ui'
 import {
-  createContext,
   useCallback,
   useEffect,
   useMemo,
@@ -19,8 +18,6 @@ import {
   useRef,
   useState,
   type FunctionComponent,
-  type PropsWithChildren,
-  type ReactNode,
 } from 'react'
 import {styled} from 'styled-components'
 import {useOptimisticActor, useOptimisticActorReady} from '../react/useOptimisticActor'
@@ -157,7 +154,7 @@ const OverlaysController: FunctionComponent<{
 
       dispatch(message)
     },
-    [comlink, dispatch, dispatchDragEndEvent, onDrag],
+    [comlink, dispatch, dispatchDragEndEvent, onDrag, sendTelemetry],
   )
 
   const controller = useController(rootElement, overlayEventHandler, inFrame, inPopUp)

--- a/packages/visual-editing/src/ui/context-menu/ContextMenu.tsx
+++ b/packages/visual-editing/src/ui/context-menu/ContextMenu.tsx
@@ -35,14 +35,8 @@ function ContextMenuItem(props: {
       node.action?.()
       onDismiss?.()
 
-      if (node.label === 'Remove') {
-        sendTelemetry('Visual Editing Context Menu Item Removed', null)
-      } else if (node.label === 'Duplicate') {
-        sendTelemetry('Visual Editing Context Menu Item Duplicated', null)
-      } else if (['Up', 'Down', 'To top', 'To bottom'].includes(node.label)) {
-        sendTelemetry('Visual Editing Context Menu Item Moved', null)
-      } else if (['Insert before', 'Insert after'].includes(node.label)) {
-        sendTelemetry('Visual Editing Context Menu Item Inserted', null)
+      if (node.telemetryEvent) {
+        sendTelemetry(node.telemetryEvent, null)
       }
     }
   }, [node, onDismiss, sendTelemetry])

--- a/packages/visual-editing/src/ui/context-menu/ContextMenu.tsx
+++ b/packages/visual-editing/src/ui/context-menu/ContextMenu.tsx
@@ -17,6 +17,7 @@ import type {ContextMenuNode, ContextMenuProps} from '../../types'
 import {getNodeIcon} from '../../util/getNodeIcon'
 import {PopoverPortal} from '../PopoverPortal'
 import {useSchema} from '../schema/useSchema'
+import {useTelemetry} from '../telemetry/useTelemetry'
 import {getContextMenuItems} from './contextMenuItems'
 
 const POPOVER_MARGINS: PopoverMargins = [-4, 4, -4, 4]
@@ -27,11 +28,16 @@ function ContextMenuItem(props: {
   boundaryElement: HTMLDivElement | null
 }) {
   const {node, onDismiss, boundaryElement} = props
+  const sendTelemetry = useTelemetry()
 
   const onClick = useCallback(() => {
     if (node.type === 'action') {
       node.action?.()
       onDismiss?.()
+
+      if (node.label === 'Remove') {
+        sendTelemetry('Visual Editing Context Menu Item Removed', null)
+      }
     }
   }, [node, onDismiss])
 

--- a/packages/visual-editing/src/ui/context-menu/ContextMenu.tsx
+++ b/packages/visual-editing/src/ui/context-menu/ContextMenu.tsx
@@ -35,8 +35,16 @@ function ContextMenuItem(props: {
       node.action?.()
       onDismiss?.()
 
+      console.log(node.label)
+
       if (node.label === 'Remove') {
         sendTelemetry('Visual Editing Context Menu Item Removed', null)
+      } else if (node.label === 'Duplicate') {
+        sendTelemetry('Visual Editing Context Menu Item Duplicated', null)
+      } else if (['Up', 'Down', 'To top', 'To bottom'].includes(node.label)) {
+        sendTelemetry('Visual Editing Context Menu Item Moved', null)
+      } else if (['Insert before', 'Insert after'].includes(node.label)) {
+        sendTelemetry('Visual Editing Context Menu Item Inserted', null)
       }
     }
   }, [node, onDismiss])

--- a/packages/visual-editing/src/ui/context-menu/ContextMenu.tsx
+++ b/packages/visual-editing/src/ui/context-menu/ContextMenu.tsx
@@ -35,8 +35,6 @@ function ContextMenuItem(props: {
       node.action?.()
       onDismiss?.()
 
-      console.log(node.label)
-
       if (node.label === 'Remove') {
         sendTelemetry('Visual Editing Context Menu Item Removed', null)
       } else if (node.label === 'Duplicate') {
@@ -47,7 +45,7 @@ function ContextMenuItem(props: {
         sendTelemetry('Visual Editing Context Menu Item Inserted', null)
       }
     }
-  }, [node, onDismiss])
+  }, [node, onDismiss, sendTelemetry])
 
   if (node.type === 'divider') {
     return <MenuDivider />

--- a/packages/visual-editing/src/ui/context-menu/ContextMenu.tsx
+++ b/packages/visual-editing/src/ui/context-menu/ContextMenu.tsx
@@ -109,7 +109,7 @@ function ContextMenuItem(props: {
 
   if (node.type === 'custom') {
     const {component: Component} = node
-    return <Component boundaryElement={boundaryElement} />
+    return <Component boundaryElement={boundaryElement} sendTelemetry={sendTelemetry} />
   }
 
   return null

--- a/packages/visual-editing/src/ui/context-menu/contextMenuItems.tsx
+++ b/packages/visual-editing/src/ui/context-menu/contextMenuItems.tsx
@@ -78,6 +78,7 @@ function getDuplicateItem(context: {doc: OptimisticDocument; node: SanityNode}) 
       label: 'Duplicate',
       icon: CopyIcon,
       action: getDuplicateAction(node, doc),
+      telemetryEvent: 'Visual Editing Context Menu Item Duplicated' as const,
     },
   ]
 }
@@ -91,6 +92,7 @@ function getRemoveItems(context: {doc: OptimisticDocument; node: SanityNode}) {
       label: 'Remove',
       icon: RemoveIcon,
       action: getArrayRemoveAction(node, doc),
+      telemetryEvent: 'Visual Editing Context Menu Item Removed' as const,
     },
   ]
 }
@@ -121,6 +123,7 @@ async function getMoveItems(
       label: 'To top',
       icon: PublishIcon,
       action: () => doc.patch(moveFirstPatches),
+      telemetryEvent: 'Visual Editing Context Menu Item Moved',
     })
   }
   if (moveUpPatches.length) {
@@ -129,6 +132,7 @@ async function getMoveItems(
       label: 'Up',
       icon: ArrowUpIcon,
       action: () => doc.patch(moveUpPatches),
+      telemetryEvent: 'Visual Editing Context Menu Item Moved',
     })
   }
   if (moveDownPatches.length) {
@@ -137,6 +141,7 @@ async function getMoveItems(
       label: 'Down',
       icon: ArrowDownIcon,
       action: () => doc.patch(moveDownPatches),
+      telemetryEvent: 'Visual Editing Context Menu Item Moved',
     })
   }
   if (moveLastPatches.length) {
@@ -145,6 +150,7 @@ async function getMoveItems(
       label: 'To bottom',
       icon: UnpublishIcon,
       action: () => doc.patch(moveLastPatches),
+      telemetryEvent: 'Visual Editing Context Menu Item Moved',
     })
   }
 
@@ -179,12 +185,14 @@ async function getContextMenuArrayItems(context: {
     label: 'Insert before',
     icon: InsertAboveIcon,
     action: getArrayInsertAction(node, doc, field.name, 'before'),
+    telemetryEvent: 'Visual Editing Context Menu Item Inserted',
   })
   items.push({
     type: 'action',
     label: 'Insert after',
     icon: InsertBelowIcon,
     action: getArrayInsertAction(node, doc, field.name, 'after'),
+    telemetryEvent: 'Visual Editing Context Menu Item Inserted',
   })
 
   return items
@@ -300,6 +308,7 @@ async function getContextMenuUnionItems(context: {
           icon: getNodeIcon(t),
           label: t.name === 'block' ? 'Paragraph' : t.title || t.name,
           action: getArrayInsertAction(node, doc, t.name, 'before'),
+          telemetryEvent: 'Visual Editing Context Menu Item Inserted',
         }
       }),
     })
@@ -315,6 +324,7 @@ async function getContextMenuUnionItems(context: {
           label: t.name === 'block' ? 'Paragraph' : t.title || t.name,
           icon: getNodeIcon(t),
           action: getArrayInsertAction(node, doc, t.name, 'after'),
+          telemetryEvent: 'Visual Editing Context Menu Item Inserted',
         }
       }),
     })

--- a/packages/visual-editing/src/ui/context-menu/contextMenuItems.tsx
+++ b/packages/visual-editing/src/ui/context-menu/contextMenuItems.tsx
@@ -29,7 +29,6 @@ import {
   getArrayMovePatches,
   getArrayRemovePatches,
 } from '../../util/mutations'
-import {useTelemetry} from '../telemetry/useTelemetry'
 
 export function getArrayRemoveAction(node: SanityNode, doc: OptimisticDocument): () => void {
   if (!node.type) throw new Error('Node type is missing')
@@ -249,9 +248,7 @@ async function getContextMenuUnionItems(context: {
 
     items.push({
       type: 'custom',
-      component: ({boundaryElement}) => {
-        const sendTelemetry = useTelemetry()
-
+      component: ({boundaryElement, sendTelemetry}) => {
         const onSelect = (schemaType: SchemaType) => {
           const action = getArrayInsertAction(node, doc, schemaType.name, 'before')
           action()
@@ -272,9 +269,7 @@ async function getContextMenuUnionItems(context: {
 
     items.push({
       type: 'custom',
-      component: ({boundaryElement}) => {
-        const sendTelemetry = useTelemetry()
-
+      component: ({boundaryElement, sendTelemetry}) => {
         const onSelect = (schemaType: SchemaType) => {
           const action = getArrayInsertAction(node, doc, schemaType.name, 'after')
           action()

--- a/packages/visual-editing/src/ui/context-menu/contextMenuItems.tsx
+++ b/packages/visual-editing/src/ui/context-menu/contextMenuItems.tsx
@@ -29,6 +29,7 @@ import {
   getArrayMovePatches,
   getArrayRemovePatches,
 } from '../../util/mutations'
+import {useTelemetry} from '../telemetry/useTelemetry'
 
 export function getArrayRemoveAction(node: SanityNode, doc: OptimisticDocument): () => void {
   if (!node.type) throw new Error('Node type is missing')
@@ -249,9 +250,13 @@ async function getContextMenuUnionItems(context: {
     items.push({
       type: 'custom',
       component: ({boundaryElement}) => {
+        const sendTelemetry = useTelemetry()
+
         const onSelect = (schemaType: SchemaType) => {
           const action = getArrayInsertAction(node, doc, schemaType.name, 'before')
           action()
+
+          sendTelemetry('Visual Editing Context Menu Item Inserted', null)
         }
         return (
           <InsertMenuWrapper
@@ -268,9 +273,13 @@ async function getContextMenuUnionItems(context: {
     items.push({
       type: 'custom',
       component: ({boundaryElement}) => {
+        const sendTelemetry = useTelemetry()
+
         const onSelect = (schemaType: SchemaType) => {
           const action = getArrayInsertAction(node, doc, schemaType.name, 'after')
           action()
+
+          sendTelemetry('Visual Editing Context Menu Item Inserted', null)
         }
         return (
           <InsertMenuWrapper

--- a/packages/visual-editing/src/ui/telemetry/TelemetryContext.tsx
+++ b/packages/visual-editing/src/ui/telemetry/TelemetryContext.tsx
@@ -32,6 +32,11 @@ export const events = {
     description: 'An item is inserted using the Context Menu.',
     version: 1,
   }),
+  'Visual Editing Insert Menu Item Inserted': defineEvent({
+    name: 'Visual Editing Insert Menu Item Inserted',
+    description: 'An item is inserted using the Insert Menu.',
+    version: 1,
+  }),
 }
 
 type EventDataMap = {

--- a/packages/visual-editing/src/ui/telemetry/TelemetryContext.tsx
+++ b/packages/visual-editing/src/ui/telemetry/TelemetryContext.tsx
@@ -1,10 +1,15 @@
 import {defineEvent} from '@sanity/telemetry'
-import type {VisualEditingNode} from '../../types'
+import {createContext} from 'react'
 
-const events = {
+export const events = {
   'Visual Editing Drag Sequence Completed': defineEvent({
     name: 'Visual Editing Drag Sequence Completed',
     description: 'An array is successfully reordered using drag and drop.',
+    version: 1,
+  }),
+  'Visual Editing Context Menu Item Removed': defineEvent({
+    name: 'Visual Editing Context Menu Item Removed',
+    description: 'An item is removed using the Context Menu.',
     version: 1,
   }),
 }
@@ -15,20 +20,9 @@ type EventDataMap = {
     : never
 }
 
-function sendTelemetry<K extends keyof typeof events>(
+export type TelemetryContextValue = <K extends keyof typeof events>(
   name: K,
   data: EventDataMap[K] extends void ? null | undefined : EventDataMap[K],
-  comlink: VisualEditingNode | undefined,
-): void {
-  if (!comlink) return
+) => void
 
-  const event = events[name]
-
-  if (!event) {
-    throw new Error(`Telemetry event: ${name} does not exist`)
-  } else {
-    comlink.post('visual-editing/telemetry-log', {event, data})
-  }
-}
-
-export {sendTelemetry}
+export const TelemetryContext = createContext<TelemetryContextValue | undefined>(undefined)

--- a/packages/visual-editing/src/ui/telemetry/TelemetryContext.tsx
+++ b/packages/visual-editing/src/ui/telemetry/TelemetryContext.tsx
@@ -18,7 +18,7 @@ export const events = {
     version: 1,
   }),
   'Visual Editing Context Menu Item Duplicated': defineEvent({
-    name: 'Visual Editing Context Menu Item Dupliacted',
+    name: 'Visual Editing Context Menu Item Duplicated',
     description: 'An item is duplicated using the Context Menu.',
     version: 1,
   }),
@@ -49,6 +49,8 @@ type EventDataMap = {
     ? T
     : never
 }
+
+export type TelemetryEventNames = keyof typeof events
 
 export type TelemetryContextValue = <K extends keyof typeof events>(
   name: K,

--- a/packages/visual-editing/src/ui/telemetry/TelemetryContext.tsx
+++ b/packages/visual-editing/src/ui/telemetry/TelemetryContext.tsx
@@ -37,6 +37,11 @@ export const events = {
     description: 'An item is inserted using the Insert Menu.',
     version: 1,
   }),
+  'Visual Editing Overlay Clicked': defineEvent({
+    name: 'Visual Editing Overlay Clicked',
+    description: 'An Overlay is clicked.',
+    version: 1,
+  }),
 }
 
 type EventDataMap = {

--- a/packages/visual-editing/src/ui/telemetry/TelemetryContext.tsx
+++ b/packages/visual-editing/src/ui/telemetry/TelemetryContext.tsx
@@ -7,6 +7,11 @@ export const events = {
     description: 'An array is successfully reordered using drag and drop.',
     version: 1,
   }),
+  'Visual Editing Drag Minimap Enabled': defineEvent({
+    name: 'Visual Editing Drag Minimap Enabled',
+    description: 'The zoomed-out minimap view is enabled during a drag sequence.',
+    version: 1,
+  }),
   'Visual Editing Context Menu Item Removed': defineEvent({
     name: 'Visual Editing Context Menu Item Removed',
     description: 'An item is removed using the Context Menu.',

--- a/packages/visual-editing/src/ui/telemetry/TelemetryContext.tsx
+++ b/packages/visual-editing/src/ui/telemetry/TelemetryContext.tsx
@@ -12,6 +12,21 @@ export const events = {
     description: 'An item is removed using the Context Menu.',
     version: 1,
   }),
+  'Visual Editing Context Menu Item Duplicated': defineEvent({
+    name: 'Visual Editing Context Menu Item Dupliacted',
+    description: 'An item is duplicated using the Context Menu.',
+    version: 1,
+  }),
+  'Visual Editing Context Menu Item Moved': defineEvent({
+    name: 'Visual Editing Context Menu Item Moved',
+    description: 'An item is moved using the Context Menu.',
+    version: 1,
+  }),
+  'Visual Editing Context Menu Item Inserted': defineEvent({
+    name: 'Visual Editing Context Menu Item Inserted',
+    description: 'An item is inserted using the Context Menu.',
+    version: 1,
+  }),
 }
 
 type EventDataMap = {

--- a/packages/visual-editing/src/ui/telemetry/TelemetryProvider.tsx
+++ b/packages/visual-editing/src/ui/telemetry/TelemetryProvider.tsx
@@ -1,0 +1,24 @@
+import {useCallback, type FunctionComponent, type PropsWithChildren} from 'react'
+import type {VisualEditingNode} from '../../types'
+import {events, TelemetryContext, type TelemetryContextValue} from './TelemetryContext'
+
+export const TelemetryProvider: FunctionComponent<
+  PropsWithChildren<{comlink?: VisualEditingNode}>
+> = ({children, comlink}) => {
+  const log = useCallback<TelemetryContextValue>(
+    (name, data) => {
+      if (!comlink) return
+
+      const event = events[name]
+
+      if (!event) {
+        throw new Error(`Telemetry event: ${name} does not exist`)
+      } else {
+        comlink.post('visual-editing/telemetry-log', {event, data})
+      }
+    },
+    [comlink],
+  )
+
+  return <TelemetryContext.Provider value={log}>{children}</TelemetryContext.Provider>
+}

--- a/packages/visual-editing/src/ui/telemetry/useTelemetry.tsx
+++ b/packages/visual-editing/src/ui/telemetry/useTelemetry.tsx
@@ -1,0 +1,12 @@
+import {useContext} from 'react'
+import {TelemetryContext, type TelemetryContextValue} from './TelemetryContext'
+
+export function useTelemetry(): TelemetryContextValue {
+  const context = useContext(TelemetryContext)
+
+  if (!context) {
+    throw new Error('Telemetry context is missing')
+  }
+
+  return context
+}

--- a/packages/visual-editing/src/util/dragAndDrop.ts
+++ b/packages/visual-editing/src/util/dragAndDrop.ts
@@ -455,13 +455,6 @@ export function handleOverlayDrag(opts: HandleOverlayDragOpts): void {
       display: false,
     })
 
-    handler({
-      type: 'overlay/dragToggleMinimap',
-      display: true,
-    })
-
-    minimapScaleApplied = true
-
     applyMinimapWrapperTransform(
       scaleTarget,
       scaleFactor,
@@ -497,6 +490,8 @@ export function handleOverlayDrag(opts: HandleOverlayDragOpts): void {
 
     if (e.shiftKey && !minimapScaleApplied && !disableMinimap) {
       window.dispatchEvent(new CustomEvent('unstable_sanity/dragApplyMinimap'))
+
+      minimapScaleApplied = true
 
       setTimeout(() => {
         applyMinimap()
@@ -544,6 +539,8 @@ export function handleOverlayDrag(opts: HandleOverlayDragOpts): void {
 
     if (e.shiftKey && !minimapScaleApplied && !disableMinimap) {
       window.dispatchEvent(new CustomEvent('unstable_sanity/dragApplyMinimap'))
+
+      minimapScaleApplied = true
 
       setTimeout(() => {
         applyMinimap()


### PR DESCRIPTION
This PR: 

- Adds a new `useTelemetry` hook to Visual Editing that makes it easier to send telemetry in nested components
- Adds several new telemetry events: 
- `Visual Editing Drag Minimap Enabled`
- `Visual Editing Context Menu Item Removed`
- `Visual Editing Context Menu Item Duplicated`
- `Visual Editing Context Menu Item Moved`
- `Visual Editing Context Menu Item Inserted`
- `Visual Editing Insert Menu Item Inserted`
- `Visual Editing Overlay Clicked`

Question for @sanity-io/creator-x — is there any other events we would like to add as part of this PR? Trying to hit all the basic elements here and we can expand with more niche scenarios in time. 

⚠️ Events must be reviewed by @sanity-io/data-eng  before merging ⚠️