### PR TITLE
feat(comlink): add pause method

### DIFF
--- a/packages/comlink/src/controller.ts
+++ b/packages/comlink/src/controller.ts
@@ -33,6 +33,7 @@ export interface ChannelInstance<TSends extends Message, TReceives extends Messa
     ...params: (TMessage['data'] extends undefined ? [TType] : never) | [TType, TMessage['data']]
   ) => void
   start: () => () => void
+  pause: () => () => void
   stop: () => void
 }
 
@@ -278,12 +279,20 @@ export const createController = (input: {targetOrigin: string}): Controller => {
       return stop
     }
 
+    const pause = () => {
+      const connections = channel.connections as unknown as Set<Connection>
+      connections.forEach(cleanupConnection)
+
+      return start
+    }
+
     return {
       on,
       onInternalEvent,
       onStatus,
       post,
       start,
+      pause,
       stop,
     }
   }


### PR DESCRIPTION
### Description

Dashboard would _love_ a way to "pause" channels, but not delete and destroy them (which is what the `stop` method appears to do). Because our iframes are kept "alive" by the activity API. So instead this method just runs the "cleanup" function that disconnects & stops connections, but they're kept in the registries so the start function should work once more when called.

### Disclaimer

This PR is just a "how in my naive mind thinks it could work" – it'd be good to know, what tests to add (if applicable).