### PR TITLE
fix(remix): apply presentation perspective for initial server loader

### DIFF
--- a/apps/remix/app/routes/shoes.$slug.tsx
+++ b/apps/remix/app/routes/shoes.$slug.tsx
@@ -1,5 +1,6 @@
 import {PortableText} from '@portabletext/react'
 import {Link, useLoaderData} from '@remix-run/react'
+import {ClientPerspective} from '@sanity/client'
 import {stegaClean} from '@sanity/client/stega'
 import {useQuery} from '@sanity/react-loader'
 import {createDataAttribute} from '@sanity/visual-editing'
@@ -9,12 +10,17 @@ import {urlFor, urlForCrossDatasetReference} from '~/sanity'
 import {loadQuery} from '~/sanity.loader.server'
 import {formatCurrency} from '~/utils'
 
-export const loader: LoaderFunction = async ({params}) => {
+export const loader: LoaderFunction = async ({params, request}) => {
+  const url = new URL(request.url)
+  const perspective = url.searchParams.get('sanity-preview-perspective')?.split(',') as
+    | ClientPerspective
+    | undefined
+
   return json({
     params,
     initial: {
-      shoe: await loadQuery<ShoeResult>(shoe, params),
-      shoes: await loadQuery<ShoesListResult>(`${shoesList}[0..3]`),
+      shoe: await loadQuery<ShoeResult>(shoe, params, {perspective}),
+      shoes: await loadQuery<ShoesListResult>(`${shoesList}[0..3]`, {}, {perspective}),
     },
   })
 }

--- a/apps/remix/app/routes/shoes._index.tsx
+++ b/apps/remix/app/routes/shoes._index.tsx
@@ -1,4 +1,5 @@
 import {Link, useLoaderData} from '@remix-run/react'
+import {ClientPerspective} from '@sanity/client'
 import {useQuery} from '@sanity/react-loader'
 import {json} from '@vercel/remix'
 import {shoesList, type ShoesListResult} from '~/queries'
@@ -6,10 +7,16 @@ import {urlFor, urlForCrossDatasetReference} from '~/sanity'
 import {loadQuery} from '~/sanity.loader.server'
 import {formatCurrency} from '~/utils'
 
-export const loader = async () => {
-  return json({initial: await loadQuery<ShoesListResult>(shoesList)})
-}
+export const loader = async ({request}: {request: Request}) => {
+  const url = new URL(request.url)
+  const perspective = url.searchParams.get('sanity-preview-perspective')?.split(',') as
+    | ClientPerspective
+    | undefined
 
+  return json({
+    initial: await loadQuery<ShoesListResult>(shoesList, {}, {perspective}),
+  })
+}
 export default function ShoesPage() {
   const {initial} = useLoaderData<typeof loader>()
   const {

--- a/apps/remix/app/sanity.ts
+++ b/apps/remix/app/sanity.ts
@@ -10,6 +10,8 @@ export const client = createClient({
   dataset,
   useCdn: false,
   apiVersion,
+  token: typeof process === 'undefined' ? undefined : process.env.SANITY_API_READ_TOKEN,
+  perspective: 'published',
   stega: {
     enabled: true,
     studioUrl: (sourceDocument) => {

--- a/packages/core-loader/src/live-mode/enableLiveMode.ts
+++ b/packages/core-loader/src/live-mode/enableLiveMode.ts
@@ -31,8 +31,11 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
       `Expected \`client\` to be an instance of SanityClient: ${JSON.stringify(client)}`,
     )
   }
-  const {projectId, dataset} = client.config()
-  const $perspective = atom<Exclude<ClientPerspective, 'raw'>>('drafts')
+  const {projectId, dataset, perspective} = client.config()
+
+  const $perspective = atom<Exclude<ClientPerspective, 'raw'>>(
+    perspective && perspective !== 'raw' ? perspective : 'drafts',
+  )
   const $connected = atom(false)
 
   const cache = new Map<


### PR DESCRIPTION
Updates our internal remix implementation to show an example in how to fix https://github.com/sanity-io/sanity/issues/8985

This PR updates how we load the initial data in our remix example.
Using the perspective set by presentation tool into the presentation iframe in the query parameters, specifically `sanity-preview-perspective` 

By using this query param, we can get in the initial server response the correct data.
See how loading a page now shows in the initial load the correct document when used inside presentation.

We will also update the docs to reflect how to do this.


```ts
  export const loader = async ({request}: {request: Request}) => {
    const url = new URL(request.url)
    const perspective = url.searchParams.get('sanity-preview-perspective')?.split(',') as
      | ClientPerspective
      | undefined
  
    return json({
      initial: await loadQuery(query, {}, {perspective}),
    })
  }
```

https://github.com/user-attachments/assets/ebc52e87-8817-4018-8239-6c817305c0a9



https://github.com/user-attachments/assets/95fb8d16-b8cf-4436-885c-1572f2bb1bf6


