### PR TITLE
fix(visual-editing): report documents on the page in visual order

### DIFF
--- a/.changeset/report-documents-visual-order.md
+++ b/.changeset/report-documents-visual-order.md
@@ -1,0 +1,5 @@
+---
+"@sanity/visual-editing": patch
+---
+
+fix(visual-editing): report documents on the page in visual order

--- a/packages/visual-editing/src/ui/__tests__/orderSanityNodesByPosition.test.ts
+++ b/packages/visual-editing/src/ui/__tests__/orderSanityNodesByPosition.test.ts
@@ -1,0 +1,89 @@
+import {expect, test} from 'vitest'
+
+import type {ElementState} from '../../types'
+
+import {orderSanityNodesByPosition} from '../orderSanityNodesByPosition'
+
+function makeElement(
+  overrides: Partial<ElementState> & {
+    rect: {x: number; y: number}
+    sanity: ElementState['sanity']
+  },
+): ElementState {
+  return {
+    id: 'element-id',
+    activated: false,
+    element: document.createElement('div') as unknown as ElementState['element'],
+    focused: false,
+    hovered: false,
+    dragDisabled: false,
+    targets: [],
+    elementType: 'element',
+    rect: {w: 100, h: 50, ...overrides.rect},
+    ...overrides,
+  }
+}
+
+function makeSanityNode(id: string): ElementState['sanity'] {
+  return {
+    id,
+    baseUrl: '/studio',
+    path: 'title',
+    type: 'article',
+  }
+}
+
+function makeStegaNode(): ElementState['sanity'] {
+  return {
+    origin: 'sanity.io',
+    href: '/studio',
+  }
+}
+
+test('sorts elements by rect.y ascending then rect.x ascending', () => {
+  const elements = [
+    makeElement({rect: {x: 100, y: 300}, sanity: makeSanityNode('doc-c')}),
+    makeElement({rect: {x: 50, y: 100}, sanity: makeSanityNode('doc-a')}),
+    makeElement({rect: {x: 200, y: 100}, sanity: makeSanityNode('doc-b')}),
+  ]
+
+  const result = orderSanityNodesByPosition(elements)
+
+  expect(result.map((node) => node.id)).toEqual(['doc-a', 'doc-b', 'doc-c'])
+})
+
+test('collapses duplicate ids to the topmost occurrence', () => {
+  const elements = [
+    makeElement({rect: {x: 0, y: 200}, sanity: makeSanityNode('doc-shared')}),
+    makeElement({rect: {x: 0, y: 50}, sanity: makeSanityNode('doc-top')}),
+    makeElement({rect: {x: 0, y: 100}, sanity: makeSanityNode('doc-shared')}),
+  ]
+
+  const result = orderSanityNodesByPosition(elements)
+
+  expect(result.map((node) => node.id)).toEqual(['doc-top', 'doc-shared'])
+})
+
+test('filters out elements without a sanity id (stega nodes)', () => {
+  const elements = [
+    makeElement({rect: {x: 0, y: 200}, sanity: makeSanityNode('doc-b')}),
+    makeElement({rect: {x: 0, y: 50}, sanity: makeStegaNode()}),
+    makeElement({rect: {x: 0, y: 100}, sanity: makeSanityNode('doc-a')}),
+  ]
+
+  const result = orderSanityNodesByPosition(elements)
+
+  expect(result.map((node) => node.id)).toEqual(['doc-a', 'doc-b'])
+})
+
+test('does not mutate the original elements array', () => {
+  const elements = [
+    makeElement({rect: {x: 0, y: 200}, sanity: makeSanityNode('doc-b')}),
+    makeElement({rect: {x: 0, y: 100}, sanity: makeSanityNode('doc-a')}),
+  ]
+  const original = [...elements]
+
+  orderSanityNodesByPosition(elements)
+
+  expect(elements).toEqual(original)
+})

--- a/packages/visual-editing/src/ui/__tests__/orderSanityNodesByPosition.test.ts
+++ b/packages/visual-editing/src/ui/__tests__/orderSanityNodesByPosition.test.ts
@@ -5,11 +5,12 @@ import type {ElementState} from '../../types'
 import {orderSanityNodesByPosition} from '../orderSanityNodesByPosition'
 
 function makeElement(
-  overrides: Partial<ElementState> & {
+  overrides: Partial<Omit<ElementState, 'rect'>> & {
     rect: {x: number; y: number}
     sanity: ElementState['sanity']
   },
 ): ElementState {
+  const {rect, ...rest} = overrides
   return {
     id: 'element-id',
     activated: false,
@@ -19,8 +20,8 @@ function makeElement(
     dragDisabled: false,
     targets: [],
     elementType: 'element',
-    rect: {w: 100, h: 50, ...overrides.rect},
-    ...overrides,
+    ...rest,
+    rect: {w: 100, h: 50, ...rect},
   }
 }
 

--- a/packages/visual-editing/src/ui/orderSanityNodesByPosition.ts
+++ b/packages/visual-editing/src/ui/orderSanityNodesByPosition.ts
@@ -1,0 +1,25 @@
+import type {ElementState, SanityNode} from '../types'
+
+/**
+ * Orders elements by visual position (top-to-bottom, left-to-right), maps each
+ * to its SanityNode, and de-duplicates by id — keeping the first (topmost)
+ * occurrence.
+ *
+ * @internal
+ */
+export function orderSanityNodesByPosition(elements: ElementState[]): SanityNode[] {
+  const sorted = [...elements].sort((elementA, elementB) => {
+    const yDiff = elementA.rect.y - elementB.rect.y
+    return yDiff !== 0 ? yDiff : elementA.rect.x - elementB.rect.x
+  })
+
+  const seen = new Set<string>()
+  return sorted.reduce<SanityNode[]>((acc, element) => {
+    const {sanity} = element
+    if (!sanity || !('id' in sanity)) return acc
+    if (seen.has(sanity.id)) return acc
+    seen.add(sanity.id)
+    acc.push(sanity)
+    return acc
+  }, [])
+}

--- a/packages/visual-editing/src/ui/useReportDocuments.ts
+++ b/packages/visual-editing/src/ui/useReportDocuments.ts
@@ -1,14 +1,10 @@
 import type {ClientPerspective, ContentSourceMapDocuments} from '@sanity/client'
+
 import {useCallback, useEffect, useRef} from 'react'
 
-import type {ElementState, SanityNode, VisualEditingNode} from '../types'
+import type {ElementState, VisualEditingNode} from '../types'
 
-function isEqualSets(a: Set<string>, b: Set<string>) {
-  if (a === b) return true
-  if (a.size !== b.size) return false
-  for (const value of a) if (!b.has(value)) return false
-  return true
-}
+import {orderSanityNodesByPosition} from './orderSanityNodesByPosition'
 
 /**
  * Hook for reporting in use documents to Presentation
@@ -21,7 +17,7 @@ export function useReportDocuments(
 ): void {
   const lastReported = useRef<
     | {
-        nodeIds: Set<string>
+        orderedIds: string[]
         perspective: ClientPerspective
       }
     | undefined
@@ -40,33 +36,29 @@ export function useReportDocuments(
   useEffect(() => {
     // Report only nodes of type `SanityNode`. Untransformed `SanityStegaNode`
     // nodes without an `id`, are not reported as they will not contain the
-    // necessary document data.
-    const nodes = elements
-      .map((e) => {
-        const {sanity} = e
-        if (!sanity || !('id' in sanity)) return null
-        return sanity
-      })
-      .filter((s) => !!s) as SanityNode[]
+    // necessary document data. Nodes are sorted by visual position so the
+    // reported order reflects appearance on the page.
+    const orderedNodes = orderSanityNodesByPosition(elements)
+    const orderedIds = orderedNodes.map((node) => node.id)
 
-    const nodeIds = new Set<string>(nodes.map((e) => e.id))
     // Report if:
     // - Documents not yet reported
-    // - Document IDs changed
+    // - Document IDs changed or their visual order changed
     // - Perspective changed
-    if (
-      !lastReported.current ||
-      !isEqualSets(nodeIds, lastReported.current.nodeIds) ||
-      perspective !== lastReported.current.perspective
-    ) {
-      const documentsOnPage: ContentSourceMapDocuments = Array.from(nodeIds).map((_id) => {
-        const node = nodes.find((node) => node.id === _id)!
-        const {type, projectId: _projectId, dataset: _dataset} = node
+    const lastOrderedIds = lastReported.current?.orderedIds
+    const orderChanged =
+      !lastOrderedIds ||
+      lastOrderedIds.length !== orderedIds.length ||
+      orderedIds.some((id, index) => id !== lastOrderedIds[index])
+
+    if (orderChanged || perspective !== lastReported.current?.perspective) {
+      const documentsOnPage: ContentSourceMapDocuments = orderedNodes.map((node) => {
+        const {id: _id, type, projectId: _projectId, dataset: _dataset} = node
         return _projectId && _dataset
           ? {_id, _type: type!, _projectId, _dataset}
           : {_id, _type: type!}
       })
-      lastReported.current = {nodeIds, perspective}
+      lastReported.current = {orderedIds, perspective}
       reportDocuments(documentsOnPage, perspective)
     }
   }, [elements, perspective, reportDocuments])


### PR DESCRIPTION
## Description

`useReportDocuments` built its document list from a `Set` iterated in element registration order - the order elements mounted, not the order they appear on the page. The Presentation sidebar therefore received documents in an arbitrary sequence, making "by appearance" ordering impossible to implement (sanity-io/sanity#12956).

This PR extracts a pure helper, `orderSanityNodesByPosition`, that sorts elements by `rect.y` then `rect.x` (document-absolute coordinates already on each `ElementState`) before mapping to `SanityNode` and de-duplicating by id. The hook uses this sorted list to build `documentsOnPage` and replaces the `isEqualSets` re-report gate with an ordered-array comparison so layout reflows that change visual order trigger a fresh report.

## Testing

Four unit tests cover the helper directly: elements sorted by rect position, duplicate ids collapsed to the topmost occurrence, stega nodes (no id) filtered out, and the input array not mutated. All pass. Lint and type checks are clean.
