### PR TITLE
feat(preview-url-secret): add editing variant support

### DIFF
--- a/.changeset/preview-url-secret-variant.md
+++ b/.changeset/preview-url-secret-variant.md
@@ -1,0 +1,5 @@
+---
+"@sanity/preview-url-secret": minor
+---
+
+Add editing variant support: new `urlSearchParamPreviewVariant` and `variantCookieName` constants, `studioPreviewVariant` parsed, forwarded and returned by `parsePreviewUrl` / `validatePreviewUrl`, and variant handling in `withoutSecretSearchParams`, `setSecretSearchParams` and `definePreviewUrl`.

--- a/packages/preview-url-secret/src/constants.ts
+++ b/packages/preview-url-secret/src/constants.ts
@@ -31,6 +31,9 @@ export const urlSearchParamPreviewPathname = 'sanity-preview-pathname'
 export const urlSearchParamPreviewPerspective = 'sanity-preview-perspective'
 
 /** @internal */
+export const urlSearchParamPreviewVariant = 'sanity-preview-variant'
+
+/** @internal */
 export const urlSearchParamVercelProtectionBypass = 'x-vercel-protection-bypass'
 
 /** @internal */
@@ -88,5 +91,8 @@ export const tag = 'sanity.preview-url-secret' as const
 
 /** @internal */
 export const perspectiveCookieName = 'sanity-preview-perspective'
+
+/** @internal */
+export const variantCookieName = 'sanity-preview-variant'
 
 export type {VercelSetBypassCookieValue} from './types'

--- a/packages/preview-url-secret/src/definePreviewUrl.ts
+++ b/packages/preview-url-secret/src/definePreviewUrl.ts
@@ -2,6 +2,7 @@ import {
   urlSearchParamPreviewPathname,
   urlSearchParamPreviewPerspective,
   urlSearchParamPreviewSecret,
+  urlSearchParamPreviewVariant,
 } from './constants'
 import type {
   PreviewUrlResolver,
@@ -51,6 +52,11 @@ export function definePreviewUrl<SanityClientType>(
       const {searchParams} = enablePreviewModeRequestUrl
       searchParams.set(urlSearchParamPreviewSecret, context.previewUrlSecret)
       searchParams.set(urlSearchParamPreviewPerspective, context.studioPreviewPerspective)
+      if (context.studioPreviewVariant) {
+        searchParams.set(urlSearchParamPreviewVariant, context.studioPreviewVariant)
+      } else {
+        searchParams.delete(urlSearchParamPreviewVariant)
+      }
       if (previewUrl.pathname !== enablePreviewModeRequestUrl.pathname) {
         searchParams.set(
           urlSearchParamPreviewPathname,

--- a/packages/preview-url-secret/src/parsePreviewUrl.test.ts
+++ b/packages/preview-url-secret/src/parsePreviewUrl.test.ts
@@ -4,9 +4,11 @@ import {
   urlSearchParamPreviewPathname,
   urlSearchParamPreviewPerspective,
   urlSearchParamPreviewSecret,
+  urlSearchParamPreviewVariant,
   urlSearchParamVercelProtectionBypass,
 } from './constants'
 import {parsePreviewUrl} from './parsePreviewUrl'
+import {setSecretSearchParams, withoutSecretSearchParams} from './withoutSecretSearchParams'
 
 test('handles absolute URLs', () => {
   const unsafe = new URL('https://example.com/api/draft')
@@ -16,6 +18,7 @@ test('handles absolute URLs', () => {
     redirectTo: '/preview?foo=bar',
     secret: 'abc123',
     studioPreviewPerspective: null,
+    studioPreviewVariant: null,
   })
 })
 
@@ -28,6 +31,7 @@ test('handles relative URLs', () => {
     redirectTo: '/preview?foo=bar&sanity-preview-perspective=published',
     secret: 'abc123',
     studioPreviewPerspective: 'published',
+    studioPreviewVariant: null,
   })
 })
 
@@ -39,7 +43,42 @@ test('includes hash', () => {
     redirectTo: '/preview?foo=bar#heading1',
     secret: 'abc123',
     studioPreviewPerspective: null,
+    studioPreviewVariant: null,
   })
+})
+
+test('forwards preview variant to redirect', () => {
+  const unsafe = new URL('/api/draft', 'http://localhost')
+  unsafe.searchParams.set(urlSearchParamPreviewSecret, 'abc123')
+  unsafe.searchParams.set(urlSearchParamPreviewPathname, '/preview?foo=bar')
+  unsafe.searchParams.set(urlSearchParamPreviewVariant, 'Ab12cd34')
+  expect(parsePreviewUrl(`${unsafe.pathname}${unsafe.search}`)).toEqual({
+    redirectTo: '/preview?foo=bar&sanity-preview-variant=Ab12cd34',
+    secret: 'abc123',
+    studioPreviewPerspective: null,
+    studioPreviewVariant: 'Ab12cd34',
+  })
+})
+
+test('withoutSecretSearchParams removes preview variant', () => {
+  const url = new URL('https://example.com/preview?foo=bar')
+  url.searchParams.set(urlSearchParamPreviewVariant, 'Ab12cd34')
+  url.searchParams.set(urlSearchParamPreviewPerspective, 'drafts')
+  url.searchParams.set(urlSearchParamPreviewSecret, 'abc123')
+  const cleaned = withoutSecretSearchParams(url)
+  expect(cleaned.searchParams.has(urlSearchParamPreviewVariant)).toBe(false)
+  expect(cleaned.searchParams.has(urlSearchParamPreviewPerspective)).toBe(false)
+  expect(cleaned.searchParams.has(urlSearchParamPreviewSecret)).toBe(false)
+  expect(cleaned.searchParams.get('foo')).toBe('bar')
+})
+
+test('setSecretSearchParams sets and clears preview variant', () => {
+  const url = new URL('https://example.com/api/preview')
+  const withVariant = setSecretSearchParams(url, 'abc123', '/preview', 'drafts', 'Ab12cd34')
+  expect(withVariant.searchParams.get(urlSearchParamPreviewVariant)).toBe('Ab12cd34')
+
+  const withoutVariant = setSecretSearchParams(withVariant, 'abc123', '/preview', 'drafts')
+  expect(withoutVariant.searchParams.has(urlSearchParamPreviewVariant)).toBe(false)
 })
 
 test('forwards vercel bypass secret to redirect', () => {
@@ -52,6 +91,7 @@ test('forwards vercel bypass secret to redirect', () => {
       '/preview?foo=bar&x-vercel-protection-bypass=dfg456&x-vercel-set-bypass-cookie=samesitenone#heading1',
     secret: 'abc123',
     studioPreviewPerspective: null,
+    studioPreviewVariant: null,
   })
 })
 
@@ -66,5 +106,6 @@ test('strips origin from redirect', () => {
     redirectTo: '/preview?foo=bar',
     secret: 'abc123',
     studioPreviewPerspective: null,
+    studioPreviewVariant: null,
   })
 })

--- a/packages/preview-url-secret/src/parsePreviewUrl.ts
+++ b/packages/preview-url-secret/src/parsePreviewUrl.ts
@@ -3,6 +3,7 @@ import {
   urlSearchParamPreviewPathname,
   urlSearchParamPreviewPerspective,
   urlSearchParamPreviewSecret,
+  urlSearchParamPreviewVariant,
   urlSearchParamVercelProtectionBypass,
   urlSearchParamVercelSetBypassCookie,
 } from './constants'
@@ -18,6 +19,7 @@ export function parsePreviewUrl(unsafeUrl: string): ParsedPreviewUrl {
     throw new Error('Missing secret')
   }
   const studioPreviewPerspective = url.searchParams.get(urlSearchParamPreviewPerspective)
+  const studioPreviewVariant = url.searchParams.get(urlSearchParamPreviewVariant) || null
   let redirectTo: string | undefined
   const unsafeRedirectTo = url.searchParams.get(urlSearchParamPreviewPathname)
   if (unsafeRedirectTo) {
@@ -29,6 +31,10 @@ export function parsePreviewUrl(unsafeUrl: string): ParsedPreviewUrl {
       !redirectUrl.searchParams.has(urlSearchParamPreviewPerspective)
     ) {
       redirectUrl.searchParams.set(urlSearchParamPreviewPerspective, studioPreviewPerspective)
+    }
+
+    if (studioPreviewVariant && !redirectUrl.searchParams.has(urlSearchParamPreviewVariant)) {
+      redirectUrl.searchParams.set(urlSearchParamPreviewVariant, studioPreviewVariant)
     }
 
     // If there's a vercel bypass secret in the redirect URL, we forward it to the redirect to ensure it's set
@@ -47,5 +53,5 @@ export function parsePreviewUrl(unsafeUrl: string): ParsedPreviewUrl {
     const {pathname, search, hash} = redirectUrl
     redirectTo = `${pathname}${search}${hash}`
   }
-  return {secret, redirectTo, studioPreviewPerspective}
+  return {secret, redirectTo, studioPreviewPerspective, studioPreviewVariant}
 }

--- a/packages/preview-url-secret/src/types.ts
+++ b/packages/preview-url-secret/src/types.ts
@@ -58,6 +58,11 @@ export interface PreviewUrlValidateUrlResult {
    * The value can be arbitrary and has to be validated to make sure it's a valid perspective.
    */
   studioPreviewPerspective?: string | null | undefined
+  /**
+   * The initial editing variant the Studio was using when starting to load the preview.
+   * It can change over time and should also be handled with `postMessage` listeners.
+   */
+  studioPreviewVariant?: string | null | undefined
 }
 
 /** @internal */
@@ -65,6 +70,7 @@ export interface ParsedPreviewUrl {
   secret: string
   redirectTo?: string | undefined
   studioPreviewPerspective: string | null
+  studioPreviewVariant: string | null
 }
 
 /** @public */
@@ -168,6 +174,10 @@ export interface PreviewUrlResolverContext<SanityClientType> {
    * The value can be arbitrary and has to be validated to make sure it's a valid perspective.
    */
   studioPreviewPerspective: string
+  /**
+   * The initial editing variant the Studio was using when starting to load the preview.
+   */
+  studioPreviewVariant?: string
   /**
    * If the user navigated to a preview path already, this will be the path
    */

--- a/packages/preview-url-secret/src/validatePreviewUrl.ts
+++ b/packages/preview-url-secret/src/validatePreviewUrl.ts
@@ -38,6 +38,7 @@ export async function validatePreviewUrl(
   )
   const redirectTo = isValid ? parsedPreviewUrl.redirectTo : undefined
   const studioPreviewPerspective = isValid ? parsedPreviewUrl.studioPreviewPerspective : undefined
+  const studioPreviewVariant = isValid ? parsedPreviewUrl.studioPreviewVariant : undefined
   let studioOrigin: string | undefined
   if (isValid) {
     try {
@@ -53,7 +54,7 @@ export async function validatePreviewUrl(
     }
   }
 
-  return {isValid, redirectTo, studioOrigin, studioPreviewPerspective}
+  return {isValid, redirectTo, studioOrigin, studioPreviewPerspective, studioPreviewVariant}
 }
 
 export type {PreviewUrlValidateUrlResult, SanityClientLike}

--- a/packages/preview-url-secret/src/withoutSecretSearchParams.ts
+++ b/packages/preview-url-secret/src/withoutSecretSearchParams.ts
@@ -2,6 +2,7 @@ import {
   urlSearchParamPreviewPathname,
   urlSearchParamPreviewPerspective,
   urlSearchParamPreviewSecret,
+  urlSearchParamPreviewVariant,
   urlSearchParamVercelProtectionBypass,
   urlSearchParamVercelSetBypassCookie,
 } from './constants'
@@ -13,6 +14,7 @@ export function withoutSecretSearchParams(url: URL): URL {
   searchParams.delete(urlSearchParamPreviewPathname)
   searchParams.delete(urlSearchParamPreviewSecret)
   searchParams.delete(urlSearchParamPreviewPerspective)
+  searchParams.delete(urlSearchParamPreviewVariant)
   searchParams.delete(urlSearchParamVercelProtectionBypass)
   searchParams.delete(urlSearchParamVercelSetBypassCookie)
   return newUrl
@@ -29,6 +31,7 @@ export function setSecretSearchParams(
   secret: string | null,
   redirectTo: string,
   perspective: string,
+  variant?: string,
 ): URL {
   const newUrl = new URL(url)
   const {searchParams} = newUrl
@@ -39,6 +42,11 @@ export function setSecretSearchParams(
   }
   // Always set the perspective that's being used
   searchParams.set(urlSearchParamPreviewPerspective, perspective)
+  if (variant) {
+    searchParams.set(urlSearchParamPreviewVariant, variant)
+  } else {
+    searchParams.delete(urlSearchParamPreviewVariant)
+  }
 
   return newUrl
 }


### PR DESCRIPTION
## Summary
Adding this changes first to get a preview version of `sanity` because it depends on this one.

- Add `urlSearchParamPreviewVariant` (`sanity-preview-variant`) and `variantCookieName` constants
- Parse, forward and return `studioPreviewVariant` in `parsePreviewUrl` / `validatePreviewUrl`
- Handle the variant param in `withoutSecretSearchParams`, `setSecretSearchParams` (optional trailing `variant` arg) and `definePreviewUrl`

Split out of #3500 so `@sanity/preview-url-secret` can be released first for the `sanity` monorepo (phase 3) to depend on. All changes are optional and backward compatible.

## Test plan
- [x] `pnpm --filter @sanity/preview-url-secret test` (8 tests, typecheck clean)
- [x] `pnpm --filter @sanity/preview-url-secret build`