### PR TITLE
fix: support overlay clicks in popups

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "sanity build --source-maps",
-    "dev": "sanity dev"
+    "dev": "rimraf .sanity && sanity dev"
   },
   "prettier": "@repo/prettier-config",
   "dependencies": {
@@ -25,7 +25,8 @@
   },
   "devDependencies": {
     "@repo/prettier-config": "workspace:*",
-    "babel-plugin-react-compiler": "19.0.0-beta-63e3235-20250105"
+    "babel-plugin-react-compiler": "19.0.0-beta-63e3235-20250105",
+    "rimraf": "^5.0.5"
   },
   "dependenciesMeta": {
     "@repo/sanity-schema": {

--- a/apps/studio/turbo.json
+++ b/apps/studio/turbo.json
@@ -19,7 +19,7 @@
         "SANITY_STUDIO_PRESENTATION_ENABLE_LIVE_DRAFT_EVENTS",
         "SANITY_STUDIO_DEBUG_TELEMETRY"
       ],
-      "outputs": [".sanity/**", "dist/**"]
+      "outputs": ["dist/**"]
     },
     "dev": {
       "inputs": ["$TURBO_DEFAULT$", ".env", ".env.local"],

--- a/packages/visual-editing/src/react/useDocuments.ts
+++ b/packages/visual-editing/src/react/useDocuments.ts
@@ -25,9 +25,10 @@ function debounce<F extends (...args: Parameters<F>) => ReturnType<F>>(fn: F, ti
 }
 
 function getDocumentsAndSnapshot<T extends Record<string, any>>(id: string, actor: MutatorActor) {
-  const inFrame = window.self !== window.top || window.opener
+  const inFrame = window.self !== window.top
+  const inPopUp = Boolean(window.opener)
 
-  if (isEmptyActor(actor) || !inFrame) {
+  if (isEmptyActor(actor) || (!inFrame && !inPopUp)) {
     throw new Error('The `useDocuments` hook cannot be used in this context')
   }
 

--- a/packages/visual-editing/src/stories/Overlays.stories.tsx
+++ b/packages/visual-editing/src/stories/Overlays.stories.tsx
@@ -1,19 +1,48 @@
 import type {Meta, StoryObj} from '@storybook/react'
+import {useEffect, useState} from 'react'
+import {createPortal} from 'react-dom'
 import {Overlays} from '../ui/Overlays'
 import {useComlink} from '../ui/useComlink'
 import {MarketingPage as MarketingExample} from './examples/marketing/MarketingPage'
 import {MediaArticlePage as MediaArticleExample} from './examples/media/MediaArticlePage'
 import {MediaHomePage as MediaHomeExample} from './examples/media/MediaHomePage'
 
-function Example(props: {example: React.ComponentType; inFrame: boolean; zIndex: number}) {
-  const {example: Example, inFrame, zIndex} = props
+function Example(props: {
+  example: React.ComponentType
+  inFrame: boolean
+  inPopUp: boolean
+  zIndex: number
+}) {
+  const {example: Example, inFrame, inPopUp, zIndex} = props
 
-  const comlink = useComlink()
+  const [portalElement, setPortalElement] = useState<HTMLElement | null>(null)
+  useEffect(() => {
+    const node = document.createElement('sanity-visual-editing')
+    document.documentElement.appendChild(node)
+    setPortalElement(node)
+    return () => {
+      setPortalElement(null)
+      if (document.documentElement.contains(node)) {
+        document.documentElement.removeChild(node)
+      }
+    }
+  }, [])
+
+  const comlink = useComlink(inFrame === true || inPopUp === true)
 
   return (
     <>
       <Example />
-      {comlink && <Overlays comlink={comlink} inFrame={inFrame} zIndex={zIndex} />}
+      {portalElement &&
+        createPortal(
+          <Overlays
+            comlink={comlink}
+            inFrame={inFrame}
+            inPopUp={inPopUp && !inFrame}
+            zIndex={zIndex}
+          />,
+          portalElement,
+        )}
     </>
   )
 }
@@ -24,6 +53,7 @@ const meta = {
   args: {
     zIndex: 5,
     inFrame: false,
+    inPopUp: false,
   },
   parameters: {
     layout: 'fullscreen',

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -265,6 +265,7 @@ export interface OverlayOptions {
   handler: OverlayEventHandler
   overlayElement: HTMLElement
   inFrame: boolean
+  inPopUp: boolean
   optimisticActorReady: boolean
 }
 

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -111,11 +111,12 @@ const OverlaysController: FunctionComponent<{
   comlink?: VisualEditingNode
   dispatch: (value: OverlayMsg | VisualEditingControllerMsg) => void
   inFrame: boolean
+  inPopUp: boolean
   onDrag: (x: number, y: number) => void
   overlayEnabled: boolean
   rootElement: HTMLElement | null
 }> = (props) => {
-  const {comlink, dispatch, inFrame, onDrag, overlayEnabled, rootElement} = props
+  const {comlink, dispatch, inFrame, inPopUp, onDrag, overlayEnabled, rootElement} = props
   const {dispatchDragEndEvent} = useDragEndEvents()
 
   const overlayEventHandler: OverlayEventHandler = useCallback(
@@ -154,7 +155,7 @@ const OverlaysController: FunctionComponent<{
     [comlink, dispatch, dispatchDragEndEvent, onDrag],
   )
 
-  const controller = useController(rootElement, overlayEventHandler, inFrame)
+  const controller = useController(rootElement, overlayEventHandler, inFrame, inPopUp)
 
   useEffect(() => {
     if (overlayEnabled) {
@@ -174,9 +175,10 @@ export const Overlays: FunctionComponent<{
   comlink?: VisualEditingNode
   componentResolver?: OverlayComponentResolver
   inFrame: boolean
+  inPopUp: boolean
   zIndex?: string | number
 }> = (props) => {
-  const {comlink, componentResolver: _componentResolver, inFrame, zIndex} = props
+  const {comlink, componentResolver: _componentResolver, inFrame, inPopUp, zIndex} = props
 
   const [status, setStatus] = useState<Status>()
 
@@ -337,7 +339,7 @@ export const Overlays: FunctionComponent<{
   }, [_componentResolver, optimisticActorReady])
 
   const elementsToRender = useMemo(() => {
-    if ((inFrame && status !== 'connected') || isDragging) {
+    if (((inFrame || inPopUp) && status !== 'connected') || isDragging) {
       return []
     }
 
@@ -364,6 +366,7 @@ export const Overlays: FunctionComponent<{
             hovered={hovered}
             node={sanity}
             rect={rect}
+            // When inside a popup window we want actions to show up on hover, but iframes should hide them
             showActions={!inFrame}
             draggable={draggable}
             isDragging={isDragging || dragMinimapTransition}
@@ -377,6 +380,7 @@ export const Overlays: FunctionComponent<{
     dragShowMinimap,
     elements,
     inFrame,
+    inPopUp,
     isDragging,
     optimisticActorReady,
     status,
@@ -401,6 +405,7 @@ export const Overlays: FunctionComponent<{
                     comlink={comlink}
                     dispatch={dispatch}
                     inFrame={inFrame}
+                    inPopUp={inPopUp}
                     onDrag={updateDragPreviewCustomProps}
                     overlayEnabled={overlayEnabled}
                     rootElement={rootElement}

--- a/packages/visual-editing/src/ui/VisualEditing.tsx
+++ b/packages/visual-editing/src/ui/VisualEditing.tsx
@@ -15,7 +15,11 @@ export const VisualEditing = (props: VisualEditingOptions & {portal: boolean}): 
   const {components, history, portal = true, refresh, zIndex} = props
 
   const [inFrame, setInFrame] = useState<boolean | null>(null)
-  useEffect(() => setInFrame(window.self !== window.top || Boolean(window.opener)), [])
+  const [inPopUp, setInPopUp] = useState<boolean | null>(null)
+  useEffect(() => {
+    setInFrame(window.self !== window.top)
+    setInPopUp(Boolean(window.opener))
+  }, [])
 
   const [portalElement, setPortalElement] = useState<HTMLElement | null>(null)
   useEffect(() => {
@@ -31,16 +35,17 @@ export const VisualEditing = (props: VisualEditingOptions & {portal: boolean}): 
     }
   }, [portal])
 
-  const comlink = useComlink(inFrame === true)
+  const comlink = useComlink(inFrame === true || inPopUp === true)
   useDatasetMutator(comlink)
 
   const children = (
     <>
-      {inFrame !== null && (
+      {inFrame !== null && inPopUp !== null && (
         <Overlays
           comlink={comlink}
           componentResolver={components}
           inFrame={inFrame}
+          inPopUp={inPopUp}
           zIndex={zIndex}
         />
       )}

--- a/packages/visual-editing/src/ui/useController.tsx
+++ b/packages/visual-editing/src/ui/useController.tsx
@@ -11,6 +11,7 @@ export function useController(
   element: HTMLElement | null,
   handler: OverlayEventHandler,
   inFrame: boolean,
+  inPopUp: boolean,
 ): MutableRefObject<OverlayController | undefined> {
   const overlayController = useRef<OverlayController | undefined>()
 
@@ -23,6 +24,7 @@ export function useController(
       handler,
       overlayElement: element,
       inFrame,
+      inPopUp,
       optimisticActorReady,
     })
 
@@ -30,7 +32,7 @@ export function useController(
       overlayController.current?.destroy()
       overlayController.current = undefined
     }
-  }, [element, handler, inFrame, optimisticActorReady])
+  }, [element, handler, inFrame, inPopUp, optimisticActorReady])
 
   return overlayController
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -704,6 +704,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: 19.0.0-beta-63e3235-20250105
         version: 19.0.0-beta-63e3235-20250105
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
     dependenciesMeta:
       '@repo/sanity-schema':
         injected: true


### PR DESCRIPTION
[Thread](https://sanity-io.slack.com/archives/C043ZRB9E4S/p1736263845340979)

It's clear we now need to make a distinction on wether we're inside an iframe, or a popup window, as the UX have nuanced differences.
iframes don't want "Open in Studio" buttons for example, but popups do 😅 

Also fixes a regression from https://github.com/sanity-io/visual-editing/pull/2356