### PR TITLE
fix: explicitly fetch preview snapshots on connect

### DIFF
--- a/packages/visual-editing-helpers/src/types/comlink.ts
+++ b/packages/visual-editing-helpers/src/types/comlink.ts
@@ -195,6 +195,13 @@ export type VisualEditingNodeMsg =
       }
     }
   | {
+      type: 'visual-editing/preview-snapshots'
+      data: undefined
+      response: {
+        snapshots: PreviewSnapshot[]
+      }
+    }
+  | {
       type: 'visual-editing/refreshing'
       data: HistoryRefresh
     }

--- a/packages/visual-editing/src/ui/preview/PreviewSnapshotsProvider.tsx
+++ b/packages/visual-editing/src/ui/preview/PreviewSnapshotsProvider.tsx
@@ -1,4 +1,11 @@
-import {useEffect, useMemo, useState, type FunctionComponent, type PropsWithChildren} from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type FunctionComponent,
+  type PropsWithChildren,
+} from 'react'
 import type {VisualEditingNode} from '../../types'
 import {PreviewSnapshotsContext, type PreviewSnapshotsContextValue} from './PreviewSnapshotsContext'
 
@@ -10,6 +17,36 @@ export const PreviewSnapshotsProvider: FunctionComponent<
   const {comlink, children} = props
 
   const [previewSnapshots, setPreviewSnapshots] = useState<PreviewSnapshotsContextValue>([])
+
+  const fetchPreviewSnapshots = useCallback(
+    async (signal: AbortSignal) => {
+      if (!comlink) return
+      try {
+        const response = await comlink.fetch('visual-editing/preview-snapshots', undefined, {
+          signal,
+          suppressWarnings: true,
+        })
+        setPreviewSnapshots(response.snapshots)
+      } catch (e) {
+        // Fail silently as the app may be communicating with a version of
+        // Presentation that does not support this feature
+      }
+    },
+    [comlink],
+  )
+  useEffect(() => {
+    if (!comlink) return
+
+    const previewSapshotsFetch = new AbortController()
+    const unsub = comlink.onStatus(() => {
+      fetchPreviewSnapshots(previewSapshotsFetch.signal)
+    }, 'connected')
+
+    return () => {
+      previewSapshotsFetch.abort()
+      unsub()
+    }
+  }, [comlink, fetchPreviewSnapshots])
 
   useEffect(() => {
     return comlink?.on('presentation/preview-snapshots', (data) => {


### PR DESCRIPTION
Ensure the visual editing package explicitly requests preview snapshots for Presentation on connect, this should fix the issue we're seeing with Astro.

Currently snapshots are only returned from Presentation when the preview snapshot observable emits. This is a problem if for example the app inside the iframe reloads, as the observable will not emit until some change is made.