### PR TITLE
feat(react): port experimental hooks from next-sanity

### DIFF
--- a/apps/live-next/app/alert-banner.tsx
+++ b/apps/live-next/app/alert-banner.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import {useIsPresentationTool} from 'next-sanity/hooks'
+import {useIsPresentationTool} from '@sanity/visual-editing/react'
 import {useRouter} from 'next/navigation'
 import {useTransition} from 'react'
 

--- a/apps/live-next/app/draft-mode-status.tsx
+++ b/apps/live-next/app/draft-mode-status.tsx
@@ -1,18 +1,27 @@
 'use client'
 
-import {useDraftModeEnvironment, useDraftModePerspective, useIsLivePreview} from 'next-sanity/hooks'
+import {useVisualEditingEnvironment} from '@sanity/visual-editing/react'
+import {ViewTransition} from 'react'
 
-export function DraftModeStatus() {
-  const isLivePreview = useIsLivePreview()
-  const perspective = useDraftModePerspective()
-  const environment = useDraftModeEnvironment()
+export function DraftModeStatus({perspective}: {perspective: string}) {
+  const environment = useVisualEditingEnvironment()
 
-  if (isLivePreview !== true) return null
+  if (environment === null) return null
 
   return (
     <div className="fixed bottom-3 right-3 block rounded bg-theme-inverse px-2 py-1 text-xs text-theme-inverse">
-      <p>perspective: {Array.isArray(perspective) ? perspective.join(',') : perspective}</p>
-      <p>environment: {environment}</p>
+      <p className="will-change-contents">
+        perspective:{' '}
+        <ViewTransition>
+          <code>{JSON.stringify(perspective)}</code>
+        </ViewTransition>
+      </p>
+      <p className="will-change-contents">
+        environment:{' '}
+        <ViewTransition>
+          <code>{JSON.stringify(environment)}</code>
+        </ViewTransition>
+      </p>
     </div>
   )
 }

--- a/apps/live-next/app/posts/[slug]/OptimisticPostContent.tsx
+++ b/apps/live-next/app/posts/[slug]/OptimisticPostContent.tsx
@@ -1,7 +1,8 @@
 'use client'
 
+import {useIsPresentationTool} from '@sanity/visual-editing/react'
 import {defineQuery, type PortableTextBlock} from 'next-sanity'
-import {useIsPresentationTool, usePresentationQuery} from 'next-sanity/hooks'
+import {usePresentationQuery} from 'next-sanity/hooks'
 
 import CustomPortableText from '@/app/portable-text'
 

--- a/apps/live-next/next.config.ts
+++ b/apps/live-next/next.config.ts
@@ -12,6 +12,7 @@ const nextConfig: NextConfig = {
   },
 
   reactCompiler: true,
+  experimental: {viewTransition: true},
 } satisfies NextConfig
 
 export default nextConfig

--- a/apps/live-next/sanity.types.ts
+++ b/apps/live-next/sanity.types.ts
@@ -366,6 +366,7 @@ export type SanityImageMetadata = {
   palette?: SanityImagePalette
   lqip?: string
   blurHash?: string
+  thumbHash?: string
   hasAlpha?: boolean
   isOpaque?: boolean
 }

--- a/apps/page-builder-demo/src/app/alert-banner.tsx
+++ b/apps/page-builder-demo/src/app/alert-banner.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import {useDraftModeEnvironment} from 'next-sanity/hooks'
+import {useVisualEditingEnvironment} from '@sanity/visual-editing/react'
 import {useRouter} from 'next/navigation'
 import {useTransition} from 'react'
 
@@ -10,8 +10,8 @@ export default function AlertBanner() {
   const router = useRouter()
   const [pending, startTransition] = useTransition()
 
-  const env = useDraftModeEnvironment()
-  const shouldShow = env !== 'checking' && env !== 'presentation-iframe'
+  const env = useVisualEditingEnvironment()
+  const shouldShow = env !== null && env !== 'presentation-iframe'
 
   if (!shouldShow) return null
 

--- a/apps/page-builder-demo/src/app/dnd/OptimisticSortOrder.tsx
+++ b/apps/page-builder-demo/src/app/dnd/OptimisticSortOrder.tsx
@@ -4,7 +4,7 @@ import type {SanityDocument} from '@sanity/client'
 
 import {type StudioPathLike} from '@sanity/client/csm'
 import {get} from '@sanity/util/paths'
-import {useOptimistic} from '@sanity/visual-editing'
+import {useOptimistic} from '@sanity/visual-editing/react'
 import {Children, isValidElement} from 'react'
 
 import type {DndTestPage} from '@/sanity.types'

--- a/apps/page-builder-demo/src/components/page/Page.tsx
+++ b/apps/page-builder-demo/src/components/page/Page.tsx
@@ -2,7 +2,7 @@
 
 import type {SanityDocument} from '@sanity/client'
 
-import {useOptimistic} from '@sanity/visual-editing'
+import {useOptimistic} from '@sanity/visual-editing/react'
 
 import type {FrontPageQueryResult} from '@/sanity.types'
 

--- a/apps/page-builder-demo/src/components/page/sections/FeaturedProducts.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/FeaturedProducts.tsx
@@ -1,6 +1,6 @@
 import type {SanityDocument} from '@sanity/client'
 
-import {useOptimistic} from '@sanity/visual-editing'
+import {useOptimistic} from '@sanity/visual-editing/react'
 import Link from 'next/link'
 
 import type {FrontPageQueryResult} from '@/sanity.types'

--- a/apps/page-builder-demo/src/components/page/sections/Intro.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/Intro.tsx
@@ -1,7 +1,7 @@
 import type {SanityDocument} from '@sanity/client'
 
-import {createDataAttribute, useOptimistic} from '@sanity/visual-editing'
-import React, {useMemo} from 'react'
+import {createDataAttribute, useOptimistic} from '@sanity/visual-editing/react'
+import {useMemo} from 'react'
 
 import type {FrontPageQueryResult} from '@/sanity.types'
 

--- a/package.json
+++ b/package.json
@@ -3,10 +3,9 @@
   "private": true,
   "scripts": {
     "build": "turbo run build --filter='!./apps/*'",
-    "dev": "turbo run build --filter='!./apps/*' && turbo watch dev --filter='./packages/*' --filter='./packages/@repo/*' --filter=./apps/* --filter=!next-with-i18n",
+    "dev": "turbo run build --filter='!./apps/*' && turbo watch dev --filter='./packages/*' --filter='./packages/@repo/*' --filter=./apps/*",
     "dev:live-next": "turbo run build --filter=live-next^... --filter=apps-studio^... && turbo watch dev --filter=live-next... --filter=apps-studio...",
     "dev:next": "turbo run build --filter=apps-next^... --filter=apps-studio^... && turbo watch dev --filter=apps-next... --filter=apps-studio...",
-    "dev:next-with-i18n": "turbo run build --filter=next-with-i18n^... && turbo watch dev --filter=next-with-i18n...",
     "dev:page-builder-demo": "turbo run build --filter=page-builder-demo^... --filter=apps-studio^... && turbo watch dev --filter=page-builder-demo... --filter=apps-studio...",
     "format": "oxfmt . --no-error-on-unmatched-pattern",
     "knip": "knip",

--- a/packages/visual-editing/src/react/index.ts
+++ b/packages/visual-editing/src/react/index.ts
@@ -74,3 +74,5 @@ export type {
 export {useOptimistic} from './useOptimistic'
 export {useOptimisticActor} from './useOptimisticActor'
 export {useDocuments} from './useDocuments'
+export {useVisualEditingEnvironment} from './useVisualEditingEnvironment'
+export {useIsPresentationTool} from './useIsPresentationTool'

--- a/packages/visual-editing/src/react/useIsPresentationTool.ts
+++ b/packages/visual-editing/src/react/useIsPresentationTool.ts
@@ -1,0 +1,12 @@
+import {useVisualEditingEnvironment} from './useVisualEditingEnvironment'
+
+/**
+ * Initially returns `null`, until `<VisualEditing />` is rendered on the page.
+ * Returns `false` if there's no parent window context with Presentation Tool connected over comlink.
+ * Returns `true` when a connection is established over comlink and window.postMessage, the handshake might take a while and the hook may return `false` initially before it eventually returns `true`.
+ */
+export function useIsPresentationTool(): null | boolean {
+  const env = useVisualEditingEnvironment()
+  if (env === null) return null
+  return env === 'presentation-iframe' || env === 'presentation-window'
+}

--- a/packages/visual-editing/src/react/useVisualEditingEnvironment.ts
+++ b/packages/visual-editing/src/react/useVisualEditingEnvironment.ts
@@ -1,0 +1,11 @@
+import {useDeferredValue, useSyncExternalStore} from 'react'
+
+import {type VisualEditingEnvironment, subscribe, getSnapshot} from '../ui/environment/context'
+
+/**
+ * @alpha - unstable API, may have breaking changes in a minor release
+ */
+export function useVisualEditingEnvironment(): VisualEditingEnvironment {
+  const environment = useSyncExternalStore(subscribe, getSnapshot, () => null)
+  return useDeferredValue(environment, null)
+}

--- a/packages/visual-editing/src/ui/environment/context.ts
+++ b/packages/visual-editing/src/ui/environment/context.ts
@@ -1,0 +1,30 @@
+/**
+ * The environment is `null` initially, until `<VisualEditing />` is rendered on the page.
+ * It then becomes `'standalone'` by default. If Presentation Tool is detected and connected over comlink it then becomes either:
+ * - `'presentation-iframe'` if the page is loaded in an iframe, this is the default
+ * - `'presentation-window'` if the page is loaded in a new window, which happens if the studio user has clicked the "Open preview" button in the Presentation Tool URL bar.
+ */
+export type VisualEditingEnvironment =
+  | null
+  | 'presentation-iframe'
+  | 'presentation-window'
+  | 'standalone'
+
+const listeners: Set<() => void> = new Set()
+export function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => void listeners.delete(listener)
+}
+
+let environment: VisualEditingEnvironment = null
+export function getSnapshot(): VisualEditingEnvironment {
+  return environment
+}
+
+export function setEnvironment(nextEnvironment: VisualEditingEnvironment): void {
+  if (environment === nextEnvironment) return
+  environment = nextEnvironment
+  for (const onEnvironmentChange of listeners) {
+    onEnvironmentChange()
+  }
+}


### PR DESCRIPTION
This PR ports over two hooks from `next-sanity/hooks`.

### `useIsPresentationTool`

In `next-sanity` the signature is:
```ts
import {useIsPresentationTool} from 'next-sanity/hooks'

const isPresentationTool = useIsPresentationTool()
//     ^? null | boolean
```

The signature is the same when used from `@sanity/visual-editing/react`:
```ts
import {useIsPresentationTool} from '@sanity/visual-editing/react'
```

The rule is that it always returns `null` until `<VisualEditing />` has mounted, then it'll be `true` if the comlink handshake successfully connects to Presentation Tool in a parent window, or `false` if it's either detected as a standalone context or there are no parent window contexts that could host Presentation Tool.
The `next-sanity` hook version required the `<SanityLive />` component to render in order to set the right state, this version only requires `<VisualEditing />`, which is more intuitive as the only required component for Presentation Tool to be on the page is in fact `<VisualEditing />` and `<SanityLive />` should be totally optional without affecting this type of hooks.

### `useVisualEditingEnvironment`

This hook is based on `useDraftModeEnvironment` in `next-sanity`:

```ts
import {useDraftModeEnvironment} from 'next-sanity/hooks'

const env = useDraftModeEnvironment()
//    ^? 'checking' | 'presentation-iframe' | 'presentation-window' | 'live' | 'static' | 'unknown'
```

The signature is simplified:
```ts
import {useVisualEditingEnvironment} from '@sanity/visual-editing/react'

const env = useVisualEditingEnvironment()
//    ^? null | 'presentation-iframe' | 'presentation-window' | 'standalone'
```
Like `useIsPresentationTool` it is `null` until `<VisualEditing />` has mounted. Since it's controlled by `<VisualEditing />` rather than `<SanityLive />` it does not have `'live'` and `'static'`, as those are related to wether or not `<SanityLive />` has a `browserToken` or not, and is generally a very leaky abstraction.

The new hook is much simpler, it's `presentation-iframe` if the app is loaded in the default iframe in Presentation Tool, it's `presentation-window` if the "Open preview" toolbar button was clicked. And `standalone` if `<VisualEditing>` is rendering but there are no Presentation Tool detected.

### Frameworks beyond react

The internal store that sets `environment` can be adapted for non-react use cases in the future, it's react-only for now in order to unblock https://github.com/sanity-io/next-sanity/pull/3109