### PR TITLE
chore(deps): update dependency @sanity/image-url to ^2.0.0

### DIFF
--- a/apps/astro/package.json
+++ b/apps/astro/package.json
@@ -20,7 +20,7 @@
     "@repo/studio-url": "workspace:*",
     "@sanity/astro": "^3.2.10",
     "@sanity/client": "catalog:",
-    "@sanity/image-url": "^1.2.0",
+    "@sanity/image-url": "^2.0.0",
     "@sanity/visual-editing": "workspace:*",
     "@vercel/stega": "^0.1.2",
     "astro": "^5.12.8",

--- a/apps/astro/src/sanity.ts
+++ b/apps/astro/src/sanity.ts
@@ -1,14 +1,14 @@
 import {workspaces} from '@repo/env'
-import imageUrlBuilder from '@sanity/image-url'
+import {createImageUrlBuilder} from '@sanity/image-url'
 
 const {projectId, dataset} = workspaces['astro']
 
-const builder = imageUrlBuilder({projectId, dataset})
+const builder = createImageUrlBuilder({projectId, dataset})
 export function urlFor(source: any) {
   return builder.image(source).auto('format').fit('max')
 }
 
-const crossDatasetBuilder = imageUrlBuilder({
+const crossDatasetBuilder = createImageUrlBuilder({
   projectId: workspaces['cross-dataset-references'].projectId,
   dataset: workspaces['cross-dataset-references'].dataset,
 })

--- a/apps/live-next/package.json
+++ b/apps/live-next/package.json
@@ -16,7 +16,7 @@
     "@repo/sanity-extracted-schema": "workspace:*",
     "@repo/studio-url": "workspace:*",
     "@sanity/client": "catalog:",
-    "@sanity/image-url": "^1.2.0",
+    "@sanity/image-url": "^2.0.0",
     "@sanity/preview-url-secret": "workspace:*",
     "@sanity/visual-editing": "workspace:*",
     "@tailwindcss/typography": "catalog:tailwind3",

--- a/apps/live-next/sanity/lib/utils.ts
+++ b/apps/live-next/sanity/lib/utils.ts
@@ -1,5 +1,5 @@
 import {dataset, projectId} from '@/sanity/lib/api'
-import createImageUrlBuilder from '@sanity/image-url'
+import {createImageUrlBuilder} from '@sanity/image-url'
 
 const imageBuilder = createImageUrlBuilder({
   projectId: projectId || '',

--- a/apps/next/package.json
+++ b/apps/next/package.json
@@ -16,7 +16,7 @@
     "@repo/sanity-extracted-schema": "workspace:*",
     "@repo/studio-url": "workspace:*",
     "@sanity/client": "catalog:",
-    "@sanity/image-url": "^1.2.0",
+    "@sanity/image-url": "^2.0.0",
     "@sanity/preview-url-secret": "workspace:*",
     "@sanity/react-loader": "workspace:*",
     "@sanity/visual-editing": "workspace:*",

--- a/apps/next/src/app/shoes/utils.ts
+++ b/apps/next/src/app/shoes/utils.ts
@@ -1,14 +1,14 @@
 import {workspaces} from '@repo/env'
-import imageUrlBuilder from '@sanity/image-url'
+import {createImageUrlBuilder} from '@sanity/image-url'
 
 const {projectId, dataset} = workspaces['next-app-router']
 
-const builder = imageUrlBuilder({projectId, dataset})
+const builder = createImageUrlBuilder({projectId, dataset})
 export function urlFor(source: any) {
   return builder.image(source).auto('format').fit('max')
 }
 
-const crossDatasetBuilder = imageUrlBuilder({
+const crossDatasetBuilder = createImageUrlBuilder({
   projectId: workspaces['cross-dataset-references'].projectId,
   dataset: workspaces['cross-dataset-references'].dataset,
 })

--- a/apps/next/src/components/utils.ts
+++ b/apps/next/src/components/utils.ts
@@ -1,14 +1,14 @@
 import {workspaces} from '@repo/env'
-import imageUrlBuilder from '@sanity/image-url'
+import {createImageUrlBuilder} from '@sanity/image-url'
 
 const {projectId, dataset} = workspaces['next-pages-router']
 
-const builder = imageUrlBuilder({projectId, dataset})
+const builder = createImageUrlBuilder({projectId, dataset})
 export function urlFor(source: any) {
   return builder.image(source).auto('format').fit('max')
 }
 
-const crossDatasetBuilder = imageUrlBuilder({
+const crossDatasetBuilder = createImageUrlBuilder({
   projectId: workspaces['cross-dataset-references'].projectId,
   dataset: workspaces['cross-dataset-references'].dataset,
 })

--- a/apps/nuxt/utils.ts
+++ b/apps/nuxt/utils.ts
@@ -1,7 +1,7 @@
 import {apiVersion, workspaces} from '@repo/env'
 import {studioUrl as baseUrl} from '@repo/studio-url'
 import {createClient} from '@sanity/client'
-import imageUrlBuilder from '@sanity/image-url'
+import {createImageUrlBuilder} from '@sanity/image-url'
 import {vercelStegaSplit} from '@vercel/stega'
 
 export function formatCurrency(_value: number | string): string {
@@ -46,12 +46,12 @@ export function getClient() {
   })
 }
 
-const builder = imageUrlBuilder({projectId, dataset})
+const builder = createImageUrlBuilder({projectId, dataset})
 export function urlFor(source: any) {
   return builder.image(source).auto('format').fit('max')
 }
 
-const crossDatasetBuilder = imageUrlBuilder({
+const crossDatasetBuilder = createImageUrlBuilder({
   projectId: workspaces['cross-dataset-references'].projectId,
   dataset: workspaces['cross-dataset-references'].dataset,
 })

--- a/apps/page-builder-demo/package.json
+++ b/apps/page-builder-demo/package.json
@@ -23,7 +23,7 @@
     "@sanity/cli": "catalog:",
     "@sanity/client": "catalog:",
     "@sanity/demo": "^2.0.0",
-    "@sanity/image-url": "^1.2.0",
+    "@sanity/image-url": "^2.0.0",
     "@sanity/preview-url-secret": "workspace:*",
     "@sanity/util": "catalog:",
     "@sanity/visual-editing": "workspace:*",

--- a/apps/page-builder-demo/src/sanity/image.ts
+++ b/apps/page-builder-demo/src/sanity/image.ts
@@ -1,5 +1,5 @@
 import {workspaces} from '@repo/env'
-import createImageUrlBuilder from '@sanity/image-url'
+import {createImageUrlBuilder} from '@sanity/image-url'
 
 const {projectId, dataset} = workspaces['page-builder-demo']
 

--- a/apps/remix/app/sanity.ts
+++ b/apps/remix/app/sanity.ts
@@ -1,7 +1,7 @@
 import {apiVersion, workspaces} from '@repo/env'
 import {studioUrl as baseUrl} from '@repo/studio-url'
 import {createClient} from '@sanity/client'
-import imageUrlBuilder from '@sanity/image-url'
+import {createImageUrlBuilder} from '@sanity/image-url'
 
 const {projectId, dataset} = workspaces['remix']
 
@@ -30,12 +30,12 @@ export const client = createClient({
   },
 })
 
-const builder = imageUrlBuilder({projectId, dataset})
+const builder = createImageUrlBuilder({projectId, dataset})
 export function urlFor(source: any) {
   return builder.image(source).auto('format').fit('max')
 }
 
-const crossDatasetBuilder = imageUrlBuilder({
+const crossDatasetBuilder = createImageUrlBuilder({
   projectId: workspaces['cross-dataset-references'].projectId,
   dataset: workspaces['cross-dataset-references'].dataset,
 })

--- a/apps/remix/package.json
+++ b/apps/remix/package.json
@@ -17,7 +17,7 @@
     "@repo/env": "workspace:*",
     "@repo/studio-url": "workspace:*",
     "@sanity/client": "catalog:",
-    "@sanity/image-url": "^1.2.0",
+    "@sanity/image-url": "^2.0.0",
     "@sanity/preview-url-secret": "workspace:*",
     "@sanity/react-loader": "workspace:*",
     "@sanity/visual-editing": "workspace:*",

--- a/apps/svelte/package.json
+++ b/apps/svelte/package.json
@@ -18,7 +18,7 @@
     "@portabletext/svelte": "^3.0.0",
     "@repo/env": "workspace:*",
     "@repo/studio-url": "workspace:*",
-    "@sanity/image-url": "^1.2.0"
+    "@sanity/image-url": "^2.0.0"
   },
   "devDependencies": {
     "@fontsource/fira-mono": "^5.2.6",

--- a/apps/svelte/src/lib/sanity.ts
+++ b/apps/svelte/src/lib/sanity.ts
@@ -1,7 +1,7 @@
 import {apiVersion, workspaces} from '@repo/env'
 import {studioUrl as baseUrl} from '@repo/studio-url'
 import {createClient} from '@sanity/client'
-import imageUrlBuilder from '@sanity/image-url'
+import {createImageUrlBuilder} from '@sanity/image-url'
 
 const {projectId, dataset} = workspaces['svelte-basic']
 
@@ -26,13 +26,13 @@ export const client = createClient({
   },
 })
 
-const builder = imageUrlBuilder({projectId, dataset})
+const builder = createImageUrlBuilder({projectId, dataset})
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function urlFor(source: any) {
   return builder.image(source).auto('format').fit('max')
 }
 
-const crossDatasetBuilder = imageUrlBuilder({
+const crossDatasetBuilder = createImageUrlBuilder({
   projectId: workspaces['cross-dataset-references'].projectId,
   dataset: workspaces['cross-dataset-references'].dataset,
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,8 +152,8 @@ importers:
         specifier: ^7.12.0
         version: 7.12.0(debug@4.4.3)
       '@sanity/image-url':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^2.0.0
+        version: 2.0.0
       '@sanity/visual-editing':
         specifier: workspace:*
         version: link:../../packages/visual-editing
@@ -201,8 +201,8 @@ importers:
         specifier: ^7.12.0
         version: 7.12.0(debug@4.4.3)
       '@sanity/image-url':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^2.0.0
+        version: 2.0.0
       '@sanity/preview-url-secret':
         specifier: workspace:*
         version: link:../../packages/preview-url-secret
@@ -298,8 +298,8 @@ importers:
         specifier: ^7.12.0
         version: 7.12.0(debug@4.4.3)
       '@sanity/image-url':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^2.0.0
+        version: 2.0.0
       '@sanity/preview-url-secret':
         specifier: workspace:*
         version: link:../../packages/preview-url-secret
@@ -525,8 +525,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@sanity/color@3.0.6)(tailwindcss@3.4.17)
       '@sanity/image-url':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^2.0.0
+        version: 2.0.0
       '@sanity/preview-url-secret':
         specifier: workspace:*
         version: link:../../packages/preview-url-secret
@@ -621,8 +621,8 @@ importers:
         specifier: ^7.12.0
         version: 7.12.0(debug@4.4.3)
       '@sanity/image-url':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^2.0.0
+        version: 2.0.0
       '@sanity/preview-url-secret':
         specifier: workspace:*
         version: link:../../packages/preview-url-secret
@@ -761,8 +761,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@repo/studio-url
       '@sanity/image-url':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^2.0.0
+        version: 2.0.0
     devDependencies:
       '@fontsource/fira-mono':
         specifier: ^5.2.6
@@ -3612,6 +3612,13 @@ packages:
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
 
+  '@noble/ed25519@3.0.0':
+    resolution: {integrity: sha512-QyteqMNm0GLqfa5SoYbSC3+Pvykwpn95Zgth4MFVSMKBB75ELl9tX1LAVsN4c3HXOrakHsF2gL4zWDAYCcsnzg==}
+
+  '@noble/hashes@2.0.1':
+    resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -5105,6 +5112,10 @@ packages:
     resolution: {integrity: sha512-pYRhti+lDi22it+npWXkEGuYyzbXJLF+d0TYLiyWbKu46JHhYhTDKkp6zmGu4YKF5cXUjT6pnUjFsaf2vlB9nQ==}
     engines: {node: '>=10.0.0'}
 
+  '@sanity/image-url@2.0.0':
+    resolution: {integrity: sha512-ddZslfpLD1wz2HVwprkmTGQ7SjVFaNAOBOJdorfqWy2ajVO3Mx5P1xfZcwHdOkjv0Qsa1qdeMi+40cfVpIZBDw==}
+    engines: {node: '>=20.19.0'}
+
   '@sanity/import@3.38.3':
     resolution: {integrity: sha512-tWEcM5+RN+VDFuouWy6Imqmveko8tzksNYPyeMkqlkF8+s2OI2rGtMQVWvStu6zk4jVQoWXnG9hnt7TAUqKeTQ==}
     engines: {node: '>=18'}
@@ -5216,6 +5227,9 @@ packages:
   '@sanity/sdk@2.1.2':
     resolution: {integrity: sha512-gRBMDNvMUqlFTVoNgOLtcOFDO+e8Fh6v+BrEA4C5F18oi949ObjMmPB2aZMoyP3N3GQuqwVQP6L2PrhH70H7Bw==}
     engines: {node: '>=20.0.0'}
+
+  '@sanity/signed-urls@2.0.1':
+    resolution: {integrity: sha512-/u++FnDbaXDWHiHxG1Q4rbGsKRPf6lmTKsXeZ3bbbty/kNHDhVRUA5mRA+TtXlbPrse4ksv3a2vAerKNUNDZOw==}
 
   '@sanity/sveltekit@0.0.1':
     resolution: {integrity: sha512-WXfUZVf0P+JHGSa2mz6zjXzubXurgVqYsa1wgjpHzs47s/fA4r3zvibFRiDIckcvYcD63iIjTTqcRxhpgAe0Bw==}
@@ -17342,6 +17356,10 @@ snapshots:
     dependencies:
       eslint-scope: 5.1.1
 
+  '@noble/ed25519@3.0.0': {}
+
+  '@noble/hashes@2.0.1': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -18451,7 +18469,7 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.57.1)
@@ -19048,6 +19066,10 @@ snapshots:
 
   '@sanity/image-url@1.2.0': {}
 
+  '@sanity/image-url@2.0.0':
+    dependencies:
+      '@sanity/signed-urls': 2.0.1
+
   '@sanity/import@3.38.3(@types/react@19.2.2)':
     dependencies:
       '@sanity/asset-utils': 2.3.0
@@ -19367,6 +19389,11 @@ snapshots:
       - immer
       - react
       - use-sync-external-store
+
+  '@sanity/signed-urls@2.0.1':
+    dependencies:
+      '@noble/ed25519': 3.0.0
+      '@noble/hashes': 2.0.1
 
   '@sanity/sveltekit@0.0.1(@sanity/types@4.11.0(@types/react@19.2.2))(@sveltejs/kit@2.37.1(@sveltejs/vite-plugin-svelte@6.1.4(svelte@5.38.7)(vite@7.1.11(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)))(svelte@5.38.7)(vite@7.1.11(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)))(svelte@5.38.7)':
     dependencies:
@@ -23292,21 +23319,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -23322,14 +23334,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 8.57.1
+      get-tsconfig: 4.13.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23361,7 +23388,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
### TL;DR

Upgraded `@sanity/image-url` from v1.2.0 to v2.0.0 across all applications and updated import statements to use the new API.

### What changed?

- Updated `@sanity/image-url` dependency from v1.2.0 to v2.0.0 in package.json files across multiple apps (Astro, Next.js, Live Next, Page Builder Demo, Remix, Svelte)
- Changed import statements from `import imageUrlBuilder from '@sanity/image-url'` to `import {createImageUrlBuilder} from '@sanity/image-url'`
- Updated function calls from `imageUrlBuilder()` to `createImageUrlBuilder()`