### PR TITLE
ci: build example apps to catch dependency and tailwind breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,29 @@ jobs:
       - run: pnpm build --filter=!./apps/*
       - run: pnpm lint
 
+  build-apps:
+    # Builds the example apps to catch breakages (undeclared deps, framework/tailwind bumps)
+    # that the package-only `build` job and the shared turbo cache would otherwise hide.
+    # No SANITY_API_READ_TOKEN secret exists, so the Next apps run in compile mode
+    # (Turbopack compile + PostCSS/Tailwind, no build-time Sanity fetch); the studio app
+    # builds fully. `--force` bypasses the turbo cache so latent breakage is not masked.
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          cache: pnpm
+          node-version: lts/*
+      - run: pnpm install --ignore-scripts
+      - run: pnpm turbo run build --filter=apps-studio --filter=apps-next^... --filter=live-next^... --filter=page-builder-demo^... --force
+      - run: pnpm --filter=apps-next exec next build --experimental-build-mode=compile
+      - run: pnpm --filter=live-next exec next build --experimental-build-mode=compile
+      - run: pnpm --filter=page-builder-demo exec next build --experimental-build-mode=compile
+
   test:
     needs: build
     timeout-minutes: 15


### PR DESCRIPTION
## What

Adds a `build-apps` CI job that builds the example apps, so build breakages (undeclared dependencies, framework/major dependency bumps, Tailwind v4-style PostCSS breakage) are caught at PR time instead of only surfacing on a Vercel cache miss.

Today CI runs `pnpm build --filter=!./apps/*` (apps excluded) and the turbo remote cache (shared by CI and Vercel) replays stale package successes, so broken app builds go unnoticed until Vercel misses cache. This job closes that gap. It passes `--force` to bypass the turbo cache so latent breakage is not masked.

## How

- **studio**: built fully via turbo (no build-time Sanity fetch, so it is deterministic).
- **next / live-next / page-builder-demo**: built with `next build --experimental-build-mode=compile`. This runs the Turbopack compile + PostCSS/Tailwind stage (where undeclared-dep and dependency/Tailwind breakage actually fails) without collecting page data or prerendering.

The job mirrors the existing `build` job setup (checkout, pnpm/action-setup, setup-node with pnpm cache, TURBO_TOKEN/TURBO_TEAM, `pnpm install --ignore-scripts`).

## Limitation / tradeoff

There is no `SANITY_API_READ_TOKEN` secret in the repo. The apps read that token at module load and throw without it, and the Pages Router pages (`getStaticProps`) and App Router dynamic routes fetch live Sanity data at build time - a full `next build` returns `401 Unauthorized` and fails collecting page data. A full app build therefore cannot pass deterministically in CI without that secret and live data.

Compile mode is the largest deterministically-green check that still catches the target breakage class. Verified locally that it catches both a used undeclared import (`Module not found`) and a bad Tailwind utility (`Cannot apply unknown utility class`), while a clean tree exits 0. It does not catch breakage that only manifests during prerender/data-collection; covering that would require provisioning a read token and stable build-time data.

Stacked on #(fix/next-build-time-sanity-fetch) so the diff stays narrow and CI runs against the dependency/Tailwind fixes on that branch.