### PR TITLE
fix(comlink): Promise.withResolvers shim

### DIFF
--- a/packages/comlink/src/node.ts
+++ b/packages/comlink/src/node.ts
@@ -35,6 +35,7 @@ import type {
   StatusEmitEvent,
   WithoutResponse,
 } from './types'
+import {createPromiseWithResolvers} from './util'
 
 /**
  * @public
@@ -585,7 +586,7 @@ export const createNode = <TSends extends Message, TReceives extends Message>(
   ) => {
     const {responseTimeout = FETCH_TIMEOUT_DEFAULT, signal, suppressWarnings} = options || {}
 
-    const resolvable = Promise.withResolvers<TSends['response']>()
+    const resolvable = createPromiseWithResolvers<TSends['response']>()
     const _data = {type, data} as WithoutResponse<TMessage>
 
     actor.send({

--- a/packages/comlink/src/util.ts
+++ b/packages/comlink/src/util.ts
@@ -1,0 +1,22 @@
+// Returns Promise.withResolvers or polyfill if unavailable
+export function createPromiseWithResolvers<T = unknown>(): {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reject: (reason?: any) => void
+} {
+  if (typeof Promise.withResolvers === 'function') {
+    return Promise.withResolvers<T>()
+  }
+
+  let resolve!: (value: T | PromiseLike<T>) => void
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let reject!: (reason?: any) => void
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return {promise, resolve, reject}
+}


### PR DESCRIPTION
Adds a fallback implementation of `Promise.withResolvers` used in the `fetch` method on nodes. Error was reported for dashboard users on older versions of Safari.