### PR TITLE
fix: replace `previewDrafts` with `drafts`

### DIFF
--- a/apps/astro/src/load-query.ts
+++ b/apps/astro/src/load-query.ts
@@ -15,7 +15,7 @@ export async function loadQuery<QueryResponse>({
     throw new Error('The `SANITY_API_READ_TOKEN` environment variable is required in Draft Mode.')
   }
 
-  const perspective = visualEditingEnabled ? 'previewDrafts' : 'published'
+  const perspective = visualEditingEnabled ? 'drafts' : 'published'
 
   const {result, resultSourceMap} = await sanityClient.fetch<QueryResponse>(query, params ?? {}, {
     filterResponse: false,

--- a/apps/next-with-i18n/data/sanity/loadQuery.ts
+++ b/apps/next-with-i18n/data/sanity/loadQuery.ts
@@ -25,7 +25,7 @@ export async function loadQuery<QueryResponse>({
     )
   }
 
-  const perspective = isDraftMode ? 'previewDrafts' : 'published'
+  const perspective = isDraftMode ? 'drafts' : 'published'
 
   const options = {
     filterResponse: false,

--- a/apps/next/src/app/only-visual-editing/page.tsx
+++ b/apps/next/src/app/only-visual-editing/page.tsx
@@ -16,7 +16,7 @@ export default async function ShoesPage() {
     {},
     {
       filterResponse: false,
-      perspective: (await draftMode()).isEnabled ? 'previewDrafts' : 'published',
+      perspective: (await draftMode()).isEnabled ? 'drafts' : 'published',
       useCdn: (await draftMode()).isEnabled ? false : true,
       next: {revalidate: false, tags: ['shoe']},
     },

--- a/apps/next/src/app/shoes/[slug]/page.tsx
+++ b/apps/next/src/app/shoes/[slug]/page.tsx
@@ -11,7 +11,7 @@ type Props = {
 export default async function ShoePage(props: Props) {
   const params = await props.params
   const initial = loadQuery<ShoeResult>(shoe, params, {
-    perspective: (await draftMode()).isEnabled ? 'previewDrafts' : 'published',
+    perspective: (await draftMode()).isEnabled ? 'drafts' : 'published',
     next: {
       revalidate: (await draftMode()).isEnabled ? 0 : false,
       tags: [`shoe:${params.slug}`],

--- a/apps/next/src/app/shoes/page.tsx
+++ b/apps/next/src/app/shoes/page.tsx
@@ -9,7 +9,7 @@ export default async function ShoesPage() {
     shoesList,
     {},
     {
-      perspective: (await draftMode()).isEnabled ? 'previewDrafts' : 'published',
+      perspective: (await draftMode()).isEnabled ? 'drafts' : 'published',
       next: {revalidate: (await draftMode()).isEnabled ? 0 : false, tags: ['shoe']},
     },
   )

--- a/apps/next/src/app/shoes/sanity.ssr.ts
+++ b/apps/next/src/app/shoes/sanity.ssr.ts
@@ -17,11 +17,11 @@ setServerClient(
 // Automatically handle draft mode
 export const loadQuery = (async (query, params = {}, options = {}) => {
   const isDraftMode = (await draftMode()).isEnabled
-  const perspective = options.perspective || (isDraftMode ? 'previewDrafts' : 'published')
+  const perspective = options.perspective || (isDraftMode ? 'drafts' : 'published')
   return _loadQuery(query, params, {
     ...options,
     perspective,
-    stega: process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview' || perspective === 'previewDrafts',
+    stega: process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview' || perspective !== 'published',
     next: {revalidate: isDraftMode ? 0 : 60},
   })
 }) satisfies typeof _loadQuery

--- a/apps/next/src/pages/pages-router/performance-test/index.tsx
+++ b/apps/next/src/pages/pages-router/performance-test/index.tsx
@@ -33,7 +33,7 @@ function createSanityClient(config: ClientConfig) {
 const sanityClient = createSanityClient({
   useCdn: false,
   token: sanityToken,
-  perspective: 'previewDrafts',
+  perspective: 'drafts',
 })
 // Production
 const cdnSanityClient = createSanityClient({

--- a/apps/next/src/pages/pages-router/shoes/[slug].tsx
+++ b/apps/next/src/pages/pages-router/shoes/[slug].tsx
@@ -18,7 +18,7 @@ interface Props extends SharedProps {
 
 export const getStaticProps = (async (context) => {
   const {draftMode = false, params} = context
-  const perspective = (draftMode ? 'previewDrafts' : 'published') satisfies ClientPerspective
+  const perspective = (draftMode ? 'drafts' : 'published') satisfies ClientPerspective
 
   const slug = Array.isArray(params!.slug) ? params!.slug[0] : params!.slug
   if (!slug) throw new Error('slug is required')

--- a/apps/next/src/pages/pages-router/shoes/index.tsx
+++ b/apps/next/src/pages/pages-router/shoes/index.tsx
@@ -16,7 +16,7 @@ interface Props extends SharedProps {
 
 export const getStaticProps = (async (context) => {
   const {draftMode = false} = context
-  const perspective = (draftMode ? 'previewDrafts' : 'published') satisfies ClientPerspective
+  const perspective = (draftMode ? 'drafts' : 'published') satisfies ClientPerspective
   const initial = await loadQuery<ShoesListResult>(shoesList, {}, {perspective})
   return {props: {draftMode, initial}, revalidate: 1}
 }) satisfies GetStaticProps<Props>

--- a/packages/@repo/sanity-schema/src/shoes/index.tsx
+++ b/packages/@repo/sanity-schema/src/shoes/index.tsx
@@ -41,7 +41,7 @@ const shoeType = defineType({
               type: document._type,
               slug,
             },
-            {perspective: 'previewDrafts'},
+            {perspective: 'drafts'},
           )
           return result < 2
         },

--- a/packages/core-loader/src/live-mode/enableLiveMode.ts
+++ b/packages/core-loader/src/live-mode/enableLiveMode.ts
@@ -32,7 +32,7 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
     )
   }
   const {projectId, dataset} = client.config()
-  const $perspective = atom<Exclude<ClientPerspective, 'raw'>>('previewDrafts')
+  const $perspective = atom<Exclude<ClientPerspective, 'raw'>>('drafts')
   const $connected = atom(false)
 
   const cache = new Map<
@@ -66,7 +66,7 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
   comlink.on('loader/perspective', (data) => {
     if (data.projectId === projectId && data.dataset === dataset) {
       validateApiPerspective(data.perspective)
-      $perspective.set(data.perspective === 'raw' ? 'previewDrafts' : data.perspective)
+      $perspective.set(data.perspective === 'raw' ? 'drafts' : data.perspective)
       updateLiveQueries()
     }
   })

--- a/packages/next-loader/src/resolveCookiePerspective.ts
+++ b/packages/next-loader/src/resolveCookiePerspective.ts
@@ -1,0 +1,17 @@
+/// <reference types="next" />
+
+import type {ClientPerspective} from '@sanity/client'
+import {perspectiveCookieName} from '@sanity/preview-url-secret/constants'
+import {cookies, draftMode} from 'next/headers.js'
+import {sanitizePerspective} from './utils'
+
+/**
+ * @internal
+ */
+export async function resolveCookiePerspective(): Promise<Exclude<ClientPerspective, 'raw'>> {
+  return (await draftMode()).isEnabled
+    ? (await cookies()).has(perspectiveCookieName)
+      ? sanitizePerspective((await cookies()).get(perspectiveCookieName)?.value, 'drafts')
+      : 'drafts'
+    : 'published'
+}

--- a/packages/next-loader/src/server-actions/index.ts
+++ b/packages/next-loader/src/server-actions/index.ts
@@ -31,7 +31,7 @@ export async function setPerspectiveCookie(perspective: ClientPerspective): Prom
     // throw new Error('Draft mode is not enabled, setting perspective cookie is not allowed')
     return
   }
-  const sanitizedPerspective = sanitizePerspective(perspective, 'previewDrafts')
+  const sanitizedPerspective = sanitizePerspective(perspective, 'drafts')
   if (perspective !== sanitizedPerspective) {
     throw new Error(`Invalid perspective: ${perspective}`)
   }

--- a/packages/next-loader/src/utils.ts
+++ b/packages/next-loader/src/utils.ts
@@ -3,7 +3,7 @@ import {validateApiPerspective, type ClientPerspective} from '@sanity/client'
 /** @internal */
 export function sanitizePerspective(
   _perspective: unknown,
-  fallback: 'previewDrafts' | 'published',
+  fallback: 'drafts' | 'published',
 ): Exclude<ClientPerspective, 'raw'> {
   const perspective =
     typeof _perspective === 'string' && _perspective.includes(',')

--- a/packages/react-loader/src/createQueryStore/server-only.ts
+++ b/packages/react-loader/src/createQueryStore/server-only.ts
@@ -29,9 +29,11 @@ export const createQueryStore = (options: CreateQueryStoreOptions): QueryStore =
       _options.perspective || unstable__serverClient.instance?.config().perspective || 'published'
     const useCdn = _options.useCdn || unstable__serverClient.instance!.config().useCdn
 
-    if (perspective === 'previewDrafts' && !unstable__serverClient.canPreviewDrafts) {
+    const previewPerspective =
+      Array.isArray(perspective) || perspective === 'drafts' || perspective === 'previewDrafts'
+    if (previewPerspective && !unstable__serverClient.canPreviewDrafts) {
       throw new Error(
-        `You cannot use "previewDrafts" unless you set a "token" in the "client" instance you're pasing to "setServerClient".`,
+        `You cannot use 'perspective: ${JSON.stringify(perspective)}' unless you set a "token" in the "client" instance you're pasing to "setServerClient".`,
       )
     }
 
@@ -42,13 +44,13 @@ export const createQueryStore = (options: CreateQueryStoreOptions): QueryStore =
         filterResponse: false,
         next,
         perspective,
-        useCdn: perspective === 'previewDrafts' ? false : useCdn,
+        useCdn: previewPerspective ? false : useCdn,
         stega,
         headers,
         tag,
       })
     const payload = resultSourceMap ? {data: result, sourceMap: resultSourceMap} : {data: result}
-    if (perspective === 'previewDrafts') {
+    if (previewPerspective) {
       // @ts-expect-error - update typings
       return {...payload, perspective}
     }

--- a/packages/react-loader/src/createQueryStore/universal.ts
+++ b/packages/react-loader/src/createQueryStore/universal.ts
@@ -57,10 +57,10 @@ export const createQueryStore = (options: CreateQueryStoreOptions): QueryStore =
         `You cannot use other perspectives than "published" unless you set "ssr: true" and call "setServerClient" first.`,
       )
     }
-    if (perspective === 'previewDrafts') {
+    if (Array.isArray(perspective) || perspective === 'drafts' || perspective === 'previewDrafts') {
       if (!unstable__serverClient.canPreviewDrafts) {
         throw new Error(
-          `You cannot use "previewDrafts" unless you set a "token" in the "client" instance you're pasing to "setServerClient".`,
+          `You cannot use 'perspective: ${JSON.stringify(perspective)}' unless you set a "token" in the "client" instance you're pasing to "setServerClient".`,
         )
       }
 

--- a/packages/svelte-loader/src/createQueryStore.ts
+++ b/packages/svelte-loader/src/createQueryStore.ts
@@ -50,10 +50,10 @@ export const createQueryStore = (options: CreateQueryStoreOptions): QueryStore =
         `You cannot use other perspectives than "published" unless call "setServerClient" first.`,
       )
     }
-    if (perspective === 'previewDrafts') {
+    if (Array.isArray(perspective) || perspective === 'drafts' || perspective === 'previewDrafts') {
       if (!unstable__serverClient.canPreviewDrafts) {
         throw new Error(
-          `You cannot use "previewDrafts" unless you set a "token" in the "client" instance passed to "setServerClient".`,
+          `You cannot use 'perspective: ${JSON.stringify(perspective)}' unless you set a "token" in the "client" instance passed to "setServerClient".`,
         )
       }
       const {result, resultSourceMap} =

--- a/packages/visual-editing/svelte/hooks.ts
+++ b/packages/visual-editing/svelte/hooks.ts
@@ -22,7 +22,7 @@ export const handlePreview = ({client, preview}: HandlePreviewOptions): Handle =
     event.locals.preview = event.cookies.get(cookieName) === secret
 
     // Set default perspective and useCdn based on preview status
-    const perspective = event.locals.preview ? 'previewDrafts' : 'published'
+    const perspective = event.locals.preview ? 'drafts' : 'published'
     const useCdn = event.locals.preview ? false : true
 
     // Check if the request is to enable or disable previews


### PR DESCRIPTION
Since https://github.com/sanity-io/client/pull/1007 the client warns when using `perspective: 'previewDrafts'`. This PR refactors to the new `perspective: 'drafts'` approach.