### PR TITLE
fix: remove vX override

### DIFF
--- a/packages/next-loader/src/defineLive.tsx
+++ b/packages/next-loader/src/defineLive.tsx
@@ -240,21 +240,9 @@ export function defineLive(config: DefineSanityLiveOptions): {
       tag = 'next-loader.live',
       onError,
     } = props
-    const {
-      projectId,
-      dataset,
-      apiHost,
-      apiVersion: _apiVersion,
-      useProjectHostname,
-      requestTagPrefix,
-    } = client.config()
+    const {projectId, dataset, apiHost, apiVersion, useProjectHostname, requestTagPrefix} =
+      client.config()
     const {isEnabled: isDraftModeEnabled} = await draftMode()
-
-    let apiVersion = _apiVersion
-    // @TODO temporarily handle the Live Draft Content API only being available on vX
-    if (typeof browserToken === 'string' && isDraftModeEnabled) {
-      apiVersion = 'vX'
-    }
 
     return (
       <SanityLiveClientComponent


### PR DESCRIPTION
It's no longer necessary to use vX with Draft Live Content 🥳 