### PR TITLE
feat(presentation): add __internalApplicationType to tool spec

### DIFF
--- a/packages/presentation/src/plugin.tsx
+++ b/packages/presentation/src/plugin.tsx
@@ -136,6 +136,7 @@ export const presentationTool = definePlugin<PresentationPluginOptions>((options
         },
         getIntentState,
         router,
+        __internalApplicationType: 'sanity/presentation',
       },
     ],
   }


### PR DESCRIPTION
Adds the `__internalApplicationType` property to the configuration of the presentation tool as part of the CoreUI project. More information can be seen here – https://github.com/sanity-io/sanity/pull/7980 – we added this parameter to many of the common tools sanity provides.

TLDR; this helps us identify & group tools across studio manifests to be used for the CoreUI menus etc. We see it as a temporary measure of using a studio manifest (similar to create) and this will be replaced in the ✨ _future_ ✨.