### PR TITLE
fix: double heartbeat interval

### DIFF
--- a/.changeset/tall-chairs-knock.md
+++ b/.changeset/tall-chairs-knock.md
@@ -1,0 +1,6 @@
+---
+"@sanity/visual-editing": patch
+"@sanity/core-loader": patch
+---
+
+Increase heartbeat interval

--- a/packages/core-loader/src/live-mode/enableLiveMode.ts
+++ b/packages/core-loader/src/live-mode/enableLiveMode.ts
@@ -23,7 +23,7 @@ export interface LazyEnableLiveModeOptions extends EnableLiveModeOptions {
   setFetcher: SetFetcher
 }
 
-const LISTEN_HEARTBEAT_INTERVAL = 10_000
+const LISTEN_HEARTBEAT_INTERVAL = 20_000
 
 export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
   const {client, setFetcher, onConnect, onDisconnect, onPerspective} = options

--- a/packages/visual-editing/src/react/usePresentationQuery.ts
+++ b/packages/visual-editing/src/react/usePresentationQuery.ts
@@ -73,7 +73,7 @@ const initialState: UsePresentationQueryReturnsInactive = {
 }
 
 const EMPTY_QUERY_PARAMS: QueryParams = {}
-const LISTEN_HEARTBEAT_INTERVAL = 10_000
+const LISTEN_HEARTBEAT_INTERVAL = 20_000
 
 /**
  * Experimental hook that can run queries in Presentation Tool.


### PR DESCRIPTION
### Description

This branch doubles the heartbeat interval in order to reduce garbage collection work. This is to address reports of Presentation getting stuck in the reconnecting state after prolonged usage (5+ minutes navigating between various pages).

### What to review

Any concerns doubling the heartbeat interval to 20 seconds?

### Testing

Existing tests pass.
