### PR TITLE
fix: remove isDraft

### DIFF
--- a/packages/core-loader/test/encodeDataAttribute.test.ts
+++ b/packages/core-loader/test/encodeDataAttribute.test.ts
@@ -709,12 +709,12 @@ describe('encodeDataAttribute', () => {
 
   test('string paths', () => {
     expect(encodeDataAttribute('page.sections[4].style')).toMatchInlineSnapshot(
-      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2Fstudio;isDraft"`,
+      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2Fstudio"`,
     )
   })
   test('array paths', () => {
     expect(encodeDataAttribute(['page', 'sections', 4, 'style'])).toMatchInlineSnapshot(
-      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2Fstudio;isDraft"`,
+      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2Fstudio"`,
     )
   })
 })
@@ -724,20 +724,20 @@ describe('scoping', () => {
   test('string paths', () => {
     const scoped = encodeDataAttribute.scope('page.sections[4]')
     expect(scoped('style')).toMatchInlineSnapshot(
-      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2Fstudio;isDraft"`,
+      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2Fstudio"`,
     )
   })
   test('array paths', () => {
     const scoped = encodeDataAttribute.scope(['page', 'sections', 4])
     expect(scoped(['style'])).toMatchInlineSnapshot(
-      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2Fstudio;isDraft"`,
+      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2Fstudio"`,
     )
   })
   test('array paths recursive', () => {
     const scoped = encodeDataAttribute.scope(['page'])
     const scopedDeeper = scoped.scope(['sections', 4])
     expect(scopedDeeper(['style'])).toMatchInlineSnapshot(
-      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2Fstudio;isDraft"`,
+      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2Fstudio"`,
     )
   })
 })

--- a/packages/visual-editing-csm/src/createDataAttribute.test.ts
+++ b/packages/visual-editing-csm/src/createDataAttribute.test.ts
@@ -35,49 +35,49 @@ describe('createDataAttribute', () => {
   test('resolves using function call', () => {
     const scoped = createDataAttribute({id, type})
     expect(scoped(path)).toMatchInlineSnapshot(
-      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2F;isDraft"`,
+      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2F"`,
     )
   })
 
   test('resolves using empty function call if path is set', () => {
     const scopedWithPath = createDataAttribute({id, type, path})
     expect(scopedWithPath()).toMatchInlineSnapshot(
-      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2F;isDraft"`,
+      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2F"`,
     )
   })
 
   test('resolves using `.toString`', () => {
     const scopedWithPath = createDataAttribute({id, type, path})
     expect(scopedWithPath.toString()).toMatchInlineSnapshot(
-      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2F;isDraft"`,
+      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2F"`,
     )
   })
 
   test('resolves using `.toString` after setting path with `.scope`', () => {
     const scoped = createDataAttribute({id, type})
     expect(scoped.scope(path).toString()).toMatchInlineSnapshot(
-      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2F;isDraft"`,
+      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2F"`,
     )
   })
 
   test('resolves with a custom basePath', () => {
     const scopedWithBaseUrl = createDataAttribute({id, type, baseUrl})
     expect(scopedWithBaseUrl(path)).toMatchInlineSnapshot(
-      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2Fstudio;isDraft"`,
+      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2Fstudio"`,
     )
   })
 
   test('resolves combined path using attribute and `.scope`', () => {
     const scopedWithPath = createDataAttribute({id, type, path: basePath})
     expect(scopedWithPath.scope(sectionPath).toString()).toMatchInlineSnapshot(
-      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2F;isDraft"`,
+      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2F"`,
     )
   })
 
   test('resolves combined path using `.scope` and function call', () => {
     const scoped = createDataAttribute({id, type})
     expect(scoped.scope(basePath)(sectionPath)).toMatchInlineSnapshot(
-      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2F;isDraft"`,
+      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2F"`,
     )
   })
 
@@ -85,7 +85,7 @@ describe('createDataAttribute', () => {
     const scopedWithBaseUrlOnly = createDataAttribute({baseUrl})
     const scoped = scopedWithBaseUrlOnly.combine({id, type})
     expect(scoped(path)).toMatchInlineSnapshot(
-      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2Fstudio;isDraft"`,
+      `"id=home;type=page;path=sections:0bd049fc047a.style;base=%2Fstudio"`,
     )
   })
 })

--- a/packages/visual-editing-csm/src/decodeSanityNodeData.ts
+++ b/packages/visual-editing-csm/src/decodeSanityNodeData.ts
@@ -50,9 +50,6 @@ export function decodeSanityString(str: string): SanityNode | undefined {
       case 'dataset':
         acc.dataset = value
         break
-      case 'isDraft':
-        acc.isDraft = ''
-        break
       default:
     }
 

--- a/packages/visual-editing-csm/src/encodeSanityNodeData.ts
+++ b/packages/visual-editing-csm/src/encodeSanityNodeData.ts
@@ -1,4 +1,4 @@
-import {getPublishedId, isDraftId, studioPath} from '@sanity/client/csm'
+import {getPublishedId, studioPath} from '@sanity/client/csm'
 import type {SanityNode} from '@sanity/visual-editing-types'
 import {isValidSanityNode} from './isValidSanityNode'
 import {pathToUrlString} from './pathToUrlString'
@@ -23,16 +23,10 @@ export function encodeSanityNodeData(node: SanityNode): string | undefined {
     ['base', encodeURIComponent(baseUrl)],
     ['workspace', workspace],
     ['tool', tool],
-    ['isDraft', isDraftId(_id)],
   ]
 
   return parts
     .filter(([, value]) => !!value)
-    .map((part) => {
-      const [key, value] = part
-      // For true values, just display the key
-      if (value === true) return key
-      return part.join('=')
-    })
+    .map((part) => part.join('='))
     .join(';')
 }

--- a/packages/visual-editing-csm/src/sanityNodeSchema.ts
+++ b/packages/visual-editing-csm/src/sanityNodeSchema.ts
@@ -12,5 +12,4 @@ export const sanityNodeSchema = object({
   tool: optionalLengthyStr,
   type: optionalLengthyStr,
   workspace: optionalLengthyStr,
-  isDraft: optional(string()),
 })

--- a/packages/visual-editing-types/src/index.ts
+++ b/packages/visual-editing-types/src/index.ts
@@ -14,7 +14,6 @@ export type SanityNode = {
   baseUrl: string
   dataset?: string
   id: string
-  isDraft?: string
   path: string
   projectId?: string
   tool?: string

--- a/packages/visual-editing/src/ui/useReportDocuments.ts
+++ b/packages/visual-editing/src/ui/useReportDocuments.ts
@@ -1,5 +1,4 @@
 import type {ClientPerspective, ContentSourceMapDocuments} from '@sanity/client'
-import {getDraftId} from '@sanity/client/csm'
 import {useCallback, useEffect, useRef} from 'react'
 import type {ElementState, SanityNode, VisualEditingNode} from '../types'
 
@@ -45,10 +44,7 @@ export function useReportDocuments(
       .map((e) => {
         const {sanity} = e
         if (!('id' in sanity)) return null
-        return {
-          ...sanity,
-          id: 'isDraft' in sanity ? getDraftId(sanity.id) : sanity.id,
-        }
+        return sanity
       })
       .filter((s) => !!s) as SanityNode[]
 


### PR DESCRIPTION
Since https://github.com/sanity-io/sanity/pull/8320 landed it's no longer necessary to send a draft id in the `visual-editing/documents` postMessage handler