### PR TITLE
fix(visual-editing-csm): decode all-numeric _key as a key, not an array index

### DIFF
--- a/.changeset/heavy-eels-search.md
+++ b/.changeset/heavy-eels-search.md
@@ -1,0 +1,5 @@
+---
+'@sanity/visual-editing-csm': patch
+---
+
+fix: decode an all-numeric `_key` as a key instead of an array index

--- a/packages/visual-editing-csm/src/urlStringToPath.test.ts
+++ b/packages/visual-editing-csm/src/urlStringToPath.test.ts
@@ -74,6 +74,28 @@ describe('urlStringToPath should convert', () => {
     ])
   })
 
+  test('an all-numeric key too large to be an array index to an object', () => {
+    expect(urlStringToPath('array:342330179449')).toEqual([
+      'array',
+      {
+        _key: '342330179449',
+      },
+    ])
+  })
+
+  test('the largest index-shaped number to a number', () => {
+    expect(urlStringToPath('array:999999999')).toEqual(['array', 999999999])
+  })
+
+  test('one past the largest index-shaped number to an object', () => {
+    expect(urlStringToPath('array:1000000000')).toEqual([
+      'array',
+      {
+        _key: '1000000000',
+      },
+    ])
+  })
+
   test('a key with a tuple', () => {
     expect(urlStringToPath('array:123,456')).toEqual(['array', [123, 456]])
   })

--- a/packages/visual-editing-csm/src/urlStringToPath.ts
+++ b/packages/visual-editing-csm/src/urlStringToPath.ts
@@ -1,6 +1,10 @@
 import type {Path} from '@sanity/client/csm'
 
-const RE_SEGMENT_WITH_INDEX = /^([\w-]+):(0|[1-9][0-9]*)$/
+// An all-digit segment is ambiguous, as `pathToUrlString` serialises an array
+// index and a `_key` identically. Cap indexes at 9 digits so that longer
+// numbers, which no array can be indexed by anyway, fall through to
+// RE_SEGMENT_WITH_KEY.
+const RE_SEGMENT_WITH_INDEX = /^([\w-]+):(0|[1-9][0-9]{0,8})$/
 const RE_SEGMENT_WITH_TUPLE = /^([\w-]+):([0-9]+),([0-9]+)$/
 const RE_SEGMENT_WITH_KEY = /^([\w-]+):([\w-]+)$/
 


### PR DESCRIPTION
Fixes #3467.

An all-numeric `_key` was decoding as an array index, so reordering one of those items threw `Found no matching array element to replace`.

The encode side writes an index and a `_key` identically:

```ts
if (typeof segment === 'number') str += `${segment}`      // array:5
if (segment._key)                str += `${segment._key}` // array:342330179449
```

which leaves `urlStringToPath` to break the tie, and `RE_SEGMENT_WITH_INDEX` matched any run of digits and got tested first. So the key came back a number, `decodeSanityString` stringified it to `sections[342330179449]`, `getArrayItemKeyAndParentPath` found no `_key`, and the reorder ran `remove(~~"342330179449")`, which int32-truncates to `-1267204231`.

The fix is the quantifier:

```diff
-const RE_SEGMENT_WITH_INDEX = /^([\w-]+):(0|[1-9][0-9]*)$/
+const RE_SEGMENT_WITH_INDEX = /^([\w-]+):(0|[1-9][0-9]{0,8})$/
```

Nine digits max, so anything longer falls through to the key branch. That covers every `randomKey` output, since those are 12 characters. Leading-zero keys already worked. A short hand-authored key like `12345` stays ambiguous, and no magnitude rule fixes that one, so this keeps to the `randomKey` case the issue reports.

I started out with a `MAX_ARRAY_INDEX = 2 ** 32 - 2` constant and a second condition in the loop. Same behaviour, four more lines and a second place to look, so I dropped it. Happy to put it back if you would rather have the bound spelled out than the regex short.

## Testing

Three cases added to `urlStringToPath.test.ts`. The existing `array:123` assertion still holds.

I also ran the chain from the issue, `createDataAttribute(['sections', {_key}])` through `decodeSanityNodeData` to `getArrayItemKeyAndParentPath`, against this branch and against main. On main:

```
_key=342330179449   sections[342330179449]          explicit=false
_key=123456789012   sections[123456789012]          explicit=false
_key=999999999999   sections[999999999999]          explicit=false
_key=000000000001   sections[_key=="000000000001"]  explicit=true
_key=abc123def456   sections[_key=="abc123def456"]  explicit=true
```

All six pass on this branch, and `['items', 0]`, `['items', 5]`, `['items', 999999999]` decode as indexes either way.

