### PR TITLE
fix(insert-menu): prevent icon/preview overlap in grid menu items

### DIFF
--- a/.changeset/tidy-pumpkins-shine.md
+++ b/.changeset/tidy-pumpkins-shine.md
@@ -1,0 +1,5 @@
+---
+"@sanity/insert-menu": patch
+---
+
+fix(insert-menu): prevent icon/preview overlap in grid menu items

--- a/packages/insert-menu/src/InsertMenu.tsx
+++ b/packages/insert-menu/src/InsertMenu.tsx
@@ -262,6 +262,7 @@ type GridMenuItemProps = {
 function GridMenuItem(props: GridMenuItemProps) {
   const [failedToLoad, setFailedToLoad] = useState(false)
   const Icon = props.icon
+  const hasPreviewImage = Boolean(props.previewImageUrl) && !failedToLoad
 
   return (
     <MenuItem padding={0} radius={2} onClick={props.onClick} style={{overflow: 'hidden'}}>
@@ -274,7 +275,7 @@ function GridMenuItem(props: GridMenuItemProps) {
             position: 'relative',
           }}
         >
-          {isValidElementType(Icon) ? (
+          {isValidElementType(Icon) && !hasPreviewImage ? (
             <Flex
               align="center"
               justify="center"
@@ -291,7 +292,7 @@ function GridMenuItem(props: GridMenuItemProps) {
               </Text>
             </Flex>
           ) : null}
-          {!props.previewImageUrl || failedToLoad ? null : (
+          {hasPreviewImage ? (
             <img
               src={props.previewImageUrl}
               style={{
@@ -305,7 +306,7 @@ function GridMenuItem(props: GridMenuItemProps) {
                 setFailedToLoad(true)
               }}
             />
-          )}
+          ) : null}
 
           <div
             style={{


### PR DESCRIPTION
### Description

[SGH-609](https://linear.app/sanity/issue/SGH-609/array-item-preview-image-overlaps-with-icon) / [#3406](https://github.com/sanity-io/visual-editing/issues/3406): in grid view, `GridMenuItem` rendered the schema-type icon and the `previewImageUrl` image simultaneously in the same absolutely-positioned tile. When the preview image has transparent regions or its aspect ratio leaves letterbox gaps, the icon visibly bleeds through behind the image. The icon was intended as a fallback for when no preview is available, but the conditional was never gated on the image's presence.

This PR makes the icon and preview image mutually exclusive in `GridMenuItem`. A `hasPreviewImage` derived value (`Boolean(previewImageUrl) && !failedToLoad`) now drives both branches, so the icon only renders when there is no URL or the image has failed to load, restoring the intended fallback behaviour without introducing new state.

### Testing

Verified visually in `@sanity/insert-menu`'s workshop with grid-view schema types that have both an `icon` and a transparent-background preview PNG. After the change, only the preview renders; swapping in a 404 URL confirms the icon reappears once `onError` fires. `pnpm --filter @sanity/insert-menu lint`, `ts:check`, and `build` all pass.

### Notes for release

Fix overlap between schema-type icon and preview image in the array insert menu's grid view.