### PR TITLE
feat(comlink)!: update internal message types, buffer unhandled messages

### DIFF
--- a/packages/comlink/playground/app/routes/_index.tsx
+++ b/packages/comlink/playground/app/routes/_index.tsx
@@ -43,17 +43,15 @@ export default function Index() {
 
     setChannel(channel)
 
-    channel.onInternalEvent('_message', (event) => {
-      console.log('_message', event)
-      setReceived((prev) => [event.message, ...prev])
+    channel.onInternalEvent('message', ({message}) => {
+      setReceived((prev) => [message, ...prev])
     })
 
-    channel.onInternalEvent('_buffer.added', (event) => {
-      console.log('_buffer.added', event)
+    channel.onInternalEvent('buffer.added', (event) => {
       setBuffer((prev) => [event.message, ...prev])
     })
 
-    channel.onInternalEvent('_buffer.flushed', () => {
+    channel.onInternalEvent('buffer.flushed', () => {
       setBuffer([])
     })
 

--- a/packages/comlink/playground/app/routes/frame.tsx
+++ b/packages/comlink/playground/app/routes/frame.tsx
@@ -27,15 +27,15 @@ export default function Frame() {
 
     setNode(node)
 
-    node.actor.on('_message', (event) => {
+    node.actor.on('message', (event) => {
       setReceived((prev) => [event.message, ...prev])
     })
 
-    node.actor.on('_buffer.added', (event) => {
+    node.actor.on('buffer.added', (event) => {
       setBuffered((prev) => [event.message, ...prev])
     })
 
-    node.actor.on('_buffer.flushed', () => {
+    node.actor.on('buffer.flushed', () => {
       setBuffered([])
     })
 

--- a/packages/comlink/src/common.ts
+++ b/packages/comlink/src/common.ts
@@ -20,7 +20,7 @@ export const listenInputFromContext =
     },
   ) =>
   <
-    T extends {
+    TContext extends {
       domain: string
       connectTo: string
       name: string
@@ -29,7 +29,7 @@ export const listenInputFromContext =
   >({
     context,
   }: {
-    context: T
+    context: TContext
   }): ListenInput => {
     const {count, include, exclude, responseType = 'message.received'} = config
     return {
@@ -59,8 +59,10 @@ export const listenFilter =
   }
 
 export const eventToMessage =
-  <T>(type: T) =>
-  (event: MessageEvent<ProtocolMessage>): {type: T; message: MessageEvent<ProtocolMessage>} => ({
+  <TType>(type: TType) =>
+  (
+    event: MessageEvent<ProtocolMessage>,
+  ): {type: TType; message: MessageEvent<ProtocolMessage>} => ({
     type,
     message: event,
   })

--- a/packages/comlink/src/index.ts
+++ b/packages/comlink/src/index.ts
@@ -38,7 +38,6 @@ export type {
   MessageEmitEvent,
   MessageType,
   ProtocolMessage,
-  ReceivedEmitEvent,
   RequestData,
   ResponseMessage,
   Status,

--- a/packages/comlink/src/request.ts
+++ b/packages/comlink/src/request.ts
@@ -24,7 +24,7 @@ const throwOnEvent =
 /**
  * @public
  */
-export interface RequestMachineContext<S extends Message> {
+export interface RequestMachineContext<TSends extends Message> {
   channelId: string
   data: MessageData | undefined
   domain: string
@@ -32,8 +32,8 @@ export interface RequestMachineContext<S extends Message> {
   from: string
   id: string
   parentRef: AnyActorRef
-  resolvable: PromiseWithResolvers<S['response']> | undefined
-  response: S['response'] | null
+  resolvable: PromiseWithResolvers<TSends['response']> | undefined
+  response: TSends['response'] | null
   responseTimeout: number | undefined
   responseTo: string | undefined
   signal: AbortSignal | undefined
@@ -47,15 +47,15 @@ export interface RequestMachineContext<S extends Message> {
 /**
  * @public
  */
-export type RequestActorRef<S extends Message> = ActorRefFrom<
-  ReturnType<typeof createRequestMachine<S>>
+export type RequestActorRef<TSends extends Message> = ActorRefFrom<
+  ReturnType<typeof createRequestMachine<TSends>>
 >
 
 /**
  * @public
  */
 export const createRequestMachine = <
-  S extends Message,
+  TSends extends Message,
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 >() => {
   return setup({
@@ -63,7 +63,7 @@ export const createRequestMachine = <
       children: {
         'listen for response': 'listen'
       }
-      context: RequestMachineContext<S>
+      context: RequestMachineContext<TSends>
       // @todo Should response types be specified?
       events: {type: 'message'; data: ProtocolMessage<ResponseMessage>} | {type: 'abort'}
       emitted:
@@ -77,12 +77,12 @@ export const createRequestMachine = <
           }
       input: {
         channelId: string
-        data?: S['data']
+        data?: TSends['data']
         domain: string
         expectResponse?: boolean
         from: string
         parentRef: AnyActorRef
-        resolvable?: PromiseWithResolvers<S['response']>
+        resolvable?: PromiseWithResolvers<TSends['response']>
         responseTimeout?: number
         responseTo?: string
         signal?: AbortSignal
@@ -90,11 +90,11 @@ export const createRequestMachine = <
         suppressWarnings?: boolean
         targetOrigin: string
         to: string
-        type: S['type']
+        type: TSends['type']
       }
       output: {
         requestId: string
-        response: S['response'] | null
+        response: TSends['response'] | null
         responseTo: string | undefined
       }
     },

--- a/packages/comlink/src/types.ts
+++ b/packages/comlink/src/types.ts
@@ -39,12 +39,12 @@ export interface Message {
 /**
  * @public
  */
-export interface RequestData<S extends Message> {
+export interface RequestData<TSends extends Message> {
   data?: MessageData
   expectResponse?: boolean
   responseTo?: string
   type: MessageType
-  resolvable?: PromiseWithResolvers<S['response']>
+  resolvable?: PromiseWithResolvers<TSends['response']>
   options?: {
     responseTimeout?: number
     signal?: AbortSignal
@@ -55,7 +55,7 @@ export interface RequestData<S extends Message> {
 /**
  * @public
  */
-export type WithoutResponse<T extends Message> = Omit<T, 'response'>
+export type WithoutResponse<TMessage extends Message> = Omit<TMessage, 'response'>
 
 /**
  * @public
@@ -74,67 +74,60 @@ export interface ListenInput {
 /**
  * @public
  */
-export interface BufferAddedEmitEvent<T extends Message> {
-  type: '_buffer.added'
-  message: T
+export interface BufferAddedEmitEvent<TMessage extends Message> {
+  type: 'buffer.added'
+  message: TMessage
 }
 
 /**
  * @public
  */
-export interface BufferFlushedEmitEvent<T extends Message> {
-  type: '_buffer.flushed'
-  messages: T[]
+export interface BufferFlushedEmitEvent<TMessage extends Message> {
+  type: 'buffer.flushed'
+  messages: TMessage[]
 }
 
 /**
  * @public
  */
 export interface HeartbeatEmitEvent {
-  type: '_heartbeat'
-}
-
-/**
- * @public
- */
-export interface MessageEmitEvent<T extends Message> {
-  type: '_message'
-  message: ProtocolMessage<T>
+  type: 'heartbeat'
 }
 
 /**
  * @public
  */
 export interface StatusEmitEvent {
-  type: '_status'
+  type: 'status'
   status: Status
 }
 
-export type ReceivedEmitEvent<T extends Message> = T extends T
-  ? {type: T['type']; message: ProtocolMessage<T>}
-  : never
+export type MessageEmitEvent<TMessage extends Message> = {
+  type: 'message'
+  message: ProtocolMessage<TMessage>
+}
 
 /**
  * @public
  */
-export type InternalEmitEvent<S extends Message, R extends Message> =
-  | BufferAddedEmitEvent<S>
-  | BufferFlushedEmitEvent<R>
-  | MessageEmitEvent<R>
+export type InternalEmitEvent<TSends extends Message, TReceives extends Message> =
+  | BufferAddedEmitEvent<TSends>
+  | BufferFlushedEmitEvent<TReceives>
+  | MessageEmitEvent<TReceives>
   | StatusEmitEvent
 
 /**
  * @public
  */
-export type ProtocolMessage<T extends Message = Message> = {
+export type ProtocolMessage<TMessage extends Message = Message> = {
   id: string
   channelId: string
-  data?: T['data']
+  data?: TMessage['data']
   domain: string
   from: string
   responseTo?: string
   to: string
-  type: T['type']
+  type: TMessage['type']
 }
 
 /**

--- a/packages/visual-editing/src/ui/useComlink.tsx
+++ b/packages/visual-editing/src/ui/useComlink.tsx
@@ -26,19 +26,10 @@ export function useComlink(active: boolean = true): VisualEditingNode | undefine
       }),
     )
 
-    let timeout = 0
+    setNode(instance)
     const stop = instance.start()
-    // Wait with forwarding the comlink until the connection is established
-    const unsubscribe = instance.onStatus(() => {
-      // Due to race conditions in when Presentation Tool loads up components with handlers for comlink, we need to wait a bit before forwarding the comlink instance
-      timeout = window.setTimeout(() => {
-        setNode(instance)
-      }, 3_000)
-    }, 'connected')
 
     return () => {
-      clearTimeout(timeout)
-      unsubscribe()
       stop()
       setNode(undefined)
     }


### PR DESCRIPTION
This PR introduces unhandled message buffering, so that if some event handler is added after a related event is received, the last n (defaults to 1) events can be replayed. This should resolve the race condition issue we've been seeing.

It also introduces a change I've wanted to make for a while, specifically to remove user defined events being emitted directly from the `node` and `connection` actors. All Comlink messages are now emitted via the `'message'` event type, so the state machine will no longer directly emit messages like `'visual-editing/focus'`. This means we no longer need to prefix state machine related events (referred to as "internal events") with an underscore to differentiate them from user defined events, and it also helps improves typings.

As these internal event types are accessible via the `onInternalEvent` method, this is a breaking change.

I've also refactored generic type names to follow convention as they were unnecessarily ambiguous, i.e. `S` -> `TSends`, `R` -> `TReceives`.