### PR TITLE
fix: align page-builder demo props with next-sanity stega types

### DIFF
--- a/apps/live-next/package.json
+++ b/apps/live-next/package.json
@@ -27,7 +27,7 @@
     "date-fns": "^4.4.0",
     "motion": "^13.0.0",
     "next": "16.3.0-preview.8",
-    "next-sanity": "^13.1.7",
+    "next-sanity": "^13.3.1",
     "postcss": "^8.5.6",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/apps/next/package.json
+++ b/apps/next/package.json
@@ -25,7 +25,7 @@
     "@vercel/stega": "^1.1.0",
     "@vercel/toolbar": "^0.2.6",
     "next": "^16.2.11",
-    "next-sanity": "^13.1.7",
+    "next-sanity": "^13.3.1",
     "postcss": "8.5.10",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/apps/page-builder-demo/package.json
+++ b/apps/page-builder-demo/package.json
@@ -31,7 +31,7 @@
     "babel-plugin-react-compiler": "catalog:",
     "clsx": "^2.1.1",
     "next": "^16.2.11",
-    "next-sanity": "^13.1.7",
+    "next-sanity": "^13.3.1",
     "postcss": "8.5.10",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/apps/page-builder-demo/src/components/page/Page.tsx
+++ b/apps/page-builder-demo/src/components/page/Page.tsx
@@ -3,7 +3,6 @@
 import type {SanityDocument} from '@sanity/client'
 import {useOptimistic} from '@sanity/visual-editing/react'
 
-import type {FrontPageQueryResult} from '@/sanity.types'
 import {dataAttribute} from '@/sanity/dataAttribute'
 
 import {FeaturedProducts} from './sections/FeaturedProducts'
@@ -11,9 +10,9 @@ import {FeatureHighlight} from './sections/FeatureHighlight'
 import {Hero} from './sections/Hero'
 import {Intro} from './sections/Intro'
 import {Section} from './sections/Section'
-import {PageData, PageSection} from './types'
+import {PageData, PageQueryData, PageSection} from './types'
 
-export function Page(props: {data: FrontPageQueryResult}) {
+export function Page(props: {data: PageQueryData}) {
   const {data} = props
 
   const sections = useOptimistic<PageSection[] | null | undefined, SanityDocument<PageData>>(

--- a/apps/page-builder-demo/src/components/page/Page.tsx
+++ b/apps/page-builder-demo/src/components/page/Page.tsx
@@ -2,7 +2,9 @@
 
 import type {SanityDocument} from '@sanity/client'
 import {useOptimistic} from '@sanity/visual-editing/react'
+import type {StegaBranded} from 'next-sanity'
 
+import type {FrontPageQueryResult} from '@/sanity.types'
 import {dataAttribute} from '@/sanity/dataAttribute'
 
 import {FeaturedProducts} from './sections/FeaturedProducts'
@@ -10,9 +12,9 @@ import {FeatureHighlight} from './sections/FeatureHighlight'
 import {Hero} from './sections/Hero'
 import {Intro} from './sections/Intro'
 import {Section} from './sections/Section'
-import {PageData, PageQueryData, PageSection} from './types'
+import {PageData, PageSection} from './types'
 
-export function Page(props: {data: PageQueryData}) {
+export function Page(props: {data: StegaBranded<FrontPageQueryResult>}) {
   const {data} = props
 
   const sections = useOptimistic<PageSection[] | null | undefined, SanityDocument<PageData>>(

--- a/apps/page-builder-demo/src/components/page/PageSection.tsx
+++ b/apps/page-builder-demo/src/components/page/PageSection.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import {type StegaBranded, stegaClean} from 'next-sanity'
 import {HTMLProps} from 'react'
 
 const variants: Record<'default' | 'inverted', string> = {
@@ -6,11 +7,13 @@ const variants: Record<'default' | 'inverted', string> = {
   inverted: 'bg-[#364c35] text-white dark:bg-[#b5cbb4] dark:text-black',
 }
 
-export function PageSection(props: {variant?: 'default' | 'inverted'} & HTMLProps<HTMLDivElement>) {
+export function PageSection(
+  props: {variant?: StegaBranded<'default' | 'inverted'>} & HTMLProps<HTMLDivElement>,
+) {
   const {children, className, variant = 'default', ...restProps} = props
 
   return (
-    <div {...restProps} className={clsx(className, variants[variant])}>
+    <div {...restProps} className={clsx(className, variants[stegaClean(variant)])}>
       {children}
     </div>
   )

--- a/apps/page-builder-demo/src/components/page/sections/FeatureHighlight.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/FeatureHighlight.tsx
@@ -1,14 +1,15 @@
-import {stegaClean} from 'next-sanity'
+import {type StegaBranded, stegaClean} from 'next-sanity'
 import Link from 'next/link'
 
 import {Image} from '@/components/image'
+import type {FrontPageQueryResult} from '@/sanity.types'
 import {dataAttribute} from '@/sanity/dataAttribute'
 
 import {PageSection} from '../PageSection'
-import type {FeatureHighlightSectionData, PageQueryData} from '../types'
+import type {FeatureHighlightSectionData} from '../types'
 
 export function FeatureHighlight(props: {
-  page: NonNullable<PageQueryData>
+  page: NonNullable<StegaBranded<FrontPageQueryResult>>
   section: FeatureHighlightSectionData
 }) {
   const {page: data, section} = props

--- a/apps/page-builder-demo/src/components/page/sections/FeatureHighlight.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/FeatureHighlight.tsx
@@ -2,14 +2,13 @@ import {stegaClean} from 'next-sanity'
 import Link from 'next/link'
 
 import {Image} from '@/components/image'
-import type {FrontPageQueryResult} from '@/sanity.types'
 import {dataAttribute} from '@/sanity/dataAttribute'
 
 import {PageSection} from '../PageSection'
-import type {FeatureHighlightSectionData} from '../types'
+import type {FeatureHighlightSectionData, PageQueryData} from '../types'
 
 export function FeatureHighlight(props: {
-  page: NonNullable<FrontPageQueryResult>
+  page: NonNullable<PageQueryData>
   section: FeatureHighlightSectionData
 }) {
   const {page: data, section} = props
@@ -22,7 +21,7 @@ export function FeatureHighlight(props: {
         path: `sections[_key=="${section._key}"]`,
       }).toString()}
       className=""
-      variant={section.style?.variant}
+      variant={stegaClean(section.style?.variant)}
     >
       <div className="relative w-full overflow-hidden">
         <div className="">

--- a/apps/page-builder-demo/src/components/page/sections/FeatureHighlight.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/FeatureHighlight.tsx
@@ -22,7 +22,7 @@ export function FeatureHighlight(props: {
         path: `sections[_key=="${section._key}"]`,
       }).toString()}
       className=""
-      variant={stegaClean(section.style?.variant)}
+      variant={section.style?.variant}
     >
       <div className="relative w-full overflow-hidden">
         <div className="">

--- a/apps/page-builder-demo/src/components/page/sections/FeaturedProducts.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/FeaturedProducts.tsx
@@ -1,13 +1,13 @@
 import type {SanityDocument} from '@sanity/client'
 import {useOptimistic} from '@sanity/visual-editing/react'
 import Link from 'next/link'
+import {stegaClean} from 'next-sanity'
 
 import {Image} from '@/components/image'
-import type {FrontPageQueryResult} from '@/sanity.types'
 import {dataAttribute} from '@/sanity/dataAttribute'
 
 import {PageSection} from '../PageSection'
-import {FeaturedProductsSectionData, PageData} from '../types'
+import {FeaturedProductsSectionData, PageData, PageQueryData} from '../types'
 
 function FeaturedProductsList(props: {
   id: string
@@ -63,7 +63,7 @@ function FeaturedProductsList(props: {
 }
 
 export function FeaturedProducts(props: {
-  page: NonNullable<FrontPageQueryResult>
+  page: NonNullable<PageQueryData>
   section: FeaturedProductsSectionData
 }) {
   const {page: data, section} = props
@@ -75,7 +75,7 @@ export function FeaturedProducts(props: {
         type: data._type,
         path: `sections[_key=="${section._key}"]`,
       }).toString()}
-      variant={section.style?.variant}
+      variant={stegaClean(section.style?.variant)}
     >
       <div className="flex w-full flex-col gap-4 p-4 pb-7 sm:px-5 md:flex-row md:px-6 md:pb-8">
         <div className="w-full flex-shrink-0 md:max-w-44">

--- a/apps/page-builder-demo/src/components/page/sections/FeaturedProducts.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/FeaturedProducts.tsx
@@ -1,13 +1,14 @@
 import type {SanityDocument} from '@sanity/client'
 import {useOptimistic} from '@sanity/visual-editing/react'
 import Link from 'next/link'
-import {stegaClean} from 'next-sanity'
+import {type StegaBranded, stegaClean} from 'next-sanity'
 
 import {Image} from '@/components/image'
+import type {FrontPageQueryResult} from '@/sanity.types'
 import {dataAttribute} from '@/sanity/dataAttribute'
 
 import {PageSection} from '../PageSection'
-import {FeaturedProductsSectionData, PageData, PageQueryData} from '../types'
+import {FeaturedProductsSectionData, PageData} from '../types'
 
 function FeaturedProductsList(props: {
   id: string
@@ -63,7 +64,7 @@ function FeaturedProductsList(props: {
 }
 
 export function FeaturedProducts(props: {
-  page: NonNullable<PageQueryData>
+  page: NonNullable<StegaBranded<FrontPageQueryResult>>
   section: FeaturedProductsSectionData
 }) {
   const {page: data, section} = props

--- a/apps/page-builder-demo/src/components/page/sections/FeaturedProducts.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/FeaturedProducts.tsx
@@ -1,7 +1,7 @@
 import type {SanityDocument} from '@sanity/client'
 import {useOptimistic} from '@sanity/visual-editing/react'
 import Link from 'next/link'
-import {type StegaBranded, stegaClean} from 'next-sanity'
+import type {StegaBranded} from 'next-sanity'
 
 import {Image} from '@/components/image'
 import type {FrontPageQueryResult} from '@/sanity.types'
@@ -76,7 +76,7 @@ export function FeaturedProducts(props: {
         type: data._type,
         path: `sections[_key=="${section._key}"]`,
       }).toString()}
-      variant={stegaClean(section.style?.variant)}
+      variant={section.style?.variant}
     >
       <div className="flex w-full flex-col gap-4 p-4 pb-7 sm:px-5 md:flex-row md:px-6 md:pb-8">
         <div className="w-full flex-shrink-0 md:max-w-44">

--- a/apps/page-builder-demo/src/components/page/sections/Hero.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/Hero.tsx
@@ -1,12 +1,16 @@
-import {stegaClean} from 'next-sanity'
+import {type StegaBranded, stegaClean} from 'next-sanity'
 
 import {Image} from '@/components/image'
+import type {FrontPageQueryResult} from '@/sanity.types'
 import {dataAttribute} from '@/sanity/dataAttribute'
 
 import {PageSection} from '../PageSection'
-import {HeroSectionData, PageQueryData} from '../types'
+import {HeroSectionData} from '../types'
 
-export function Hero(props: {page: NonNullable<PageQueryData>; section: HeroSectionData}) {
+export function Hero(props: {
+  page: NonNullable<StegaBranded<FrontPageQueryResult>>
+  section: HeroSectionData
+}) {
   const {page: data, section} = props
 
   return (

--- a/apps/page-builder-demo/src/components/page/sections/Hero.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/Hero.tsx
@@ -1,4 +1,4 @@
-import {type StegaBranded, stegaClean} from 'next-sanity'
+import type {StegaBranded} from 'next-sanity'
 
 import {Image} from '@/components/image'
 import type {FrontPageQueryResult} from '@/sanity.types'
@@ -22,7 +22,7 @@ export function Hero(props: {
       }).toString()}
       className="relative flex items-center justify-center px-4 py-6 sm:px-5 sm:py-7 md:px-7 md:py-9"
       style={{cursor: 'crosshair'}} // Useful for testing overlay cursor overrides
-      variant={stegaClean(section.style?.variant)}
+      variant={section.style?.variant}
     >
       <div className="relative z-10 p-5 text-center backdrop-blur-xl">
         {section.headline ? (

--- a/apps/page-builder-demo/src/components/page/sections/Hero.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/Hero.tsx
@@ -1,11 +1,12 @@
+import {stegaClean} from 'next-sanity'
+
 import {Image} from '@/components/image'
-import type {FrontPageQueryResult} from '@/sanity.types'
 import {dataAttribute} from '@/sanity/dataAttribute'
 
 import {PageSection} from '../PageSection'
-import {HeroSectionData} from '../types'
+import {HeroSectionData, PageQueryData} from '../types'
 
-export function Hero(props: {page: NonNullable<FrontPageQueryResult>; section: HeroSectionData}) {
+export function Hero(props: {page: NonNullable<PageQueryData>; section: HeroSectionData}) {
   const {page: data, section} = props
 
   return (
@@ -17,7 +18,7 @@ export function Hero(props: {page: NonNullable<FrontPageQueryResult>; section: H
       }).toString()}
       className="relative flex items-center justify-center px-4 py-6 sm:px-5 sm:py-7 md:px-7 md:py-9"
       style={{cursor: 'crosshair'}} // Useful for testing overlay cursor overrides
-      variant={section.style?.variant}
+      variant={stegaClean(section.style?.variant)}
     >
       <div className="relative z-10 p-5 text-center backdrop-blur-xl">
         {section.headline ? (

--- a/apps/page-builder-demo/src/components/page/sections/Intro.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/Intro.tsx
@@ -1,6 +1,6 @@
 import type {SanityDocument} from '@sanity/client'
 import {createDataAttribute, useOptimistic} from '@sanity/visual-editing/react'
-import {type StegaBranded, stegaClean} from 'next-sanity'
+import type {StegaBranded} from 'next-sanity'
 import {useMemo} from 'react'
 
 import type {FrontPageQueryResult} from '@/sanity.types'
@@ -65,7 +65,7 @@ export function Intro(props: {
         type: data._type,
         path: `sections[_key=="${section._key}"]`,
       }).toString()}
-      variant={stegaClean(section.style?.variant)}
+      variant={section.style?.variant}
     >
       <div className="flex w-full flex-col gap-4 p-4 pb-7 sm:px-5 md:flex-row md:px-6 md:pb-8">
         {section.headline && (

--- a/apps/page-builder-demo/src/components/page/sections/Intro.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/Intro.tsx
@@ -1,15 +1,19 @@
 import type {SanityDocument} from '@sanity/client'
 import {createDataAttribute, useOptimistic} from '@sanity/visual-editing/react'
-import {stegaClean} from 'next-sanity'
+import {type StegaBranded, stegaClean} from 'next-sanity'
 import {useMemo} from 'react'
 
+import type {FrontPageQueryResult} from '@/sanity.types'
 import {dataAttribute} from '@/sanity/dataAttribute'
 
 import {PageSection} from '../PageSection'
 import {ProductModel} from '../ProductModel'
-import {IntroSectionData, PageData, PageQueryData} from '../types'
+import {IntroSectionData, PageData} from '../types'
 
-export function Intro(props: {page: NonNullable<PageQueryData>; section: IntroSectionData}) {
+export function Intro(props: {
+  page: NonNullable<StegaBranded<FrontPageQueryResult>>
+  section: IntroSectionData
+}) {
   const {page: data, section} = props
 
   const intro = useOptimistic<string | null | undefined, SanityDocument<PageData>>(

--- a/apps/page-builder-demo/src/components/page/sections/Intro.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/Intro.tsx
@@ -1,15 +1,15 @@
 import type {SanityDocument} from '@sanity/client'
 import {createDataAttribute, useOptimistic} from '@sanity/visual-editing/react'
+import {stegaClean} from 'next-sanity'
 import {useMemo} from 'react'
 
-import type {FrontPageQueryResult} from '@/sanity.types'
 import {dataAttribute} from '@/sanity/dataAttribute'
 
 import {PageSection} from '../PageSection'
 import {ProductModel} from '../ProductModel'
-import {IntroSectionData, PageData} from '../types'
+import {IntroSectionData, PageData, PageQueryData} from '../types'
 
-export function Intro(props: {page: NonNullable<FrontPageQueryResult>; section: IntroSectionData}) {
+export function Intro(props: {page: NonNullable<PageQueryData>; section: IntroSectionData}) {
   const {page: data, section} = props
 
   const intro = useOptimistic<string | null | undefined, SanityDocument<PageData>>(
@@ -61,7 +61,7 @@ export function Intro(props: {page: NonNullable<FrontPageQueryResult>; section: 
         type: data._type,
         path: `sections[_key=="${section._key}"]`,
       }).toString()}
-      variant={section.style?.variant}
+      variant={stegaClean(section.style?.variant)}
     >
       <div className="flex w-full flex-col gap-4 p-4 pb-7 sm:px-5 md:flex-row md:px-6 md:pb-8">
         {section.headline && (

--- a/apps/page-builder-demo/src/components/page/sections/Section.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/Section.tsx
@@ -1,11 +1,10 @@
-import type {FrontPageQueryResult} from '@/sanity.types'
 import {dataAttribute} from '@/sanity/dataAttribute'
 
 import {PageSection} from '../PageSection'
-import {PageSectionData} from '../types'
+import {PageQueryData, PageSectionData} from '../types'
 
 export function Section(props: {
-  page: NonNullable<FrontPageQueryResult>
+  page: NonNullable<PageQueryData>
   section: PageSectionData
 }) {
   const {page, section} = props

--- a/apps/page-builder-demo/src/components/page/sections/Section.tsx
+++ b/apps/page-builder-demo/src/components/page/sections/Section.tsx
@@ -1,10 +1,13 @@
+import type {StegaBranded} from 'next-sanity'
+
+import type {FrontPageQueryResult} from '@/sanity.types'
 import {dataAttribute} from '@/sanity/dataAttribute'
 
 import {PageSection} from '../PageSection'
-import {PageQueryData, PageSectionData} from '../types'
+import {PageSectionData} from '../types'
 
 export function Section(props: {
-  page: NonNullable<PageQueryData>
+  page: NonNullable<StegaBranded<FrontPageQueryResult>>
   section: PageSectionData
 }) {
   const {page, section} = props

--- a/apps/page-builder-demo/src/components/page/types.ts
+++ b/apps/page-builder-demo/src/components/page/types.ts
@@ -2,9 +2,9 @@ import type {StegaBranded} from 'next-sanity'
 
 import type {FrontPageQueryResult} from '@/sanity.types'
 
-export type PageQueryData = StegaBranded<FrontPageQueryResult>
-
-export type PageSection = NonNullable<NonNullable<PageQueryData>['sections']>[number]
+export type PageSection = NonNullable<
+  NonNullable<StegaBranded<FrontPageQueryResult>>['sections']
+>[number]
 
 // @TODO can we be rid of these?
 export interface SectionStyleData {

--- a/apps/page-builder-demo/src/components/page/types.ts
+++ b/apps/page-builder-demo/src/components/page/types.ts
@@ -1,6 +1,10 @@
+import type {StegaBranded} from 'next-sanity'
+
 import type {FrontPageQueryResult} from '@/sanity.types'
 
-export type PageSection = NonNullable<NonNullable<FrontPageQueryResult>['sections']>[number]
+export type PageQueryData = StegaBranded<FrontPageQueryResult>
+
+export type PageSection = NonNullable<NonNullable<PageQueryData>['sections']>[number]
 
 // @TODO can we be rid of these?
 export interface SectionStyleData {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
         specifier: 16.3.0-preview.8
         version: 16.3.0-preview.8(@babel/core@7.29.7)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-sanity:
-        specifier: ^13.1.7
-        version: 13.2.1(3f394e24bc96434e5aa6e1e9e11d3f62)
+        specifier: ^13.3.1
+        version: 13.3.1(3f394e24bc96434e5aa6e1e9e11d3f62)
       postcss:
         specifier: ^8.5.6
         version: 8.5.10
@@ -250,8 +250,8 @@ importers:
         specifier: ^16.2.11
         version: 16.2.11(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-sanity:
-        specifier: ^13.1.7
-        version: 13.2.1(28a3c0a508146703e9ffe911c0414861)
+        specifier: ^13.3.1
+        version: 13.3.1(28a3c0a508146703e9ffe911c0414861)
       postcss:
         specifier: 8.5.10
         version: 8.5.10
@@ -340,8 +340,8 @@ importers:
         specifier: ^16.2.11
         version: 16.2.11(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-sanity:
-        specifier: ^13.1.7
-        version: 13.2.1(28a3c0a508146703e9ffe911c0414861)
+        specifier: ^13.3.1
+        version: 13.3.1(28a3c0a508146703e9ffe911c0414861)
       postcss:
         specifier: 8.5.10
         version: 8.5.10
@@ -4504,10 +4504,6 @@ packages:
     resolution: {integrity: sha512-XRsLYFNq6DhMm+Ddt+lWzV4nuARmteYAYHrrbKFzpOpt9hCBsLjWbvTELxohEzhIFNoxbVBaRcY6GDB1/ANRFw==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
-  '@sanity/presentation-comlink@2.2.3':
-    resolution: {integrity: sha512-XRsLYFNq6DhMm+Ddt+lWzV4nuARmteYAYHrrbKFzpOpt9hCBsLjWbvTELxohEzhIFNoxbVBaRcY6GDB1/ANRFw==}
-    engines: {node: '>=20.19 <22 || >=22.12'}
-
   '@sanity/prism-groq@1.1.2':
     resolution: {integrity: sha512-McMw9U5kuYAgIwyNodhFKdarM0cPme6UYBR6ms6YBNEO8Qqu5zGHydUeORaJ/w4qdFKGB1oWjBjy525ed6LXaQ==}
     peerDependencies:
@@ -8301,8 +8297,8 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  next-sanity@13.2.1:
-    resolution: {integrity: sha512-luDsMhO8cTCt3RAdnTpafqG2ZmM9GY0Kyah7QepSzzxHB2LMJM1yVwCddpVYc4mC1WUeAk3yNtaFJzR+N/Ee9Q==}
+  next-sanity@13.3.1:
+    resolution: {integrity: sha512-vT4X6qUjo3STD78Xuo4snHMbIg3hu2YR/uAhRnXw4Q1VLroMfba2h1nabW3ohs1wpoiJNm4hTeHfuYwgGvZcUg==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       '@sanity/client': ^7.26.2
@@ -14962,13 +14958,6 @@ snapshots:
       '@sanity/visual-editing-types': link:packages/visual-editing-types
       xstate: 5.32.5
 
-  '@sanity/presentation-comlink@2.2.3':
-    dependencies:
-      '@sanity/client': 7.26.2
-      '@sanity/comlink': 4.0.3
-      '@sanity/visual-editing-types': link:packages/visual-editing-types
-      xstate: 5.32.5
-
   '@sanity/prism-groq@1.1.2': {}
 
   '@sanity/runtime-cli@17.5.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(rolldown@1.2.3)(terser@5.49.0)(tsx@4.23.8)(typescript@6.0.3)(yaml@2.9.0)':
@@ -19275,7 +19264,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next-sanity@13.2.1(28a3c0a508146703e9ffe911c0414861):
+  next-sanity@13.3.1(28a3c0a508146703e9ffe911c0414861):
     dependencies:
       '@portabletext/react': 7.0.1(react@19.2.8)
       '@sanity/client': 7.26.2
@@ -19291,7 +19280,7 @@ snapshots:
       sanity: 6.9.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.8)(yaml@2.9.0)))(@sanity/sdk@2.18.0(@types/react@19.2.17)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.60.0(svelte@5.56.7(@typescript-eslint/types@8.65.0)))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.3)(styled-components@6.5.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(terser@5.49.0)(typescript@6.0.3)
       styled-components: 6.5.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
-  next-sanity@13.2.1(3f394e24bc96434e5aa6e1e9e11d3f62):
+  next-sanity@13.3.1(3f394e24bc96434e5aa6e1e9e11d3f62):
     dependencies:
       '@portabletext/react': 7.0.1(react@19.2.8)
       '@sanity/client': 7.26.2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`pnpm lint` started failing on `main` after a duplicated `@sanity/presentation-comlink@2.2.3` lockfile entry caused pnpm to ignore the lockfile and resolve `next-sanity@13.3.x`. That release brands `sanityFetch` results with `StegaBranded`, which made the page-builder demo’s page props type-check fail.

## Changes

- Bump demo apps to `next-sanity@^13.3.1`
- Wrap page props as `StegaBranded<FrontPageQueryResult>` (no intermediate alias type)
- `stegaClean()` style `variant` values before passing them into literal-union props
- Remove the duplicated presentation-comlink lockfile entries

## Test plan

- [x] `pnpm build --filter=!./apps/*`
- [x] `pnpm lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9354e96-f758-46c4-9458-15454df3336b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9354e96-f758-46c4-9458-15454df3336b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

