### PR TITLE
fix(core-loader): re-emit query listen on perspective/variant change

### DIFF
--- a/packages/core-loader/src/live-mode/enableLiveMode.ts
+++ b/packages/core-loader/src/live-mode/enableLiveMode.ts
@@ -77,6 +77,9 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
       const nextVariant = data.variant || undefined
       $variant.set(nextVariant)
       onVariant?.(nextVariant)
+      // Re-emit `loader/query-listen` right away so the controller subscribes with the
+      // new perspective/variant immediately, instead of waiting for the next heartbeat
+      emitQueryListen()
       updateLiveQueries()
     }
   })


### PR DESCRIPTION
## Summary
I noticed some slowness when changing perspectives and variants and using the core loaders.
This fixes that by propagating the variant change immediately

Before and after created from the branch that sets up a react app using core loader in this package

### Before

https://github.com/user-attachments/assets/ed7f82aa-ec50-4ec3-9115-6bd8b34c674d


### After


https://github.com/user-attachments/assets/dfec52ba-6321-409e-8269-2e1fec74f653



- When Presentation posts `loader/perspective` (perspective or variant switch), `enableLiveMode` updated its internal `$perspective`/`$variant` atoms and called `updateLiveQueries()`, which only applies **already-cached** results — always a miss right after a switch.
- Nothing told the controller to re-subscribe with the new keys, so it kept fetching with the old perspective/variant until the next `loader/query-listen` heartbeat, i.e. up to 20s of stale content in the preview.
- This re-emits `loader/query-listen` for all live queries immediately in the `loader/perspective` handler, so the controller creates the new subscriptions right away and pushes fresh results back via `loader/query-change`. It also flips the query stores to `loading: true` and updates their `perspective`/`variant` instantly. Stale controller-side subscriptions simply stop receiving heartbeats and get GC'd.
