### PR TITLE
fix(visual-editing): fix svelte imports

### DIFF
--- a/packages/visual-editing/svelte/VisualEditing.svelte
+++ b/packages/visual-editing/svelte/VisualEditing.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+  import {enableVisualEditing, type HistoryAdapterNavigate} from '@sanity/visual-editing'
   import {afterNavigate, goto, invalidateAll} from '$app/navigation'
   import {onMount} from 'svelte'
-  import {enableVisualEditing, type HistoryAdapterNavigate} from '../dist/index.js'
   import type {VisualEditingProps} from './types'
 
   export let zIndex: VisualEditingProps['zIndex'] = undefined

--- a/packages/visual-editing/svelte/hooks.ts
+++ b/packages/visual-editing/svelte/hooks.ts
@@ -32,7 +32,7 @@ export const handlePreview = ({client, preview}: HandlePreviewOptions): Handle =
         throw error(401, 'Invalid secret')
       }
 
-      const devMode = process.env.NODE_ENV === 'development'
+      const devMode = process.env['NODE_ENV'] === 'development'
       cookies.set(cookieName, secret, {
         httpOnly: true,
         sameSite: devMode ? 'lax' : 'none',

--- a/packages/visual-editing/svelte/optimistic/useOptimistic.ts
+++ b/packages/visual-editing/svelte/optimistic/useOptimistic.ts
@@ -6,8 +6,12 @@ import {
 } from '@sanity/visual-editing/optimistic'
 import {onMount} from 'svelte'
 import {derived, get, writable, type Readable} from 'svelte/store'
-import {getPublishedId} from '../../src/util/documents'
 import {optimisticActor} from './optimisticActor'
+
+function getPublishedId(id: string): string {
+  const DRAFTS_PREFIX = 'drafts.'
+  return id.startsWith(DRAFTS_PREFIX) ? id.slice(DRAFTS_PREFIX.length) : id
+}
 
 export function useOptimistic<T, U = SanityDocument>(
   initial: T,

--- a/packages/visual-editing/svelte/types.ts
+++ b/packages/visual-editing/svelte/types.ts
@@ -1,5 +1,5 @@
 import type {SanityClient} from '@sanity/client'
-import type {HistoryRefresh, VisualEditingOptions} from '../dist'
+import type {HistoryRefresh, VisualEditingOptions} from '@sanity/visual-editing'
 
 /** @public */
 export interface VisualEditingProps extends Omit<VisualEditingOptions, 'history' | 'refresh'> {


### PR DESCRIPTION
The new optimistic functionality introduced imports from an internal repo (`@repo/visual-editing-helpers`) that `svelte-package` is unable to bundle. This moves the `getPublishedId` function inline instead of importing for now as it's super simple.

Should fix https://github.com/sanity-io/visual-editing/issues/2333.