### PR TITLE
feat: pass editing variants through preview, loaders, and visual-editing

### DIFF
--- a/.changeset/editing-variants-phase-2.md
+++ b/.changeset/editing-variants-phase-2.md
@@ -1,0 +1,8 @@
+---
+"@sanity/core-loader": minor
+"@sanity/react-loader": minor
+"@sanity/svelte-loader": minor
+"@sanity/visual-editing": minor
+---
+
+Pass editing variants through loaders and visual editing alongside perspective.

--- a/packages/core-loader/package.json
+++ b/packages/core-loader/package.json
@@ -71,9 +71,9 @@
     "test": "vitest --pass-with-no-tests --typecheck"
   },
   "dependencies": {
-    "@sanity/client": "^7.23.2",
+    "@sanity/client": "^7.24.0",
     "@sanity/comlink": "^4.0.1",
-    "@sanity/presentation-comlink": "^2.1.0",
+    "@sanity/presentation-comlink": "^2.2.0",
     "@sanity/visual-editing-csm": "workspace:^"
   },
   "devDependencies": {

--- a/packages/core-loader/src/live-mode/enableLiveMode.ts
+++ b/packages/core-loader/src/live-mode/enableLiveMode.ts
@@ -26,7 +26,7 @@ export interface LazyEnableLiveModeOptions extends EnableLiveModeOptions {
 const LISTEN_HEARTBEAT_INTERVAL = 20_000
 
 export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
-  const {client, setFetcher, onConnect, onDisconnect, onPerspective} = options
+  const {client, setFetcher, onConnect, onDisconnect, onPerspective, onVariant} = options
   if (!client) {
     throw new Error(
       `Expected \`client\` to be an instance of SanityClient: ${JSON.stringify(client)}`,
@@ -37,6 +37,7 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
   const $perspective = atom<Exclude<ClientPerspective, 'raw'>>(
     perspective && perspective !== 'raw' ? perspective : 'drafts',
   )
+  const $variant = atom<string | undefined>(undefined)
   const $connected = atom(false)
 
   const cache = new Map<
@@ -73,6 +74,9 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
       const nextPerspective = data.perspective === 'raw' ? 'drafts' : data.perspective
       $perspective.set(nextPerspective)
       onPerspective?.(nextPerspective)
+      const nextVariant = data.variant || undefined
+      $variant.set(nextVariant)
+      onVariant?.(nextVariant)
       updateLiveQueries()
     }
   })
@@ -80,12 +84,14 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
   comlink.on('loader/query-change', (data) => {
     if (data.projectId === projectId && data.dataset === dataset) {
       const {perspective, query, params} = data
+      const variant = data.variant || undefined
+      const cacheKey = JSON.stringify({perspective, variant, query, params})
       if (
         data.result !== undefined &&
         data.resultSourceMap !== undefined &&
         (client as SanityClient).config().stega.enabled
       ) {
-        cache.set(JSON.stringify({perspective, query, params}), {
+        cache.set(cacheKey, {
           ...data,
           result: stegaEncodeSourceMap(
             data.result,
@@ -94,7 +100,7 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
           ),
         })
       } else {
-        cache.set(JSON.stringify({perspective, query, params}), data)
+        cache.set(cacheKey, data)
       }
 
       updateLiveQueries()
@@ -107,8 +113,10 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
       unsetFetcher = setFetcher({
         hydrate: (query, params, initial) => {
           const perspective = initial?.perspective || $perspective.get()
+          const variant = initial?.variant || $variant.get()
           const key = JSON.stringify({
             perspective,
+            variant,
             query,
             params,
           })
@@ -120,6 +128,7 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
               data: snapshot.result,
               sourceMap: snapshot.resultSourceMap,
               perspective,
+              variant,
             }
           }
 
@@ -131,6 +140,7 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
             data: initial?.data,
             sourceMap: initial?.sourceMap,
             perspective: initial?.perspective || 'published',
+            variant: initial?.variant,
           }
         },
         fetch: <QueryResponseResult, QueryResponseError>(
@@ -194,11 +204,13 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
       throw new Error('No connection')
     }
     const perspective = $perspective.get()
+    const variant = $variant.get()
     for (const {query, params, $fetch} of liveQueries) {
       comlink.post('loader/query-listen', {
         projectId: projectId!,
         dataset: dataset!,
         perspective,
+        variant,
         query,
         params,
         heartbeat: LISTEN_HEARTBEAT_INTERVAL,
@@ -207,14 +219,16 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
         $fetch.setKey('loading', true)
       }
       $fetch.setKey('perspective', perspective)
+      $fetch.setKey('variant', variant)
     }
   }
   function updateLiveQueries() {
     const perspective = $perspective.get()
+    const variant = $variant.get()
     const documentsOnPage: ContentSourceMapDocuments = []
     // Loop over liveQueries and apply cache
     for (const {query, params, $fetch} of liveQueries) {
-      const key = JSON.stringify({perspective, query, params})
+      const key = JSON.stringify({perspective, variant, query, params})
       const value = cache.get(key)
       if (value) {
         $fetch.set({
@@ -222,6 +236,7 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
           error: undefined,
           loading: false,
           perspective,
+          variant,
           sourceMap: value.resultSourceMap,
         })
         documentsOnPage.push(...(value.resultSourceMap?.documents ?? []))
@@ -231,6 +246,7 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
       projectId: projectId!,
       dataset: dataset!,
       perspective,
+      variant,
       documents: documentsOnPage,
     })
   }

--- a/packages/core-loader/src/types.ts
+++ b/packages/core-loader/src/types.ts
@@ -10,6 +10,7 @@ export interface QueryStoreState<QueryResponseResult, QueryResponseError> {
   data?: QueryResponseResult
   sourceMap?: ContentSourceMap
   perspective?: ClientPerspective
+  variant?: string
 }
 
 /**
@@ -52,6 +53,10 @@ export interface EnableLiveModeOptions {
    * Fires when the perspective changes in the Studio, allowing you to persist the change to a session cookie if needed
    */
   onPerspective?: (perspective: Exclude<ClientPerspective, 'raw'>) => void
+  /**
+   * Fires when the variant changes in the Studio, allowing you to persist the change to a session cookie if needed
+   */
+  onVariant?: (variant: string | undefined) => void
 }
 
 /** @public */
@@ -67,7 +72,7 @@ export interface Fetcher {
     params: QueryParams,
     initial?: Pick<
       QueryStoreState<QueryResponseResult, QueryResponseError>,
-      'data' | 'sourceMap' | 'perspective'
+      'data' | 'sourceMap' | 'perspective' | 'variant'
     >,
   ) => QueryStoreState<QueryResponseResult, QueryResponseError>
   fetch: <QueryResponseResult, QueryResponseError>(

--- a/packages/react-loader/package.json
+++ b/packages/react-loader/package.json
@@ -95,7 +95,7 @@
     "test": "vitest --typecheck"
   },
   "dependencies": {
-    "@sanity/client": "^7.23.2",
+    "@sanity/client": "^7.24.0",
     "@sanity/core-loader": "workspace:^",
     "@sanity/visual-editing-csm": "workspace:^"
   },

--- a/packages/react-loader/src/createQueryStore/server-only.ts
+++ b/packages/react-loader/src/createQueryStore/server-only.ts
@@ -24,10 +24,12 @@ export const createQueryStore = (options: CreateQueryStoreOptions): QueryStore =
     data: QueryResponseResult
     sourceMap: ContentSourceMap | undefined
     perspective?: ClientPerspective
+    variant?: string
   }> => {
     const {cache, next, stega, headers, tag} = _options
     const perspective =
       _options.perspective || unstable__serverClient.instance?.config().perspective || 'published'
+    const variant = _options.variant || undefined
     const useCdn = _options.useCdn || unstable__serverClient.instance!.config().useCdn
 
     const previewPerspective =
@@ -45,6 +47,7 @@ export const createQueryStore = (options: CreateQueryStoreOptions): QueryStore =
         filterResponse: false,
         next,
         perspective,
+        variant,
         useCdn: previewPerspective ? false : useCdn,
         stega,
         headers,
@@ -53,7 +56,11 @@ export const createQueryStore = (options: CreateQueryStoreOptions): QueryStore =
     const payload = resultSourceMap ? {data: result, sourceMap: resultSourceMap} : {data: result}
     if (previewPerspective) {
       // @ts-expect-error - update typings
-      return {...payload, perspective}
+      return {...payload, perspective, variant}
+    }
+    if (variant) {
+      // @ts-expect-error - update typings
+      return {...payload, variant}
     }
     // @ts-expect-error - update typings
     return payload

--- a/packages/react-loader/src/createQueryStore/universal.ts
+++ b/packages/react-loader/src/createQueryStore/universal.ts
@@ -47,6 +47,7 @@ export const createQueryStore = (options: CreateQueryStoreOptions): QueryStore =
           false)
     const perspective =
       options.perspective || unstable__serverClient.instance?.config().perspective || 'published'
+    const variant = options.variant || undefined
 
     if (typeof document !== 'undefined') {
       throw new Error(
@@ -71,18 +72,19 @@ export const createQueryStore = (options: CreateQueryStoreOptions): QueryStore =
           resultSourceMap: 'withKeyArraySelector',
           stega,
           perspective,
+          variant,
           useCdn: false,
           headers,
           tag,
         })
       return resultSourceMap
-        ? {data: result, sourceMap: resultSourceMap, perspective}
+        ? {data: result, sourceMap: resultSourceMap, perspective, variant}
         : // @ts-expect-error - update typings
-          {data: result, perspective}
+          {data: result, perspective, variant}
     }
 
     const {result, resultSourceMap} = await unstable__cache.instance.fetch<QueryResponseResult>(
-      JSON.stringify({query, params, perspective, options: {stega}}),
+      JSON.stringify({query, params, perspective, variant, options: {stega}}),
     )
     // @ts-expect-error - update typings
     return resultSourceMap ? {data: result, sourceMap: resultSourceMap} : {data: result}

--- a/packages/react-loader/src/defineUseLiveMode.ts
+++ b/packages/react-loader/src/defineUseLiveMode.ts
@@ -15,7 +15,7 @@ export function defineUseLiveMode({
       | undefined,
   ) => void
 }): UseLiveModeHook {
-  return ({allowStudioOrigin, client, onConnect, onDisconnect, onPerspective, studioUrl}) => {
+  return ({allowStudioOrigin, client, onConnect, onDisconnect, onPerspective, onVariant, studioUrl}) => {
     useEffect(() => {
       if (allowStudioOrigin) {
         // eslint-disable-next-line no-console
@@ -26,9 +26,10 @@ export function defineUseLiveMode({
         onConnect,
         onDisconnect,
         onPerspective,
+        onVariant,
       })
       return () => disableLiveMode()
-    }, [allowStudioOrigin, client, onConnect, onDisconnect, onPerspective])
+    }, [allowStudioOrigin, client, onConnect, onDisconnect, onPerspective, onVariant])
     useEffect(() => {
       setStudioUrl(
         (studioUrl ?? typeof client === 'object')

--- a/packages/react-loader/src/defineUseQuery.ts
+++ b/packages/react-loader/src/defineUseQuery.ts
@@ -27,7 +27,7 @@ export function defineUseQuery({
     options: UseQueryOptions<QueryResponseResult> = {},
   ) => {
     const initial = useMemo(
-      () => (options.initial ? {perspective: 'published' as const, ...options.initial} : undefined),
+      () => (options.initial ? {perspective: 'published' as const, variant: undefined, ...options.initial} : undefined),
       [options.initial],
     )
     const $params = useMemo(() => JSON.stringify(params), [params])
@@ -91,6 +91,10 @@ export function defineUseQuery({
             //   prev.perspective,
             //   snapshot.perspective,
             // )
+            return snapshot
+          }
+
+          if (prev.variant !== snapshot.variant) {
             return snapshot
           }
 

--- a/packages/react-loader/src/types.ts
+++ b/packages/react-loader/src/types.ts
@@ -30,6 +30,10 @@ export interface QueryResponseInitial<QueryResponseResult> {
    * The perspective used to fetch the data, if not provided it'll assume 'published'
    */
   perspective?: ClientPerspective
+  /**
+   * The editing variant used to fetch the data, if any
+   */
+  variant?: string
 }
 
 export interface UseQueryOptions<QueryResponseResult = unknown> {
@@ -112,7 +116,9 @@ export interface QueryStore {
     options?: Pick<
       ResponseQueryOptions,
       'perspective' | 'cache' | 'next' | 'useCdn' | 'stega' | 'tag' | 'headers'
-    >,
+    > & {
+      variant?: string
+    },
   ) => Promise<QueryResponseInitial<QueryResponseResult>>
   setServerClient: ReturnType<typeof createCoreQueryStore>['setServerClient']
   useQuery: {

--- a/packages/svelte-loader/package.json
+++ b/packages/svelte-loader/package.json
@@ -42,7 +42,7 @@
     "test": "vitest --pass-with-no-tests --typecheck"
   },
   "dependencies": {
-    "@sanity/client": "^7.23.2",
+    "@sanity/client": "^7.24.0",
     "@sanity/core-loader": "workspace:^",
     "fast-deep-equal": "3.1.3"
   },

--- a/packages/svelte-loader/src/createQueryStore.ts
+++ b/packages/svelte-loader/src/createQueryStore.ts
@@ -39,6 +39,7 @@ export const createQueryStore = (options: CreateQueryStoreOptions): QueryStore =
     const {headers, tag} = options
     const perspective =
       options.perspective || unstable__serverClient.instance?.config().perspective || 'published'
+    const variant = options.variant || undefined
     const stega = options.stega ?? unstable__serverClient.instance?.config().stega ?? false
 
     if (typeof document !== 'undefined') {
@@ -62,18 +63,19 @@ export const createQueryStore = (options: CreateQueryStoreOptions): QueryStore =
           filterResponse: false,
           resultSourceMap: 'withKeyArraySelector',
           perspective,
+          variant,
           useCdn: false,
           headers,
           tag,
           stega,
         })
-      return {data: result, sourceMap: resultSourceMap, perspective}
+      return {data: result, sourceMap: resultSourceMap, perspective, variant}
     }
 
     const useCdn = options.useCdn || unstable__serverClient.instance!.config().useCdn
 
     const {result, resultSourceMap} = await unstable__cache.instance.fetch<QueryResponseResult>(
-      JSON.stringify({query, params, perspective, useCdn, stega}),
+      JSON.stringify({query, params, perspective, variant, useCdn, stega}),
     )
 
     // @ts-expect-error - update typings

--- a/packages/svelte-loader/src/defineUseLiveMode.ts
+++ b/packages/svelte-loader/src/defineUseLiveMode.ts
@@ -10,7 +10,7 @@ export function defineUseLiveMode({
 }: Pick<QueryStore, 'enableLiveMode'> & {
   studioUrlStore: ReturnType<typeof defineStudioUrlStore>
 }): UseLiveMode {
-  return ({allowStudioOrigin, client, onConnect, onDisconnect, studioUrl} = {}) => {
+  return ({allowStudioOrigin, client, onConnect, onDisconnect, onPerspective, onVariant, studioUrl} = {}) => {
     if (allowStudioOrigin) {
       // eslint-disable-next-line no-console
       console.warn('`allowStudioOrigin` is deprecated and no longer needed')
@@ -27,6 +27,8 @@ export function defineUseLiveMode({
       client,
       onConnect,
       onDisconnect,
+      onPerspective,
+      onVariant,
     })
   }
 }

--- a/packages/svelte-loader/src/defineUseQuery.ts
+++ b/packages/svelte-loader/src/defineUseQuery.ts
@@ -36,6 +36,7 @@ export function defineUseQuery({
     const initial = options.initial
       ? {
           perspective: 'published' as const,
+          variant: undefined,
           ...options.initial,
         }
       : undefined
@@ -69,6 +70,10 @@ export function defineUseQuery({
         }
 
         if (prev.perspective !== snapshot.perspective) {
+          $writeable.set(snapshot)
+        }
+
+        if (prev.variant !== snapshot.variant) {
           $writeable.set(snapshot)
         }
 

--- a/packages/svelte-loader/src/types.ts
+++ b/packages/svelte-loader/src/types.ts
@@ -43,6 +43,10 @@ export interface QueryResponseInitial<QueryResponseResult> {
    * The perspective used to fetch the data, if not provided it'll assume 'published'
    */
   perspective?: ClientPerspective
+  /**
+   * The editing variant used to fetch the data, if any
+   */
+  variant?: string
   encodeDataAttribute?: EncodeDataAttributeFunction
 }
 
@@ -125,7 +129,9 @@ export type UseLiveMode = (
 export type LoadQueryOptions = Pick<
   ResponseQueryOptions,
   'perspective' | 'cache' | 'next' | 'useCdn' | 'tag' | 'headers' | 'stega'
->
+> & {
+  variant?: string
+}
 
 /** @public */
 export type LoadQuery = <QueryResponseResult>(

--- a/packages/visual-editing/package.json
+++ b/packages/visual-editing/package.json
@@ -104,7 +104,7 @@
     "@sanity/comlink": "^4.0.1",
     "@sanity/icons": "^5.1.0",
     "@sanity/mutate": "^0.18.1",
-    "@sanity/presentation-comlink": "^2.1.0",
+    "@sanity/presentation-comlink": "^2.2.0",
     "@sanity/preview-url-secret": "workspace:^",
     "@sanity/types": "catalog:",
     "@sanity/ui": "^3.3.5",
@@ -160,7 +160,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@sanity/client": "^7.23.2",
+    "@sanity/client": "^7.24.0",
     "@sveltejs/kit": ">= 2",
     "next": ">=16.0.0-0",
     "react": "^19.2",

--- a/packages/visual-editing/src/next-pages-router/VisualEditingComponent.tsx
+++ b/packages/visual-editing/src/next-pages-router/VisualEditingComponent.tsx
@@ -27,6 +27,7 @@ export default function VisualEditingComponent(props: VisualEditingProps): null 
     refresh: refreshProp,
     zIndex,
     onPerspectiveChange,
+    onVariantChange,
     onSuspiciousStega: onSuspiciousStegaProp,
   } = props
 
@@ -86,6 +87,7 @@ export default function VisualEditingComponent(props: VisualEditingProps): null 
       zIndex,
       refresh,
       onPerspectiveChange,
+      onVariantChange,
       onSuspiciousStega: hasSuspiciousStegaCallback ? onSuspiciousStega : undefined,
       history: {
         subscribe: (_navigate) => {
@@ -96,7 +98,7 @@ export default function VisualEditingComponent(props: VisualEditingProps): null 
       },
     })
     return () => disable()
-  }, [components, keepStegaOnCopy, zIndex, onPerspectiveChange, hasSuspiciousStegaCallback])
+  }, [components, keepStegaOnCopy, zIndex, onPerspectiveChange, onVariantChange, hasSuspiciousStegaCallback])
 
   const {asPath, basePath, locale, isReady} = useRouter()
   useEffect(() => {

--- a/packages/visual-editing/src/react-router/VisualEditingComponent.tsx
+++ b/packages/visual-editing/src/react-router/VisualEditingComponent.tsx
@@ -34,6 +34,7 @@ export default function VisualEditingComponent(props: VisualEditingProps): null 
     refresh,
     zIndex,
     onPerspectiveChange,
+    onVariantChange,
     onSuspiciousStega: onSuspiciousStegaProp,
   } = props
 
@@ -68,6 +69,7 @@ export default function VisualEditingComponent(props: VisualEditingProps): null 
       keepStegaOnCopy,
       zIndex,
       onPerspectiveChange,
+      onVariantChange,
       onSuspiciousStega: hasSuspiciousStegaCallback ? onSuspiciousStega : undefined,
       refresh: (payload) => {
         function refreshDefault() {
@@ -105,6 +107,7 @@ export default function VisualEditingComponent(props: VisualEditingProps): null 
     revalidator,
     zIndex,
     onPerspectiveChange,
+    onVariantChange,
     hasSuspiciousStegaCallback,
   ])
 

--- a/packages/visual-editing/src/react/usePresentationQuery.ts
+++ b/packages/visual-editing/src/react/usePresentationQuery.ts
@@ -10,6 +10,7 @@ import {
   comlinkDataset,
   comlinkPerspective,
   comlinkProjectId,
+  comlinkVariant,
   subscribe,
 } from '../ui/loader-comlink/context'
 
@@ -18,6 +19,7 @@ export type UsePresentationQueryReturnsInactive = {
   data: null
   sourceMap: null
   perspective: null
+  variant: null
 }
 
 /** @alpha */
@@ -25,6 +27,7 @@ export type UsePresentationQueryReturnsActive<QueryString extends string> = {
   data: ClientReturn<QueryString>
   sourceMap: ContentSourceMap | null
   perspective: ClientPerspective
+  variant: string | undefined
 }
 
 /**
@@ -60,6 +63,10 @@ function reducer<QueryString extends string>(
             perspective: dequal(state.perspective, payload.perspective)
               ? (state.perspective as Exclude<ClientPerspective, 'raw'>)
               : payload.perspective,
+            variant:
+              'variant' in state && dequal(state.variant, payload.variant)
+                ? state.variant
+                : payload.variant,
           }
     default:
       return state
@@ -70,6 +77,7 @@ const initialState: UsePresentationQueryReturnsInactive = {
   data: null,
   sourceMap: null,
   perspective: null,
+  variant: null,
 }
 
 const EMPTY_QUERY_PARAMS: QueryParams = {}
@@ -116,6 +124,12 @@ export function usePresentationQuery<const QueryString extends string>(props: {
     () => null,
   )
 
+  const variant = useSyncExternalStore(
+    subscribe,
+    () => comlinkVariant,
+    () => null,
+  )
+
   // Register this hook instance as a query listener so LoaderComlink is mounted
   useEffect(() => addQueryListener(), [])
 
@@ -125,6 +139,7 @@ export function usePresentationQuery<const QueryString extends string>(props: {
       projectId,
       dataset,
       perspective,
+      variant: variant ?? undefined,
       query,
       params,
       heartbeat: LISTEN_HEARTBEAT_INTERVAL,
@@ -150,6 +165,7 @@ export function usePresentationQuery<const QueryString extends string>(props: {
             data: event.result,
             sourceMap: event.resultSourceMap || null,
             perspective: event.perspective,
+            variant: event.variant || undefined,
           },
         })
       }

--- a/packages/visual-editing/src/types.ts
+++ b/packages/visual-editing/src/types.ts
@@ -595,6 +595,12 @@ export interface VisualEditingOptions {
    */
   onPerspectiveChange?: (perspective: ClientPerspective) => void
   /**
+   * Fires when the editing variant changes in the Studio, with the bare variant id,
+   * or undefined when the variant is cleared. Allows persisting the change to a
+   * session cookie so server-side fetches can apply it.
+   */
+  onVariantChange?: (variant: string | undefined) => void
+  /**
    * Reports stega payloads found in places where they always cause bugs or bloat, such as
    * `class`, `href`, `src`, `id` and other attributes, inside `<head>` (e.g. `<title>`),
    * `<script>` or `<style>` contents, form values, or the page URL.

--- a/packages/visual-editing/src/ui/LoaderComlink.tsx
+++ b/packages/visual-editing/src/ui/LoaderComlink.tsx
@@ -10,6 +10,7 @@ import {
   setLoaderClientConfig,
   setLoaderComlink,
   setLoaderPerspective,
+  setLoaderVariant,
 } from './loader-comlink/context'
 
 /**
@@ -33,6 +34,7 @@ export default function LoaderComlink(): null {
     loaderComlink.on('loader/perspective', (data) => {
       setLoaderClientConfig(data.projectId, data.dataset)
       setLoaderPerspective(data.perspective)
+      setLoaderVariant(data.variant ?? null)
     })
 
     const stop = loaderComlink.start()
@@ -43,6 +45,7 @@ export default function LoaderComlink(): null {
       setLoaderComlink(null)
       setLoaderClientConfig(null, null)
       setLoaderPerspective(null)
+      setLoaderVariant(null)
     }
   }, [])
 

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -186,6 +186,7 @@ export function Overlays(props: {
   comlinkStatus?: Status
   componentResolver?: OverlayComponentResolver
   onPerspectiveChange?: (perspective: ClientPerspective) => Promise<void> | void
+  onVariantChange?: (variant: string | undefined) => Promise<void> | void
   plugins?: OverlayPluginDefinition[]
   inFrame: boolean
   inPopUp: boolean
@@ -199,6 +200,7 @@ export function Overlays(props: {
     inPopUp,
     zIndex,
     onPerspectiveChange,
+    onVariantChange,
   } = props
 
   const prefersDark = usePrefersDark()
@@ -213,6 +215,7 @@ export function Overlays(props: {
       elements,
       isDragging,
       perspective,
+      variant,
       wasMaybeCollapsed,
       dragMinimapTransition,
       dragGroupRect,
@@ -228,6 +231,7 @@ export function Overlays(props: {
     focusPath: '',
     isDragging: false,
     perspective: 'published',
+    variant: undefined,
     wasMaybeCollapsed: false,
     dragMinimapTransition: false,
     dragGroupRect: null,
@@ -251,9 +255,9 @@ export function Overlays(props: {
     return () => unsubs.forEach((unsub) => unsub!())
   }, [comlink])
 
-  usePerspectiveSync(comlink, dispatch, onPerspectiveChange)
+  usePerspectiveSync(comlink, dispatch, onPerspectiveChange, onVariantChange)
 
-  useReportDocuments(comlink, elements, perspective)
+  useReportDocuments(comlink, elements, perspective, variant)
 
   const updateDragPreviewCustomProps = useCallback(
     (x: number, y: number) => {

--- a/packages/visual-editing/src/ui/VisualEditing.tsx
+++ b/packages/visual-editing/src/ui/VisualEditing.tsx
@@ -38,6 +38,7 @@ export const VisualEditing = (props: VisualEditingOptions & {portal: boolean}): 
     refresh,
     zIndex,
     onPerspectiveChange,
+    onVariantChange,
     onSuspiciousStega,
   } = props
 
@@ -112,6 +113,7 @@ export const VisualEditing = (props: VisualEditingOptions & {portal: boolean}): 
           comlinkStatus={comlinkStatus}
           componentResolver={components}
           onPerspectiveChange={onPerspectiveChange}
+          onVariantChange={onVariantChange}
           plugins={plugins}
           inFrame={inFrame}
           inPopUp={inPopUp}

--- a/packages/visual-editing/src/ui/loader-comlink/context.ts
+++ b/packages/visual-editing/src/ui/loader-comlink/context.ts
@@ -13,6 +13,8 @@ export let comlinkProjectId: string | null = null
 export let comlinkDataset: string | null = null
 /** @internal */
 export let comlinkPerspective: ClientPerspective | null = null
+/** @internal */
+export let comlinkVariant: string | null = null
 
 /** @internal */
 export function setLoaderComlink(
@@ -36,6 +38,14 @@ export function setLoaderClientConfig(projectId: string | null, dataset: string 
 /** @internal */
 export function setLoaderPerspective(perspective: ClientPerspective | null): void {
   comlinkPerspective = perspective
+  for (const listener of comlinkListeners) {
+    listener()
+  }
+}
+
+/** @internal */
+export function setLoaderVariant(variant: string | null): void {
+  comlinkVariant = variant
   for (const listener of comlinkListeners) {
     listener()
   }

--- a/packages/visual-editing/src/ui/overlayStateReducer.ts
+++ b/packages/visual-editing/src/ui/overlayStateReducer.ts
@@ -22,6 +22,7 @@ export interface OverlayState {
   elements: ElementState[]
   wasMaybeCollapsed: boolean
   perspective: ClientPerspective
+  variant: string | undefined
   isDragging: boolean
   dragInsertPosition: DragInsertPosition
   dragSkeleton: DragSkeleton | null
@@ -40,6 +41,7 @@ export function overlayStateReducer(
     contextMenu,
     focusPath,
     perspective,
+    variant,
     isDragging,
     dragInsertPosition,
     dragShowMinimap,
@@ -62,6 +64,7 @@ export function overlayStateReducer(
 
   if (type === 'presentation/perspective') {
     perspective = message.data.perspective
+    variant = message.data.variant || undefined
   }
 
   if (type === 'element/contextmenu') {
@@ -128,6 +131,7 @@ export function overlayStateReducer(
     isDragging,
     focusPath,
     perspective,
+    variant,
     wasMaybeCollapsed,
     dragShowMinimap,
     dragShowMinimapPrompt,

--- a/packages/visual-editing/src/ui/renderVisualEditing.tsx
+++ b/packages/visual-editing/src/ui/renderVisualEditing.tsx
@@ -23,6 +23,7 @@ export function renderVisualEditing(
     zIndex,
     plugins,
     onPerspectiveChange,
+    onVariantChange,
     onSuspiciousStega,
   }: VisualEditingOptions,
 ): void {
@@ -64,6 +65,7 @@ export function renderVisualEditing(
         refresh={refresh}
         zIndex={zIndex}
         onPerspectiveChange={onPerspectiveChange}
+        onVariantChange={onVariantChange}
         onSuspiciousStega={onSuspiciousStega}
         // Disabling the portal, as this function is already making sure the overlays render in the right spot
         portal={false}

--- a/packages/visual-editing/src/ui/usePerspectiveSync.tsx
+++ b/packages/visual-editing/src/ui/usePerspectiveSync.tsx
@@ -8,18 +8,23 @@ export function usePerspectiveSync(
   comlink: VisualEditingNode | undefined,
   dispatch: (value: OverlayMsg | VisualEditingControllerMsg) => void,
   onPerspectiveChange?: (perspective: ClientPerspective) => void,
+  onVariantChange?: (variant: string | undefined) => void,
 ): void {
   const handlesPerspectiveChange = !!onPerspectiveChange
-  const handlePerspective = useEffectEvent((data: {perspective: ClientPerspective}) => {
-    dispatch({type: 'presentation/perspective', data})
-    onPerspectiveChange?.(data.perspective)
-  })
+  const handlesVariantChange = !!onVariantChange
+  const handlePerspective = useEffectEvent(
+    (data: {perspective: ClientPerspective; variant?: string}) => {
+      dispatch({type: 'presentation/perspective', data})
+      onPerspectiveChange?.(data.perspective)
+      onVariantChange?.(data.variant || undefined)
+    },
+  )
   useEffect(() => {
     const controller = new AbortController()
     comlink
       ?.fetch(
         'visual-editing/fetch-perspective',
-        {handlesPerspectiveChange},
+        {handlesPerspectiveChange, handlesVariantChange},
         {
           signal: controller.signal,
           suppressWarnings: true,
@@ -41,5 +46,5 @@ export function usePerspectiveSync(
       unsub?.()
       controller.abort()
     }
-  }, [comlink, dispatch, handlesPerspectiveChange])
+  }, [comlink, dispatch, handlesPerspectiveChange, handlesVariantChange])
 }

--- a/packages/visual-editing/src/ui/useReportDocuments.ts
+++ b/packages/visual-editing/src/ui/useReportDocuments.ts
@@ -12,20 +12,27 @@ export function useReportDocuments(
   comlink: VisualEditingNode | undefined,
   elements: ElementState[],
   perspective: ClientPerspective,
+  variant: string | undefined,
 ): void {
   const lastReported = useRef<
     | {
         orderedIds: string[]
         perspective: ClientPerspective
+        variant: string | undefined
       }
     | undefined
   >(undefined)
 
   const reportDocuments = useCallback(
-    (documents: ContentSourceMapDocuments, perspective: ClientPerspective) => {
+    (
+      documents: ContentSourceMapDocuments,
+      perspective: ClientPerspective,
+      variant: string | undefined,
+    ) => {
       comlink?.post('visual-editing/documents', {
         documents,
         perspective,
+        variant,
       })
     },
     [comlink],
@@ -42,22 +49,26 @@ export function useReportDocuments(
     // Report if:
     // - Documents not yet reported
     // - Document IDs changed or their visual order changed
-    // - Perspective changed
+    // - Perspective or variant changed
     const lastOrderedIds = lastReported.current?.orderedIds
     const orderChanged =
       !lastOrderedIds ||
       lastOrderedIds.length !== orderedIds.length ||
       orderedIds.some((id, index) => id !== lastOrderedIds[index])
 
-    if (orderChanged || perspective !== lastReported.current?.perspective) {
+    if (
+      orderChanged ||
+      perspective !== lastReported.current?.perspective ||
+      variant !== lastReported.current?.variant
+    ) {
       const documentsOnPage: ContentSourceMapDocuments = orderedNodes.map((node) => {
         const {id: _id, type, projectId: _projectId, dataset: _dataset} = node
         return _projectId && _dataset
           ? {_id, _type: type!, _projectId, _dataset}
           : {_id, _type: type!}
       })
-      lastReported.current = {orderedIds, perspective}
-      reportDocuments(documentsOnPage, perspective)
+      lastReported.current = {orderedIds, perspective, variant}
+      reportDocuments(documentsOnPage, perspective, variant)
     }
-  }, [elements, perspective, reportDocuments])
+  }, [elements, perspective, variant, reportDocuments])
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,7 +69,7 @@ catalogs:
       version: 4.3.3
 
 overrides:
-  '@sanity/client': ^7.23.2
+  '@sanity/client': ^7.24.0
   '@sanity/core-loader': workspace:*
   '@sanity/preview-url-secret': workspace:*
   '@sanity/react-loader': workspace:*
@@ -134,7 +134,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@repo/studio-url
       '@sanity/client':
-        specifier: ^7.23.2
+        specifier: ^7.24.0
         version: 7.24.0
       '@sanity/image-url':
         specifier: ^2.1.1
@@ -219,7 +219,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@repo/studio-url
       '@sanity/client':
-        specifier: ^7.23.2
+        specifier: ^7.24.0
         version: 7.24.0
       '@sanity/icons':
         specifier: 'catalog:'
@@ -309,7 +309,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@repo/studio-url
       '@sanity/client':
-        specifier: ^7.23.2
+        specifier: ^7.24.0
         version: 7.24.0
       '@sanity/demo':
         specifier: ^2.0.0
@@ -390,7 +390,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@repo/sanity-schema
       '@sanity/client':
-        specifier: ^7.23.2
+        specifier: ^7.24.0
         version: 7.24.0
       '@sanity/debug-preview-url-secret-plugin':
         specifier: ^2.0.19
@@ -600,14 +600,14 @@ importers:
   packages/core-loader:
     dependencies:
       '@sanity/client':
-        specifier: ^7.23.2
+        specifier: ^7.24.0
         version: 7.24.0
       '@sanity/comlink':
         specifier: ^4.0.1
         version: 4.0.1
       '@sanity/presentation-comlink':
-        specifier: ^2.1.0
-        version: 2.1.0(@sanity/client@7.24.0)(@sanity/types@6.5.0(@types/react@19.2.17))
+        specifier: ^2.2.0
+        version: 2.2.0(@sanity/client@7.24.0)(@sanity/types@6.5.0(@types/react@19.2.17))
       '@sanity/visual-editing-csm':
         specifier: workspace:*
         version: link:../visual-editing-csm
@@ -662,7 +662,7 @@ importers:
         specifier: workspace:*
         version: link:../@repo/package.config
       '@sanity/client':
-        specifier: ^7.23.2
+        specifier: ^7.24.0
         version: 7.24.0
       '@sanity/pkg-utils':
         specifier: 'catalog:'
@@ -683,7 +683,7 @@ importers:
   packages/react-loader:
     dependencies:
       '@sanity/client':
-        specifier: ^7.23.2
+        specifier: ^7.24.0
         version: 7.24.0
       '@sanity/core-loader':
         specifier: workspace:*
@@ -726,7 +726,7 @@ importers:
   packages/svelte-loader:
     dependencies:
       '@sanity/client':
-        specifier: ^7.23.2
+        specifier: ^7.24.0
         version: 7.24.0
       '@sanity/core-loader':
         specifier: workspace:*
@@ -784,8 +784,8 @@ importers:
         specifier: ^0.18.1
         version: 0.18.1(xstate@5.32.5)
       '@sanity/presentation-comlink':
-        specifier: ^2.1.0
-        version: 2.1.0(@sanity/client@7.24.0)(@sanity/types@6.5.0(@types/react@19.2.17))
+        specifier: ^2.2.0
+        version: 2.2.0(@sanity/client@7.24.0)(@sanity/types@6.5.0(@types/react@19.2.17))
       '@sanity/preview-url-secret':
         specifier: workspace:*
         version: link:../preview-url-secret
@@ -830,7 +830,7 @@ importers:
         specifier: workspace:*
         version: link:../@repo/package.config
       '@sanity/client':
-        specifier: ^7.23.2
+        specifier: ^7.24.0
         version: 7.24.0
       '@sanity/demo':
         specifier: ^2.0.0
@@ -960,7 +960,7 @@ importers:
         specifier: workspace:*
         version: link:../@repo/package.config
       '@sanity/client':
-        specifier: ^7.23.2
+        specifier: ^7.24.0
         version: 7.24.0
       '@sanity/pkg-utils':
         specifier: 'catalog:'
@@ -987,7 +987,7 @@ importers:
         specifier: workspace:*
         version: link:../@repo/package.config
       '@sanity/client':
-        specifier: ^7.23.2
+        specifier: ^7.24.0
         version: 7.24.0
       '@sanity/pkg-utils':
         specifier: 'catalog:'
@@ -4652,7 +4652,7 @@ packages:
     resolution: {integrity: sha512-jbnR3z93+hrddl0xPDuQotJYnVNtQPl969LZXo6opMZuy/uG64jwodp76pnJmq8Y9aHqR2fLk/ne7R4iBv8PhA==}
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
-      '@sanity/client': ^7.23.2
+      '@sanity/client': ^7.24.0
 
   '@sanity/insert-menu@3.0.8':
     resolution: {integrity: sha512-O3g3ZpvRYLw4VBly4fKUzEK+2Mze8iBZfLpRjh8BgjLWSZ/9XCwrRUMJvKZ6z9qQI8zHRqwZQNslgEjETTTZ6w==}
@@ -4717,6 +4717,10 @@ packages:
 
   '@sanity/presentation-comlink@2.1.0':
     resolution: {integrity: sha512-XwbGSK/cNW/awPfT8GssDTZoTlmg/7bcz1feCdfSDjOvNmlNfSqu/uPJZgKPnM0n54bFTUy8cs2zTKm1kc8nVA==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+
+  '@sanity/presentation-comlink@2.2.0':
+    resolution: {integrity: sha512-uHiiJNWER36S/M2R9B7iwf+R2GMV267kQCfIpQiGX+2C3aHwjFHjaEiPBF0aPOyBkHV2OfB3l7XSzyLIXYuQHQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
   '@sanity/prism-groq@1.1.2':
@@ -4796,7 +4800,7 @@ packages:
     resolution: {integrity: sha512-4Hu3J8qDLanymnSapRzKwHlQl6SCsBbkL1o5fSMVbWVHvTk/j2uGLLNTsjASICTqUwSm3fwWlyahzCy2uS/LvQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@sanity/client': ^7.23.2
+      '@sanity/client': ^7.24.0
       '@sanity/types': ^6.5.0
     peerDependenciesMeta:
       '@sanity/types':
@@ -8505,7 +8509,7 @@ packages:
     resolution: {integrity: sha512-72iTgqZbdvCDXzXam7PTiVFux1lMtDz7aMq6W4uBwGoVKkNforv+1LvzqZ/GfhuChXesex8VCFa+ooqABGb5NA==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
-      '@sanity/client': ^7.23.2
+      '@sanity/client': ^7.24.0
       next: ^16.0.0-0
       react: ^19.2.3
       react-dom: ^19.2.3
@@ -15191,6 +15195,14 @@ snapshots:
       - vue-tsc
 
   '@sanity/presentation-comlink@2.1.0(@sanity/client@7.24.0)(@sanity/types@6.5.0(@types/react@19.2.17))':
+    dependencies:
+      '@sanity/comlink': 4.0.1
+      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.24.0)(@sanity/types@6.5.0(@types/react@19.2.17))
+    transitivePeerDependencies:
+      - '@sanity/client'
+      - '@sanity/types'
+
+  '@sanity/presentation-comlink@2.2.0(@sanity/client@7.24.0)(@sanity/types@6.5.0(@types/react@19.2.17))':
     dependencies:
       '@sanity/comlink': 4.0.1
       '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.24.0)(@sanity/types@6.5.0(@types/react@19.2.17))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 
 catalog:
   '@sanity/assist': ^6.1.15
-  '@sanity/client': ^7.23.2
+  '@sanity/client': ^7.24.0
   '@sanity/color-input': ^6.0.16
   '@sanity/icons': ^5.1.0
   '@sanity/pkg-utils': ^10.9.2


### PR DESCRIPTION
## Summary
- Add optional `variant` transport parallel to `perspective` across `@sanity/preview-url-secret`, `@sanity/core-loader`, `@sanity/react-loader`, `@sanity/svelte-loader`, and `@sanity/visual-editing`
- Wire `onVariantChange` / `onVariant` callbacks so phase 4 (next-sanity) can persist the selected variant in a cookie
- Add `pkg.pr.new` CI that publishes only packages listed in PR changesets when labeled `trigger: preview`

## Test plan
- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] Add `trigger: preview` label to publish pkg.pr.new preview packages
- [ ] Install preview packages in a consumer app once phase 1 (`@sanity/presentation-comlink`) and phase 3 (studio) land