### PR TITLE
feat(visual-editing): strip stega from clipboard on copy, add `onSuspiciousStega` reporting

### DIFF
--- a/.changeset/strip-stega-on-copy.md
+++ b/.changeset/strip-stega-on-copy.md
@@ -1,0 +1,9 @@
+---
+'@sanity/visual-editing': minor
+---
+
+feat: strip stega from clipboard on copy, and report suspicious stega placements
+
+While Visual Editing is enabled, `copy` events are now intercepted and stega-encoded metadata (invisible characters) is stripped from the clipboard, so content copied from a preview can be pasted into other tools without the hidden characters tagging along. Copies without stega are left untouched, and the behavior can be disabled with the new `keepStegaOnCopy` option.
+
+Also adds an opt-in `onSuspiciousStega` callback that reports stega payloads found in places where they always cause bugs or bloat, such as `class`, `href`, `src`, `id` and other attributes, inside `<head>` (e.g. `<title>`), `<script>` or `<style>` contents, form values, or the page URL. Reports are deduped, batched, and include the decoded edit info when available so the source field can be tracked down.

--- a/packages/visual-editing/README.md
+++ b/packages/visual-editing/README.md
@@ -447,14 +447,14 @@ Providing the callback opts in to the detection logic — when it isn't provided
 
 Reported placements (`report.kind`):
 
-| `kind` | What it means |
-| --- | --- |
-| `attribute` | Stega in an attribute such as `class` (selectors no longer match), `id` (broken anchors and `getElementById`), `href`/`src` and other URL attributes (the invisible characters end up percent-encoded in requests), `style`, `name`, `value` or `data-*` (broken equality checks). |
-| `head` | Stega anywhere inside `<head>`, e.g. rendering `data.title` in `<title>` or `meta[content]`. It's never visible, so it's pure bloat that also corrupts SEO and social metadata. |
-| `script` | Stega inside a `<script>` element, e.g. JSON-LD structured data or embedded state. |
-| `style` | Stega inside a `<style>` element, breaking selectors or values. |
-| `form-value` | Stega in a form field value (e.g. `<textarea>` content), where it would be submitted along with user input. |
-| `url` | Stega in the page URL itself, meaning the page was reached through a link that had stega encoded into it. |
+| `kind`       | What it means                                                                                                                                                                                                                                                                      |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `attribute`  | Stega in an attribute such as `class` (selectors no longer match), `id` (broken anchors and `getElementById`), `href`/`src` and other URL attributes (the invisible characters end up percent-encoded in requests), `style`, `name`, `value` or `data-*` (broken equality checks). |
+| `head`       | Stega anywhere inside `<head>`, e.g. rendering `data.title` in `<title>` or `meta[content]`. It's never visible, so it's pure bloat that also corrupts SEO and social metadata.                                                                                                    |
+| `script`     | Stega inside a `<script>` element, e.g. JSON-LD structured data or embedded state.                                                                                                                                                                                                 |
+| `style`      | Stega inside a `<style>` element, breaking selectors or values.                                                                                                                                                                                                                    |
+| `form-value` | Stega in a form field value (e.g. `<textarea>` content), where it would be submitted along with user input.                                                                                                                                                                        |
+| `url`        | Stega in the page URL itself, meaning the page was reached through a link that had stega encoded into it.                                                                                                                                                                          |
 
 The fix is usually to clean the value before rendering it with [`stegaClean` from `@sanity/client/stega`](https://www.sanity.io/docs/stega), or to exclude the field from stega encoding entirely using your client's `stega.filter` configuration.
 

--- a/packages/visual-editing/README.md
+++ b/packages/visual-editing/README.md
@@ -31,6 +31,8 @@ npm install @sanity/visual-editing react react-dom
     - [`source: 'mutation'`](#source-mutation-1)
   - [React Router](#react-router-1)
   - [SvelteKit](#sveltekit)
+- [Stega and the clipboard](#stega-and-the-clipboard)
+- [Detecting stega in unsafe places](#detecting-stega-in-unsafe-places)
 - [Manually configuring "Edit in Sanity Studio" elements](#manually-configuring-edit-in-sanity-studio-elements)
   - [`data-sanity-edit-target`](#data-sanity-edit-target)
 - [Change the z-index of overlay elements](#change-the-z-index-of-overlay-elements)
@@ -410,6 +412,51 @@ If you only want to configure **when** revalidation is called, and not the actua
 ### [SvelteKit][sveltekit]
 
 A first class implementation for SvelteKit is coming soon.
+
+## Stega and the clipboard
+
+Visual editing locates editable content by looking for [stega-encoded metadata](https://www.sanity.io/docs/stega) — sequences of invisible characters appended to strings. Those characters would normally tag along when content is copied from a preview and pasted into other tools, showing up as unexpected garbage in plain text fields, URLs, spreadsheets and the like.
+
+To prevent this, while Visual Editing is enabled, `copy` events are intercepted and stega metadata is automatically stripped from the clipboard (both the `text/plain` and `text/html` flavors). Copies that don't contain stega are left completely untouched, and `copy` handlers of your own that call `event.preventDefault()` take precedence.
+
+If you want to keep the stega metadata in copied content, opt out with `keepStegaOnCopy`:
+
+```tsx
+<VisualEditing keepStegaOnCopy />
+```
+
+```ts
+enableVisualEditing({keepStegaOnCopy: true})
+```
+
+## Detecting stega in unsafe places
+
+Stega metadata is designed to live in rendered text (and a few attributes such as `img[alt]`, `time[datetime]` and `aria-label` on `svg`). If it ends up anywhere else — usually because a content value was rendered somewhere it shouldn't be without cleaning it first — it will always cause bugs or bloat. Provide the `onSuspiciousStega` callback to detect and report these cases:
+
+```tsx
+<VisualEditing
+  onSuspiciousStega={(reports) => {
+    for (const report of reports) {
+      console.warn(`Stega found in ${report.kind}`, report)
+    }
+  }}
+/>
+```
+
+Providing the callback opts in to the detection logic — when it isn't provided, no scanning runs. The scan happens during browser idle time: an initial audit of the document, then incremental checks of DOM changes. Reports are deduped and batched, and each report includes the offending `element`, the raw `value`, the `cleaned` value it should have been, and — when the payload can be decoded — the `sanity` edit info pointing to the document and field that produced the value.
+
+Reported placements (`report.kind`):
+
+| `kind` | What it means |
+| --- | --- |
+| `attribute` | Stega in an attribute such as `class` (selectors no longer match), `id` (broken anchors and `getElementById`), `href`/`src` and other URL attributes (the invisible characters end up percent-encoded in requests), `style`, `name`, `value` or `data-*` (broken equality checks). |
+| `head` | Stega anywhere inside `<head>`, e.g. rendering `data.title` in `<title>` or `meta[content]`. It's never visible, so it's pure bloat that also corrupts SEO and social metadata. |
+| `script` | Stega inside a `<script>` element, e.g. JSON-LD structured data or embedded state. |
+| `style` | Stega inside a `<style>` element, breaking selectors or values. |
+| `form-value` | Stega in a form field value (e.g. `<textarea>` content), where it would be submitted along with user input. |
+| `url` | Stega in the page URL itself, meaning the page was reached through a link that had stega encoded into it. |
+
+The fix is usually to clean the value before rendering it with [`stegaClean` from `@sanity/client/stega`](https://www.sanity.io/docs/stega), or to exclude the field from stega encoding entirely using your client's `stega.filter` configuration.
 
 ## Manually configuring "Edit in Sanity Studio" elements
 

--- a/packages/visual-editing/src/index.ts
+++ b/packages/visual-editing/src/index.ts
@@ -65,6 +65,7 @@ export type {
   OverlayRect,
   SanityNode,
   SanityStegaNode,
+  SuspiciousStegaReport,
   VisualEditingOptions,
   ElementChildTarget,
   OverlayPluginDefinition,

--- a/packages/visual-editing/src/next-pages-router/VisualEditingComponent.tsx
+++ b/packages/visual-editing/src/next-pages-router/VisualEditingComponent.tsx
@@ -5,6 +5,7 @@ import type {
   HistoryAdapterNavigate,
   HistoryRefresh,
   HistoryUpdate,
+  SuspiciousStegaReport,
   VisualEditingOptions,
 } from '../types'
 import {enableVisualEditing} from '../ui/enableVisualEditing'
@@ -20,7 +21,14 @@ export interface VisualEditingProps extends Omit<VisualEditingOptions, 'history'
 }
 
 export default function VisualEditingComponent(props: VisualEditingProps): null {
-  const {components, refresh: refreshProp, zIndex, onPerspectiveChange} = props
+  const {
+    components,
+    keepStegaOnCopy,
+    refresh: refreshProp,
+    zIndex,
+    onPerspectiveChange,
+    onSuspiciousStega: onSuspiciousStegaProp,
+  } = props
 
   const router = useRouter()
   const [navigate, setNavigate] = useState<HistoryAdapterNavigate | undefined>()
@@ -67,12 +75,18 @@ export default function VisualEditingComponent(props: VisualEditingProps): null 
         throw new Error(`Unknown event type: ${event.type}`)
     }
   })
+  const onSuspiciousStega = useEffectEvent((reports: SuspiciousStegaReport[]) =>
+    onSuspiciousStegaProp?.(reports),
+  )
+  const hasSuspiciousStegaCallback = typeof onSuspiciousStegaProp === 'function'
   useEffect(() => {
     const disable = enableVisualEditing({
       components,
+      keepStegaOnCopy,
       zIndex,
       refresh,
       onPerspectiveChange,
+      onSuspiciousStega: hasSuspiciousStegaCallback ? onSuspiciousStega : undefined,
       history: {
         subscribe: (_navigate) => {
           setNavigate(() => _navigate)
@@ -82,7 +96,7 @@ export default function VisualEditingComponent(props: VisualEditingProps): null 
       },
     })
     return () => disable()
-  }, [components, zIndex, onPerspectiveChange])
+  }, [components, keepStegaOnCopy, zIndex, onPerspectiveChange, hasSuspiciousStegaCallback])
 
   const {asPath, basePath, locale, isReady} = useRouter()
   useEffect(() => {

--- a/packages/visual-editing/src/next-pages-router/index.ts
+++ b/packages/visual-editing/src/next-pages-router/index.ts
@@ -11,6 +11,7 @@ export type {
   OverlayElementField,
   OverlayElementParent,
   SanityNode,
+  SuspiciousStegaReport,
   VisualEditingOptions,
   OverlayPluginDefinition,
   OverlayPluginExclusiveDefinition,

--- a/packages/visual-editing/src/react-router/VisualEditingComponent.tsx
+++ b/packages/visual-editing/src/react-router/VisualEditingComponent.tsx
@@ -1,7 +1,12 @@
-import {startTransition, useEffect, useRef, useState} from 'react'
+import {startTransition, useEffect, useEffectEvent, useRef, useState} from 'react'
 import {useLocation, useNavigate, useRevalidator} from 'react-router'
 
-import {type HistoryAdapterNavigate, type HistoryRefresh, type VisualEditingOptions} from '../types'
+import {
+  type HistoryAdapterNavigate,
+  type HistoryRefresh,
+  type SuspiciousStegaReport,
+  type VisualEditingOptions,
+} from '../types'
 import {enableVisualEditing} from '../ui/enableVisualEditing'
 
 /**
@@ -23,7 +28,14 @@ export interface VisualEditingProps extends Omit<VisualEditingOptions, 'history'
 }
 
 export default function VisualEditingComponent(props: VisualEditingProps): null {
-  const {components, refresh, zIndex, onPerspectiveChange} = props
+  const {
+    components,
+    keepStegaOnCopy,
+    refresh,
+    zIndex,
+    onPerspectiveChange,
+    onSuspiciousStega: onSuspiciousStegaProp,
+  } = props
 
   const navigateRemix = useNavigate()
   const navigateRemixRef = useRef(navigateRemix)
@@ -46,11 +58,17 @@ export default function VisualEditingComponent(props: VisualEditingProps): null 
       })
     }
   }, [revalidatorLoading, revalidator.state, revalidatorPromise])
+  const onSuspiciousStega = useEffectEvent((reports: SuspiciousStegaReport[]) =>
+    onSuspiciousStegaProp?.(reports),
+  )
+  const hasSuspiciousStegaCallback = typeof onSuspiciousStegaProp === 'function'
   useEffect(() => {
     const disable = enableVisualEditing({
       components,
+      keepStegaOnCopy,
       zIndex,
       onPerspectiveChange,
+      onSuspiciousStega: hasSuspiciousStegaCallback ? onSuspiciousStega : undefined,
       refresh: (payload) => {
         function refreshDefault() {
           if (payload.source === 'mutation' && payload.livePreviewEnabled) {
@@ -80,7 +98,15 @@ export default function VisualEditingComponent(props: VisualEditingProps): null 
       },
     })
     return () => disable()
-  }, [components, refresh, revalidator, zIndex, onPerspectiveChange])
+  }, [
+    components,
+    keepStegaOnCopy,
+    refresh,
+    revalidator,
+    zIndex,
+    onPerspectiveChange,
+    hasSuspiciousStegaCallback,
+  ])
 
   const location = useLocation()
   useEffect(() => {

--- a/packages/visual-editing/src/react-router/index.ts
+++ b/packages/visual-editing/src/react-router/index.ts
@@ -11,6 +11,7 @@ export type {
   OverlayElementField,
   OverlayElementParent,
   SanityNode,
+  SuspiciousStegaReport,
   VisualEditingOptions,
   OverlayPluginDefinition,
   OverlayPluginExclusiveDefinition,

--- a/packages/visual-editing/src/react/index.ts
+++ b/packages/visual-editing/src/react/index.ts
@@ -11,6 +11,7 @@ export type {
   OverlayElementField,
   OverlayElementParent,
   SanityNode,
+  SuspiciousStegaReport,
   VisualEditingOptions,
   VisualEditingNode,
   OverlayPluginDefinition,

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -520,6 +520,52 @@ export interface OverlayPluginHudDefinition extends OverlayPluginDefinitionBase 
 export type OverlayPluginDefinition = OverlayPluginExclusiveDefinition | OverlayPluginHudDefinition
 
 /**
+ * A report of a stega payload found somewhere it will always cause a bug or unnecessary bloat.
+ * Reports are produced when the `onSuspiciousStega` callback is provided to Visual Editing.
+ * @public
+ */
+export interface SuspiciousStegaReport {
+  /**
+   * Where the stega payload was found:
+   * - `attribute` — in an element attribute where stega always causes problems, such as `class`
+   *   (selectors no longer match), `id` (broken anchors and `getElementById`), `href`/`src` and
+   *   other URL attributes (the invisible characters end up percent-encoded in requests),
+   *   `style`, `name`, `value` or `data-*` attributes (broken equality checks).
+   * - `head` — anywhere inside `<head>`, e.g. `<title>` or `meta[content]`. Content in `<head>`
+   *   is never rendered, so the payload is pure bloat and corrupts SEO/social metadata.
+   * - `script` — inside a `<script>` element, e.g. JSON-LD or embedded state.
+   * - `style` — inside a `<style>` element, breaking selectors or values.
+   * - `form-value` — in a form field value (e.g. `<textarea>` content), where it would be
+   *   submitted along with user input.
+   * - `url` — in the page URL itself, meaning the page was reached through a link that had
+   *   stega encoded into it.
+   */
+  kind: 'attribute' | 'head' | 'script' | 'style' | 'form-value' | 'url'
+  /**
+   * The element the stega payload was found on or in. Undefined for `url` reports.
+   */
+  element?: Element
+  /**
+   * The name of the attribute containing the stega payload, if it was found in an attribute.
+   */
+  attribute?: string
+  /**
+   * The raw value containing the stega payload.
+   */
+  value: string
+  /**
+   * The value with the stega payload stripped — what the value should have been. Apply
+   * `stegaClean` from `@sanity/client/stega` to the source value to fix the issue.
+   */
+  cleaned: string
+  /**
+   * The decoded edit info, if the payload could be decoded. Points to the document and field
+   * that produced the value.
+   */
+  sanity?: SanityNode | SanityStegaNode
+}
+
+/**
  * @public
  */
 export interface VisualEditingOptions {
@@ -538,9 +584,26 @@ export interface VisualEditingOptions {
    */
   history?: HistoryAdapter
   /**
+   * While Visual Editing is enabled, stega-encoded metadata (invisible characters) is
+   * automatically stripped from clipboard data when content is copied from the page, so copied
+   * text can be pasted into other tools without the hidden characters tagging along.
+   * Set this option to `true` to opt out and keep stega in copied content.
+   */
+  keepStegaOnCopy?: boolean
+  /**
    * This event can be used to make sure server side data fetching uses the same client perspective as the Sanity Studio that is driving the visual editing.
    */
   onPerspectiveChange?: (perspective: ClientPerspective) => void
+  /**
+   * Reports stega payloads found in places where they always cause bugs or bloat, such as
+   * `class`, `href`, `src`, `id` and other attributes, inside `<head>` (e.g. `<title>`),
+   * `<script>` or `<style>` contents, form values, or the page URL.
+   * Providing the callback opts in to the detection logic — when it isn't provided no scanning
+   * runs. Reports are deduped and batched, and include the decoded edit info when available so
+   * the source field can be tracked down and cleaned with `stegaClean` from
+   * `@sanity/client/stega`.
+   */
+  onSuspiciousStega?: (reports: SuspiciousStegaReport[]) => void
   /**
    * The refresh API allows smarter refresh logic than the default `location.reload()` behavior.
    */

--- a/packages/visual-editing/src/ui/VisualEditing.tsx
+++ b/packages/visual-editing/src/ui/VisualEditing.tsx
@@ -5,12 +5,15 @@ import {
   Suspense,
   useDeferredValue,
   useEffect,
+  useEffectEvent,
   useState,
   useSyncExternalStore,
 } from 'react'
 import {createPortal} from 'react-dom'
 
-import type {VisualEditingOptions} from '../types'
+import type {SuspiciousStegaReport, VisualEditingOptions} from '../types'
+import {enableStegaCleanOnCopy} from '../util/stegaCleanOnCopy'
+import {observeSuspiciousStega} from '../util/suspiciousStega'
 import {setEnvironment} from './environment/context'
 import {History} from './History'
 import {getQueryListenerStatus, subscribeQueryListenerStatus} from './loader-comlink/context'
@@ -26,7 +29,17 @@ const LoaderComlink = lazy(() => import('./LoaderComlink'))
  * @public
  */
 export const VisualEditing = (props: VisualEditingOptions & {portal: boolean}): React.ReactNode => {
-  const {components, plugins, history, portal = true, refresh, zIndex, onPerspectiveChange} = props
+  const {
+    components,
+    plugins,
+    history,
+    keepStegaOnCopy,
+    portal = true,
+    refresh,
+    zIndex,
+    onPerspectiveChange,
+    onSuspiciousStega,
+  } = props
 
   const [inFrame, setInFrame] = useState<boolean | null>(null)
   const [inPopUp, setInPopUp] = useState<boolean | null>(null)
@@ -36,6 +49,20 @@ export const VisualEditing = (props: VisualEditingOptions & {portal: boolean}): 
       setInPopUp(isMaybePreviewWindow())
     })
   }, [])
+
+  useEffect(() => {
+    if (keepStegaOnCopy) return undefined
+    return enableStegaCleanOnCopy()
+  }, [keepStegaOnCopy])
+
+  const handleSuspiciousStega = useEffectEvent((reports: SuspiciousStegaReport[]) =>
+    onSuspiciousStega?.(reports),
+  )
+  const hasSuspiciousStegaCallback = typeof onSuspiciousStega === 'function'
+  useEffect(() => {
+    if (!hasSuspiciousStegaCallback) return undefined
+    return observeSuspiciousStega(handleSuspiciousStega)
+  }, [hasSuspiciousStegaCallback])
 
   const [portalElement, setPortalElement] = useState<HTMLElement | null>(null)
   useEffect(() => {

--- a/packages/visual-editing/src/ui/renderVisualEditing.tsx
+++ b/packages/visual-editing/src/ui/renderVisualEditing.tsx
@@ -15,7 +15,16 @@ let cleanup: ReturnType<typeof setTimeout> | null = null
 
 export function renderVisualEditing(
   signal: AbortSignal,
-  {components, history, refresh, zIndex, plugins, onPerspectiveChange}: VisualEditingOptions,
+  {
+    components,
+    history,
+    keepStegaOnCopy,
+    refresh,
+    zIndex,
+    plugins,
+    onPerspectiveChange,
+    onSuspiciousStega,
+  }: VisualEditingOptions,
 ): void {
   // Cancel pending cleanups, this is useful to avoid overlays blinking as the parent app transition between URLs, or hot module reload is happening
   if (cleanup) clearTimeout(cleanup)
@@ -51,9 +60,11 @@ export function renderVisualEditing(
         components={components}
         plugins={plugins}
         history={history}
+        keepStegaOnCopy={keepStegaOnCopy}
         refresh={refresh}
         zIndex={zIndex}
         onPerspectiveChange={onPerspectiveChange}
+        onSuspiciousStega={onSuspiciousStega}
         // Disabling the portal, as this function is already making sure the overlays render in the right spot
         portal={false}
       />

--- a/packages/visual-editing/src/util/__tests__/stega.test.ts
+++ b/packages/visual-editing/src/util/__tests__/stega.test.ts
@@ -1,7 +1,7 @@
 import {vercelStegaCombine} from '@vercel/stega'
 import {expect, test} from 'vitest'
 
-import {testAndDecodeStega} from '../stega'
+import {stegaClean, testAndDecodeStega} from '../stega'
 
 test('it handles trailing zero-width space characters', () => {
   const payload = 'foo.\u200b'
@@ -12,4 +12,14 @@ test('it handles trailing zero-width space characters', () => {
   expect(decoded).not.toEqual(null)
   expect(decoded!.origin).toEqual('sanity.io')
   expect(decoded!.href).toEqual('/studio')
+})
+
+test('stegaClean strips all stega payloads from a string', () => {
+  const editInfo = {origin: 'sanity.io', href: '/studio'}
+  const encoded = `${vercelStegaCombine('foo', editInfo, false)} and ${vercelStegaCombine('bar', editInfo, false)}`
+  expect(encoded).not.toEqual('foo and bar')
+  expect(stegaClean(encoded)).toEqual('foo and bar')
+  // Consecutive runs behave consistently even though the regex is stateful
+  expect(stegaClean(encoded)).toEqual('foo and bar')
+  expect(stegaClean('no stega')).toEqual('no stega')
 })

--- a/packages/visual-editing/src/util/__tests__/stegaCleanOnCopy.test.ts
+++ b/packages/visual-editing/src/util/__tests__/stegaCleanOnCopy.test.ts
@@ -1,0 +1,149 @@
+import {vercelStegaCombine} from '@vercel/stega'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {cleanStegaFromCopyEvent, enableStegaCleanOnCopy} from '../stegaCleanOnCopy'
+
+const editInfo = {origin: 'sanity.io', href: '/studio'}
+const encode = (value: string) => vercelStegaCombine(value, editInfo, false)
+
+function createClipboardEvent(defaultPrevented = false) {
+  const data = new Map<string, string>()
+  const event = {
+    defaultPrevented,
+    preventDefault: vi.fn(),
+    clipboardData: {
+      setData: (type: string, value: string) => {
+        data.set(type, value)
+      },
+    },
+  }
+  return {event: event as unknown as ClipboardEvent, preventDefault: event.preventDefault, data}
+}
+
+function stubSelection({text, html}: {text: string; html?: string}) {
+  const fragment = document.createDocumentFragment()
+  if (html !== undefined) {
+    const template = document.createElement('template')
+    template.innerHTML = html
+    fragment.appendChild(template.content)
+  } else {
+    fragment.appendChild(document.createTextNode(text))
+  }
+  const selection = {
+    isCollapsed: false,
+    rangeCount: 1,
+    toString: () => text,
+    getRangeAt: () => ({cloneContents: () => fragment}),
+  }
+  return vi.spyOn(document, 'getSelection').mockReturnValue(selection as unknown as Selection)
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  document.body.innerHTML = ''
+})
+
+describe('cleanStegaFromCopyEvent', () => {
+  test('strips stega from both clipboard flavors when the selection contains stega', () => {
+    const encoded = encode('Hello world')
+    stubSelection({text: encoded, html: `<p>${encoded}</p>`})
+    const {event, preventDefault, data} = createClipboardEvent()
+
+    cleanStegaFromCopyEvent(event)
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(data.get('text/plain')).toBe('Hello world')
+    expect(data.get('text/html')).toBe('<p>Hello world</p>')
+  })
+
+  test('strips stega hidden in attributes of the HTML flavor', () => {
+    const alt = encode('A nice photo')
+    stubSelection({text: 'Some caption', html: `<img alt="${alt}"><span>Some caption</span>`})
+    const {event, preventDefault, data} = createClipboardEvent()
+
+    cleanStegaFromCopyEvent(event)
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(data.get('text/plain')).toBe('Some caption')
+    expect(data.get('text/html')).toBe('<img alt="A nice photo"><span>Some caption</span>')
+  })
+
+  test('leaves the event untouched when the selection has no stega', () => {
+    stubSelection({text: 'Plain text', html: '<p>Plain text</p>'})
+    const {event, preventDefault, data} = createClipboardEvent()
+
+    cleanStegaFromCopyEvent(event)
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(data.size).toBe(0)
+  })
+
+  test('leaves the event untouched when default is already prevented', () => {
+    stubSelection({text: encode('Hello world')})
+    const {event, preventDefault, data} = createClipboardEvent(true)
+
+    cleanStegaFromCopyEvent(event)
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(data.size).toBe(0)
+  })
+
+  test('leaves the event untouched when the selection is collapsed', () => {
+    vi.spyOn(document, 'getSelection').mockReturnValue({
+      isCollapsed: true,
+      rangeCount: 0,
+    } as unknown as Selection)
+    const {event, preventDefault, data} = createClipboardEvent()
+
+    cleanStegaFromCopyEvent(event)
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(data.size).toBe(0)
+  })
+
+  test('strips stega from text selected inside an input', () => {
+    const encoded = encode('user@example.com')
+    const input = document.createElement('input')
+    input.value = encoded
+    document.body.appendChild(input)
+    input.focus()
+    input.selectionStart = 0
+    input.selectionEnd = encoded.length
+    expect(document.activeElement).toBe(input)
+
+    const {event, preventDefault, data} = createClipboardEvent()
+    cleanStegaFromCopyEvent(event)
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(data.get('text/plain')).toBe('user@example.com')
+    expect(data.has('text/html')).toBe(false)
+  })
+
+  test('leaves the event untouched when the input selection has no stega', () => {
+    const input = document.createElement('input')
+    input.value = 'user@example.com'
+    document.body.appendChild(input)
+    input.focus()
+    input.selectionStart = 0
+    input.selectionEnd = input.value.length
+
+    const {event, preventDefault, data} = createClipboardEvent()
+    cleanStegaFromCopyEvent(event)
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(data.size).toBe(0)
+  })
+})
+
+describe('enableStegaCleanOnCopy', () => {
+  test('registers a copy listener and removes it on dispose', () => {
+    const addEventListener = vi.spyOn(document, 'addEventListener')
+    const removeEventListener = vi.spyOn(document, 'removeEventListener')
+
+    const dispose = enableStegaCleanOnCopy()
+    expect(addEventListener).toHaveBeenCalledWith('copy', cleanStegaFromCopyEvent)
+
+    dispose()
+    expect(removeEventListener).toHaveBeenCalledWith('copy', cleanStegaFromCopyEvent)
+  })
+})

--- a/packages/visual-editing/src/util/__tests__/suspiciousStega.test.ts
+++ b/packages/visual-editing/src/util/__tests__/suspiciousStega.test.ts
@@ -1,0 +1,196 @@
+import {vercelStegaCombine} from '@vercel/stega'
+import {afterEach, expect, test, vi, type Mock} from 'vitest'
+
+import type {SuspiciousStegaReport} from '../../types'
+import {observeSuspiciousStega} from '../suspiciousStega'
+
+const editInfo = {origin: 'sanity.io', href: '/studio'}
+const encode = (value: string) => vercelStegaCombine(value, editInfo, false)
+
+let dispose: (() => void) | undefined
+
+afterEach(() => {
+  dispose?.()
+  dispose = undefined
+  document.head.innerHTML = ''
+  document.body.innerHTML = ''
+})
+
+function getReports(callback: Mock): SuspiciousStegaReport[] {
+  return callback.mock.calls.flatMap((call) => call[0] as SuspiciousStegaReport[])
+}
+
+async function waitForReports(callback: Mock): Promise<SuspiciousStegaReport[]> {
+  await vi.waitFor(() => expect(callback).toHaveBeenCalled())
+  return getReports(callback)
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 100))
+
+test('the initial audit reports stega in unsafe places and skips expected places', async () => {
+  const link = document.createElement('a')
+  link.setAttribute('class', encode('btn'))
+  link.setAttribute('href', `/products/${encode('slug')}`)
+  link.textContent = encode('Buy now')
+  document.body.appendChild(link)
+
+  const img = document.createElement('img')
+  img.setAttribute('alt', encode('A photo'))
+  document.body.appendChild(img)
+
+  const time = document.createElement('time')
+  time.setAttribute('datetime', encode('2026-01-01'))
+  document.body.appendChild(time)
+
+  const textarea = document.createElement('textarea')
+  textarea.textContent = encode('A message')
+  document.body.appendChild(textarea)
+
+  const script = document.createElement('script')
+  script.setAttribute('type', 'application/ld+json')
+  script.textContent = JSON.stringify({headline: encode('Headline')})
+  document.body.appendChild(script)
+
+  const title = document.createElement('title')
+  title.textContent = encode('Page title')
+  document.head.appendChild(title)
+
+  const meta = document.createElement('meta')
+  meta.setAttribute('content', encode('Description'))
+  document.head.appendChild(meta)
+
+  const callback = vi.fn()
+  dispose = observeSuspiciousStega(callback)
+  const reports = await waitForReports(callback)
+
+  const classReport = reports.find((report) => report.attribute === 'class')
+  expect(classReport).toMatchObject({
+    kind: 'attribute',
+    element: link,
+    cleaned: 'btn',
+  })
+  expect(classReport?.sanity).toEqual(editInfo)
+
+  expect(reports.find((report) => report.attribute === 'href')).toMatchObject({
+    kind: 'attribute',
+    element: link,
+    cleaned: '/products/slug',
+  })
+  expect(reports.find((report) => report.element === title)).toMatchObject({kind: 'head'})
+  expect(reports.find((report) => report.attribute === 'content')).toMatchObject({
+    kind: 'head',
+    element: meta,
+  })
+  expect(reports.find((report) => report.element === script)).toMatchObject({kind: 'script'})
+  expect(reports.find((report) => report.element === textarea)).toMatchObject({
+    kind: 'form-value',
+    cleaned: 'A message',
+  })
+
+  // Expected stega placements are not reported
+  expect(reports.find((report) => report.attribute === 'alt')).toBeUndefined()
+  expect(reports.find((report) => report.attribute === 'datetime')).toBeUndefined()
+  // Neither is stega in rendered text
+  expect(reports.find((report) => report.cleaned === 'Buy now')).toBeUndefined()
+})
+
+test('reports stega in nodes added after the initial audit', async () => {
+  const callback = vi.fn()
+  dispose = observeSuspiciousStega(callback)
+  await flush()
+  callback.mockClear()
+
+  const div = document.createElement('div')
+  div.setAttribute('id', encode('section-1'))
+  document.body.appendChild(div)
+
+  const reports = await waitForReports(callback)
+  expect(reports).toHaveLength(1)
+  expect(reports[0]).toMatchObject({
+    kind: 'attribute',
+    element: div,
+    attribute: 'id',
+    cleaned: 'section-1',
+  })
+})
+
+test('reports stega in changed attributes and text', async () => {
+  const div = document.createElement('div')
+  document.body.appendChild(div)
+  const style = document.createElement('style')
+  style.textContent = '.a{color:red}'
+  document.body.appendChild(style)
+
+  const callback = vi.fn()
+  dispose = observeSuspiciousStega(callback)
+  await flush()
+  callback.mockClear()
+
+  div.setAttribute('data-key', encode('key-1'))
+  style.firstChild!.textContent = `.${encode('a')}{color:red}`
+
+  const reports = await waitForReports(callback)
+  expect(reports.find((report) => report.attribute === 'data-key')).toMatchObject({
+    kind: 'attribute',
+    element: div,
+    cleaned: 'key-1',
+  })
+  expect(reports.find((report) => report.element === style)).toMatchObject({
+    kind: 'style',
+    cleaned: '.a{color:red}',
+  })
+})
+
+test('dedupes repeated findings', async () => {
+  const first = document.createElement('div')
+  first.setAttribute('class', encode('card'))
+  document.body.appendChild(first)
+  const second = document.createElement('div')
+  second.setAttribute('class', encode('card'))
+  document.body.appendChild(second)
+
+  const callback = vi.fn()
+  dispose = observeSuspiciousStega(callback)
+  const reports = await waitForReports(callback)
+  expect(reports.filter((report) => report.attribute === 'class')).toHaveLength(1)
+  callback.mockClear()
+
+  // Re-applying the same value doesn't produce a new report
+  first.setAttribute('class', encode('card'))
+  await flush()
+  expect(getReports(callback).filter((report) => report.attribute === 'class')).toHaveLength(0)
+})
+
+test('ignores stega inside the visual editing overlay', async () => {
+  const overlay = document.createElement('sanity-visual-editing')
+  const label = document.createElement('span')
+  label.setAttribute('data-preview', encode('Preview'))
+  overlay.appendChild(label)
+  document.body.appendChild(overlay)
+
+  const callback = vi.fn()
+  dispose = observeSuspiciousStega(callback)
+  await flush()
+  expect(getReports(callback)).toHaveLength(0)
+
+  // Also when added after the initial audit
+  const anotherLabel = document.createElement('span')
+  anotherLabel.setAttribute('data-preview', encode('Another preview'))
+  overlay.appendChild(anotherLabel)
+  await flush()
+  expect(getReports(callback)).toHaveLength(0)
+})
+
+test('stops reporting once disposed', async () => {
+  const callback = vi.fn()
+  const stop = observeSuspiciousStega(callback)
+  await flush()
+  callback.mockClear()
+  stop()
+
+  const div = document.createElement('div')
+  div.setAttribute('id', encode('section-1'))
+  document.body.appendChild(div)
+  await flush()
+  expect(callback).not.toHaveBeenCalled()
+})

--- a/packages/visual-editing/src/util/stega.ts
+++ b/packages/visual-editing/src/util/stega.ts
@@ -12,6 +12,15 @@ export function testVercelStegaRegex(input: string): boolean {
   return VERCEL_STEGA_REGEX.test(input)
 }
 
+/**
+ * Strips all stega-encoded metadata (sequences of invisible characters) from a string
+ * @param input
+ */
+export function stegaClean(input: string): string {
+  VERCEL_STEGA_REGEX.lastIndex = 0
+  return input.replace(VERCEL_STEGA_REGEX, '')
+}
+
 function decodeStega(str: string, isAltText = false): SanityStegaNode | null {
   try {
     const decoded = vercelStegaDecode<SanityStegaNode>(str)

--- a/packages/visual-editing/src/util/stegaCleanOnCopy.ts
+++ b/packages/visual-editing/src/util/stegaCleanOnCopy.ts
@@ -1,8 +1,6 @@
 import {stegaClean, testVercelStegaRegex} from './stega'
 
-function isTextField(
-  element: Element | null,
-): element is HTMLInputElement | HTMLTextAreaElement {
+function isTextField(element: Element | null): element is HTMLInputElement | HTMLTextAreaElement {
   return element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement
 }
 

--- a/packages/visual-editing/src/util/stegaCleanOnCopy.ts
+++ b/packages/visual-editing/src/util/stegaCleanOnCopy.ts
@@ -1,0 +1,82 @@
+import {stegaClean, testVercelStegaRegex} from './stega'
+
+function isTextField(
+  element: Element | null,
+): element is HTMLInputElement | HTMLTextAreaElement {
+  return element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement
+}
+
+function getTextFieldSelection(element: HTMLInputElement | HTMLTextAreaElement): string | null {
+  try {
+    const {selectionStart, selectionEnd, value} = element
+    if (selectionStart === null || selectionEnd === null || selectionStart === selectionEnd) {
+      return null
+    }
+    return value.slice(selectionStart, selectionEnd)
+  } catch {
+    // Reading `selectionStart` throws for input types that don't support selection (e.g. `type="number"`) in some browsers
+    return null
+  }
+}
+
+function serializeRangesToHtml(selection: Selection): string {
+  let html = ''
+  for (let i = 0; i < selection.rangeCount; i++) {
+    const container = document.createElement('div')
+    container.appendChild(selection.getRangeAt(i).cloneContents())
+    html += container.innerHTML
+  }
+  return html
+}
+
+/**
+ * Handles a `copy` event by rewriting the clipboard payload without stega-encoded metadata.
+ * If the copied content doesn't contain any stega characters the event is left untouched and
+ * the default browser behavior applies.
+ * @internal
+ */
+export function cleanStegaFromCopyEvent(event: ClipboardEvent): void {
+  // Defer to userland `copy` handlers that have taken over the event
+  if (event.defaultPrevented) return
+  const {clipboardData} = event
+  if (!clipboardData) return
+
+  // Copying from an input or textarea uses the field's own selection, and only has a plain text flavor
+  const activeElement = document.activeElement
+  if (isTextField(activeElement)) {
+    const text = getTextFieldSelection(activeElement)
+    if (!text || !testVercelStegaRegex(text)) return
+    event.preventDefault()
+    clipboardData.setData('text/plain', stegaClean(text))
+    return
+  }
+
+  const selection = document.getSelection()
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) return
+
+  const text = selection.toString()
+  // The HTML flavor is serialized too, both to keep rich text pastes clean and because it can
+  // contain stega payloads the plain text flavor doesn't (e.g. in `alt` attributes)
+  const html = serializeRangesToHtml(selection)
+  if (!testVercelStegaRegex(text) && !testVercelStegaRegex(html)) return
+
+  event.preventDefault()
+  clipboardData.setData('text/plain', stegaClean(text))
+  if (html) {
+    clipboardData.setData('text/html', stegaClean(html))
+  }
+}
+
+/**
+ * Strips stega-encoded metadata (invisible characters) from clipboard data when content is
+ * copied from the page, so copied text can be pasted into other tools without the hidden
+ * characters tagging along. Copies that don't contain stega are left untouched.
+ * @returns A function that disables the behavior again
+ * @internal
+ */
+export function enableStegaCleanOnCopy(): () => void {
+  document.addEventListener('copy', cleanStegaFromCopyEvent)
+  return () => {
+    document.removeEventListener('copy', cleanStegaFromCopyEvent)
+  }
+}

--- a/packages/visual-editing/src/util/suspiciousStega.ts
+++ b/packages/visual-editing/src/util/suspiciousStega.ts
@@ -1,0 +1,269 @@
+import {decodeSanityNodeData} from '@sanity/visual-editing-csm'
+import {vercelStegaDecode} from '@vercel/stega'
+
+import type {SanityNode, SanityStegaNode, SuspiciousStegaReport} from '../types'
+import {stegaClean, testVercelStegaRegex} from './stega'
+
+const OVERLAY_TAG = 'SANITY-VISUAL-EDITING'
+
+/**
+ * Attributes where stega payloads are expected and supported by the overlay element discovery
+ * in `findSanityNodes`, keyed by (uppercase) tag name. Stega anywhere else in an attribute is
+ * always a bug.
+ */
+const EXPECTED_STEGA_ATTRIBUTES: Record<string, string[] | undefined> = {
+  IMG: ['alt'],
+  TIME: ['datetime'],
+  SVG: ['aria-label'],
+}
+
+type ReportSink = (
+  kind: SuspiciousStegaReport['kind'],
+  element: Element | undefined,
+  attribute: string | undefined,
+  value: string,
+) => void
+
+function isElement(node: Node): node is Element {
+  return node.nodeType === Node.ELEMENT_NODE
+}
+
+function isOverlayElement(node: Node): boolean {
+  return isElement(node) && node.tagName.toUpperCase() === OVERLAY_TAG
+}
+
+function isInsideOverlay(node: Node): boolean {
+  const element = isElement(node) ? node : node.parentElement
+  return element ? element.closest('sanity-visual-editing') !== null : false
+}
+
+function isInsideHead(node: Node): boolean {
+  return document.head ? document.head.contains(node) : false
+}
+
+function isExpectedStegaAttribute(element: Element, attributeName: string): boolean {
+  return (
+    EXPECTED_STEGA_ATTRIBUTES[element.tagName.toUpperCase()]?.includes(
+      attributeName.toLowerCase(),
+    ) ?? false
+  )
+}
+
+function checkAttribute(
+  element: Element,
+  attributeName: string,
+  value: string | null,
+  inHead: boolean,
+  sink: ReportSink,
+): void {
+  if (!value || !testVercelStegaRegex(value)) return
+  if (inHead) {
+    sink('head', element, attributeName, value)
+    return
+  }
+  if (isExpectedStegaAttribute(element, attributeName)) return
+  sink('attribute', element, attributeName, value)
+}
+
+function checkElementAttributes(element: Element, inHead: boolean, sink: ReportSink): void {
+  const {attributes} = element
+  for (let i = 0; i < attributes.length; i++) {
+    const attribute = attributes[i]
+    if (!attribute) continue
+    checkAttribute(element, attribute.name, attribute.value, inHead, sink)
+  }
+}
+
+function checkTextNode(node: Node, inHead: boolean, sink: ReportSink): void {
+  const parentElement = node.parentElement
+  let kind: SuspiciousStegaReport['kind']
+  if (inHead) {
+    kind = 'head'
+  } else {
+    // Outside of `<head>`, text nodes are only suspicious in containers where they are never
+    // rendered or where they act as a form value. Stega in rendered text is expected — it's
+    // how visual editing locates editable content
+    switch (parentElement?.tagName.toUpperCase()) {
+      case 'SCRIPT':
+        kind = 'script'
+        break
+      case 'STYLE':
+        kind = 'style'
+        break
+      case 'TEXTAREA':
+        kind = 'form-value'
+        break
+      default:
+        return
+    }
+  }
+  const value = node.textContent
+  if (!value || !testVercelStegaRegex(value)) return
+  sink(kind, parentElement ?? undefined, undefined, value)
+}
+
+function visitNode(node: Node, inHead: boolean, sink: ReportSink): void {
+  if (isElement(node)) {
+    if (isOverlayElement(node)) return
+    checkElementAttributes(node, inHead, sink)
+  } else if (node.nodeType === Node.TEXT_NODE) {
+    checkTextNode(node, inHead, sink)
+  }
+}
+
+function auditTree(root: Node, inHead: boolean, sink: ReportSink): void {
+  visitNode(root, inHead, sink)
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, {
+    acceptNode: (node) =>
+      isOverlayElement(node) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT,
+  })
+  let node: Node | null
+  while ((node = walker.nextNode())) {
+    visitNode(node, inHead, sink)
+  }
+}
+
+function checkLocation(sink: ReportSink): void {
+  const href = location.href
+  if (testVercelStegaRegex(href)) {
+    sink('url', undefined, undefined, href)
+    return
+  }
+  // Stega characters in URLs usually end up percent-encoded, so also test the decoded URL
+  try {
+    const decoded = decodeURIComponent(href)
+    if (testVercelStegaRegex(decoded)) {
+      sink('url', undefined, undefined, decoded)
+    }
+  } catch {
+    // `decodeURIComponent` throws on malformed sequences — nothing to report then
+  }
+}
+
+function auditDocument(sink: ReportSink): void {
+  const {documentElement, head, body} = document
+  if (documentElement) {
+    checkElementAttributes(documentElement, false, sink)
+  }
+  if (head) {
+    auditTree(head, true, sink)
+  }
+  if (body) {
+    auditTree(body, false, sink)
+  }
+  checkLocation(sink)
+}
+
+function processMutation(mutation: MutationRecord, sink: ReportSink): void {
+  const {target, type} = mutation
+  if (!target.isConnected || isInsideOverlay(target)) return
+
+  if (type === 'attributes') {
+    if (isElement(target) && mutation.attributeName) {
+      const value = target.getAttributeNS(mutation.attributeNamespace, mutation.attributeName)
+      checkAttribute(target, mutation.attributeName, value, isInsideHead(target), sink)
+    }
+  } else if (type === 'characterData') {
+    checkTextNode(target, isInsideHead(target), sink)
+  } else {
+    for (let i = 0; i < mutation.addedNodes.length; i++) {
+      const added = mutation.addedNodes[i]
+      if (!added || !added.isConnected || isInsideOverlay(added)) continue
+      auditTree(added, isInsideHead(added), sink)
+    }
+  }
+}
+
+function decodeSanity(value: string): SanityNode | SanityStegaNode | undefined {
+  try {
+    const decoded = vercelStegaDecode<SanityStegaNode>(value)
+    if (!decoded || typeof decoded !== 'object' || decoded.origin !== 'sanity.io') {
+      return undefined
+    }
+    return decodeSanityNodeData(decoded) ?? decoded
+  } catch {
+    return undefined
+  }
+}
+
+function scheduleIdle(callback: () => void): () => void {
+  if (typeof requestIdleCallback === 'function') {
+    const id = requestIdleCallback(callback, {timeout: 1000})
+    return () => cancelIdleCallback(id)
+  }
+  const id = setTimeout(callback, 0)
+  return () => clearTimeout(id)
+}
+
+/**
+ * Scans the document for stega payloads in places where they always cause bugs or bloat
+ * (attributes, `<head>`, `<script>` and `<style>` contents, form values and the page URL) and
+ * reports findings to the given callback.
+ *
+ * Performs an initial full audit and then watches for DOM changes, only re-checking what
+ * actually changed. All work is deferred to idle time, reports are deduped and batched.
+ * @returns A function that stops the scanning
+ * @internal
+ */
+export function observeSuspiciousStega(
+  onSuspiciousStega: (reports: SuspiciousStegaReport[]) => void,
+): () => void {
+  const reported = new Set<string>()
+  const pendingReports: SuspiciousStegaReport[] = []
+  const pendingMutations: MutationRecord[] = []
+  let initialAuditDone = false
+  let cancelScheduled: (() => void) | null = null
+  let disposed = false
+
+  const sink: ReportSink = (kind, element, attribute, value) => {
+    const cleaned = stegaClean(value)
+    const key = `${kind}|${attribute ?? ''}|${cleaned}`
+    if (reported.has(key)) return
+    reported.add(key)
+    pendingReports.push({kind, element, attribute, value, cleaned, sanity: decodeSanity(value)})
+  }
+
+  const process = () => {
+    cancelScheduled = null
+    if (disposed) return
+    if (!initialAuditDone) {
+      initialAuditDone = true
+      auditDocument(sink)
+    }
+    if (pendingMutations.length > 0) {
+      const mutations = pendingMutations.splice(0)
+      for (const mutation of mutations) {
+        processMutation(mutation, sink)
+      }
+    }
+    if (pendingReports.length > 0) {
+      onSuspiciousStega(pendingReports.splice(0))
+    }
+  }
+
+  const schedule = () => {
+    if (cancelScheduled || disposed) return
+    cancelScheduled = scheduleIdle(process)
+  }
+
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      pendingMutations.push(mutation)
+    }
+    schedule()
+  })
+  observer.observe(document.documentElement, {
+    attributes: true,
+    characterData: true,
+    childList: true,
+    subtree: true,
+  })
+  schedule()
+
+  return () => {
+    disposed = true
+    observer.disconnect()
+    cancelScheduled?.()
+    cancelScheduled = null
+  }
+}

--- a/packages/visual-editing/svelte/VisualEditing.svelte
+++ b/packages/visual-editing/svelte/VisualEditing.svelte
@@ -10,6 +10,19 @@
    * You can call the refreshDefault argument to trigger the default refresh behavior so you don't have to reimplement it.
    */
   export let refresh: VisualEditingProps['refresh'] = undefined
+  /**
+   * While Visual Editing is enabled, stega-encoded metadata (invisible characters) is
+   * automatically stripped from clipboard data when content is copied from the page.
+   * Set this prop to `true` to opt out and keep stega in copied content.
+   */
+  export let keepStegaOnCopy: VisualEditingProps['keepStegaOnCopy'] = undefined
+  /**
+   * Reports stega payloads found in places where they always cause bugs or bloat, such as
+   * `class`, `href`, `src` and other attributes, inside `<head>`, `<script>` or `<style>`
+   * contents, form values, or the page URL. Providing the callback opts in to the detection
+   * logic — when it isn't provided no scanning runs.
+   */
+  export let onSuspiciousStega: VisualEditingProps['onSuspiciousStega'] = undefined
 
   let navigate: HistoryAdapterNavigate | undefined
   let navigatingFromUpdate = false
@@ -17,6 +30,10 @@
   onMount(() =>
     enableVisualEditing({
       zIndex,
+      keepStegaOnCopy,
+      onSuspiciousStega: onSuspiciousStega
+        ? (reports) => onSuspiciousStega?.(reports)
+        : undefined,
       refresh: (payload) => {
         function refreshDefault() {
           if (payload.source === 'mutation' && payload.livePreviewEnabled) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Part of SAPP-3204 (strip stega from paste into plain text fields). This is the app/preview side of the equation — a follow-up PR in `sanity-io/sanity` will handle paste handlers in the Studio itself, so the ticket stays open after this merges.

#### Strip stega from the clipboard on copy (default on)

Content on a preview page contains stega-encoded metadata (invisible characters), which tags along when people copy text and paste it into other tools — plain text fields, URLs, spreadsheets, etc.

While Visual Editing is enabled, `copy` events are now intercepted and stega is stripped from the clipboard:

- Both the `text/plain` and `text/html` flavors are cleaned, so rich-text pastes stay clean too, and stega hidden in attributes of the copied markup (e.g. `img[alt]`) is also removed.
- Selections inside `<input>`/`<textarea>` fields are handled via the field's own selection.
- Copies that don't contain any stega are left completely untouched (the regex pre-test is cheap), and userland `copy` handlers that call `event.preventDefault()` take precedence.
- `cut` events are deliberately not intercepted, since `preventDefault()` on cut would require reimplementing content deletion.

Opt out with the new `keepStegaOnCopy` option/prop:

```tsx
<VisualEditing keepStegaOnCopy />
```

#### Opt-in `onSuspiciousStega` reporting

New callback that reports stega payloads found in places where they always cause a bug or bloat. If the callback isn't provided, no scanning runs at all.

```tsx
<VisualEditing
  onSuspiciousStega={(reports) => {
    for (const report of reports) console.warn(`Stega found in ${report.kind}`, report)
  }}
/>
```

Reported placements (`report.kind`):

| `kind` | What it means |
| --- | --- |
| `attribute` | Any attribute except the expected stega carriers (`img[alt]`, `time[datetime]`, `svg[aria-label]`): `class` (selectors no longer match), `id` (broken anchors/`getElementById`), `href`/`src`/`srcset`/`action` and other URL attributes (invisible characters end up percent-encoded in requests), `style`, `name`, `value`, `data-*` (broken equality checks), etc. |
| `head` | Anywhere inside `<head>` (text or attributes), e.g. `data.title` rendered in `<title>`, `meta[content]`, JSON-LD — never rendered, pure bloat, corrupts SEO/social metadata |
| `script` | Text content of `<script>` in body (JSON-LD, embedded state) |
| `style` | Text content of `<style>` |
| `form-value` | `<textarea>` content that would be submitted along with user input |
| `url` | The page URL itself (tested raw and percent-decoded), meaning the page was reached through a link with stega baked in |

Each report includes the offending `element`, `attribute` name (when applicable), the raw `value`, the `cleaned` value it should have been, and the decoded `sanity` edit info when available — pointing at the exact document/field that produced the value.

Efficiency: an initial full audit (TreeWalker over `head` + `body` + `<html>` attributes) and a dedicated `MutationObserver` that only re-tests what changed (a single attribute for attribute mutations, only unsafe-context text nodes for text mutations, added subtrees for childList). All work is deferred to `requestIdleCallback` (with `setTimeout` fallback), reports are deduped by `kind + attribute + cleaned value` and batched per flush. Body text nodes outside `<script>`/`<style>`/`<textarea>` are never tested — stega in rendered text is the feature, not a bug. Everything inside `<sanity-visual-editing>` is ignored.

#### Wiring

Both options are added to `VisualEditingOptions` and forwarded through all variants: `enableVisualEditing`, the React `<VisualEditing />` (used by `next-sanity`'s App Router component via its dependency on this package), `next-pages-router`, `react-router` and the Svelte component. Callbacks are routed through `useEffectEvent` so unstable identities don't re-initialize visual editing or re-run the audit.

### What to review

- Naming and JSDoc of `keepStegaOnCopy` / `onSuspiciousStega` / `SuspiciousStegaReport` in `packages/visual-editing/src/types.ts`
- Copy interception logic in `packages/visual-editing/src/util/stegaCleanOnCopy.ts`
- The unsafe-placement map and scanning strategy in `packages/visual-editing/src/util/suspiciousStega.ts`

### Testing

- New Vitest coverage: `stegaCleanOnCopy.test.ts` (8 tests: both clipboard flavors, attribute stega in HTML flavor, input/textarea selections, no-stega/defaultPrevented/collapsed no-ops, listener disposal) and `suspiciousStega.test.ts` (6 tests: initial audit incl. allowlist and rendered-text exclusions, mutation-driven reports for added nodes/changed attributes/changed text, dedupe, overlay exclusion, disposal), plus a `stegaClean` unit test.
- `pnpm --filter @sanity/visual-editing test`, `lint` and `build` (includes `pkg check --strict`) pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d034ff4-cb63-4c03-8e28-da1c50005f33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d034ff4-cb63-4c03-8e28-da1c50005f33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

