### PR TITLE
feat: add optional redirect override to svelte preview handler

### DIFF
--- a/apps/svelte/src/hooks.server.ts
+++ b/apps/svelte/src/hooks.server.ts
@@ -1,6 +1,7 @@
 import {createRequestHandler, setServerClient} from '@sanity/svelte-loader'
+import {redirect} from '@sveltejs/kit'
 import {serverClient} from '$lib/server/sanity'
 
 setServerClient(serverClient)
 
-export const handle = createRequestHandler()
+export const handle = createRequestHandler({preview: {redirect}})

--- a/apps/svelte/src/routes/shoes-with-loaders/+layout.svelte
+++ b/apps/svelte/src/routes/shoes-with-loaders/+layout.svelte
@@ -5,21 +5,19 @@
   import {client} from '$lib/sanity'
 </script>
 
-<div class="app">
-  {#if $isPreviewing}
-    <a
-      href={`/preview/disable?redirect=${$page.url.pathname}`}
-      class="group sticky top-0 z-50 block h-8 w-full bg-white/30 p-2 text-center text-xs text-gray-800 shadow-lg backdrop-blur-md hover:bg-red-500 hover:text-white"
-    >
-      <span class="block group-hover:hidden">Preview Enabled (Shoes with Loaders)</span>
-      <span class="hidden group-hover:block">Disable Preview</span>
-    </a>
-  {/if}
+{#if $isPreviewing}
+  <a
+    href={`/preview/disable?redirect=${$page.url.pathname}`}
+    class="group sticky top-0 z-50 block h-8 w-full bg-white/30 p-2 text-center text-xs text-gray-800 shadow-lg backdrop-blur-md hover:bg-red-500 hover:text-white"
+  >
+    <span class="block group-hover:hidden">Preview Enabled (Shoes with Loaders)</span>
+    <span class="hidden group-hover:block">Disable Preview</span>
+  </a>
+{/if}
 
-  <slot />
+<slot />
 
-  {#if $isPreviewing}
-    <VisualEditing />
-    <LiveMode {client} />
-  {/if}
-</div>
+{#if $isPreviewing}
+  <VisualEditing />
+  <LiveMode {client} />
+{/if}

--- a/apps/svelte/src/routes/shoes/+layout.svelte
+++ b/apps/svelte/src/routes/shoes/+layout.svelte
@@ -3,17 +3,15 @@
   import {page} from '$app/stores'
 </script>
 
-<div class="app">
-  {#if $isPreviewing}
-    <a
-      href={`/preview/disable?redirect=${$page.url.pathname}`}
-      class="group sticky top-0 z-50 block h-8 w-full bg-white/30 p-2 text-center text-xs text-gray-800 shadow-lg backdrop-blur-md hover:bg-red-500 hover:text-white"
-    >
-      <span class="block group-hover:hidden">Preview Enabled (Shoes)</span>
-      <span class="hidden group-hover:block">Disable Preview</span>
-    </a>
-    <VisualEditing />
-  {/if}
+{#if $isPreviewing}
+  <a
+    href={`/preview/disable?redirect=${$page.url.pathname}`}
+    class="group sticky top-0 z-50 block h-8 w-full bg-white/30 p-2 text-center text-xs text-gray-800 shadow-lg backdrop-blur-md hover:bg-red-500 hover:text-white"
+  >
+    <span class="block group-hover:hidden">Preview Enabled (Shoes)</span>
+    <span class="hidden group-hover:block">Disable Preview</span>
+  </a>
+  <VisualEditing />
+{/if}
 
-  <slot />
-</div>
+<slot />

--- a/packages/svelte-loader/package.json
+++ b/packages/svelte-loader/package.json
@@ -57,7 +57,6 @@
     "@repo/prettier-config": "workspace:*",
     "@repo/visual-editing-helpers": "workspace:*",
     "@sanity/pkg-utils": "6.13.1",
-    "@sanity/preview-url-secret": "workspace:*",
     "@sanity/visual-editing": "workspace:*",
     "@sveltejs/kit": "^2.15.2",
     "@sveltejs/vite-plugin-svelte": "^3.1.2",
@@ -68,6 +67,7 @@
     "vitest": "^2.1.8"
   },
   "peerDependencies": {
+    "@sanity/visual-editing": "2.x",
     "@sveltejs/kit": "2.x",
     "svelte": "4.x"
   },

--- a/packages/svelte-loader/src/hooks.ts
+++ b/packages/svelte-loader/src/hooks.ts
@@ -40,7 +40,7 @@ export const handleLoadQuery =
 /**
  * @beta
  */
-export const createRequestHandler = ({preview, loadQuery}: HandleOptions = {}): Handle => {
+export const createRequestHandler = ({loadQuery, preview}: HandleOptions = {}): Handle => {
   const client = preview?.client || unstable__serverClient.instance
   if (!client) throw new Error('No Sanity client configured for preview')
   return sequence(handlePreview({client, preview}), handleLoadQuery({loadQuery}))

--- a/packages/visual-editing/svelte/hooks.ts
+++ b/packages/visual-editing/svelte/hooks.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto'
 import {validatePreviewUrl} from '@sanity/preview-url-secret'
-import {error, redirect, type Handle} from '@sveltejs/kit'
+import {redirect as defaultRedirect, error, type Handle} from '@sveltejs/kit'
 import type {HandlePreviewOptions} from './types'
 
 /**
@@ -11,6 +11,7 @@ export const handlePreview = ({client, preview}: HandlePreviewOptions): Handle =
   const enablePath = preview?.endpoints?.enable || '/preview/enable'
   const disablePath = preview?.endpoints?.disable || '/preview/disable'
   const secret = preview?.secret || crypto.randomBytes(16).toString('hex')
+  const redirect = preview?.redirect || defaultRedirect
 
   if (!client) throw new Error('No client configured for preview')
 

--- a/packages/visual-editing/svelte/types.ts
+++ b/packages/visual-editing/svelte/types.ts
@@ -37,6 +37,12 @@ export interface HandlePreviewOptions {
       enable?: string
       disable?: string
     }
+    /**
+     * For explicitly providing a redirect function in case of mistmatched
+     * Svelte specific dependency versions, not needed in most cases. See
+     * https://github.com/sveltejs/kit/issues/11749 for more information
+     */
+    redirect?: (status: number, location: string | URL) => never
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1463,9 +1463,6 @@ importers:
       '@sanity/pkg-utils':
         specifier: 6.13.1
         version: 6.13.1(@types/babel__core@7.20.5)(@types/node@22.10.5)(babel-plugin-react-compiler@19.0.0-beta-63e3235-20250105)(typescript@5.7.2)
-      '@sanity/preview-url-secret':
-        specifier: workspace:*
-        version: link:../preview-url-secret
       '@sanity/visual-editing':
         specifier: workspace:*
         version: link:../visual-editing
@@ -16175,7 +16172,7 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.57.1)
@@ -21033,7 +21030,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.3(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.1.0(eslint@8.57.1)
@@ -21089,22 +21086,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.0(supports-color@9.4.0)
-      enhanced-resolve: 5.18.0
-      eslint: 8.57.1
-      fast-glob: 3.3.3
-      get-tsconfig: 4.8.1
-      is-bun-module: 1.3.0
-      is-glob: 4.0.3
-      stable-hash: 0.0.4
-    optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -21137,14 +21118,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21197,7 +21178,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
The Svelte specific preview mode functionality we've implemented in the visual editing package imports `redirect` from `@sveltejs/kit`. However if the consuming app is using mismatched dependency versions the redirect will fail. See https://github.com/sveltejs/kit/issues/11749#issuecomment-1966565367 for more details as to why.

The PR just adds the option to pass a `redirect` function explicitly to override that imported by the package itself, which should ensure that preview mode redirects to the correct location instead of throwing an error.