### PR TITLE
fix: increase heartbeat interval from 1s to 10s

### DIFF
--- a/packages/core-loader/src/live-mode/enableLiveMode.ts
+++ b/packages/core-loader/src/live-mode/enableLiveMode.ts
@@ -22,7 +22,7 @@ export interface LazyEnableLiveModeOptions extends EnableLiveModeOptions {
   setFetcher: SetFetcher
 }
 
-const LISTEN_HEARTBEAT_INTERVAL = 1000
+const LISTEN_HEARTBEAT_INTERVAL = 10_000
 
 export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
   const {client, setFetcher, onConnect, onDisconnect} = options

--- a/packages/next-loader/src/client-components/live-stream/SanityLiveStream.tsx
+++ b/packages/next-loader/src/client-components/live-stream/SanityLiveStream.tsx
@@ -37,7 +37,7 @@ export interface SanityLiveStreamProps
   }) => Promise<React.ReactNode>
 }
 
-const LISTEN_HEARTBEAT_INTERVAL = 1000
+const LISTEN_HEARTBEAT_INTERVAL = 10_000
 
 /**
  * @public


### PR DESCRIPTION
Increasing the interval reduces the gc work Presentation has to do when keeping track of queries. Especially when moving back and forth between URLs.