### PR TITLE
fix(visual-editing): prevent React 19 Suspense ref loop

### DIFF
--- a/.changeset/friendly-refs-rest.md
+++ b/.changeset/friendly-refs-rest.md
@@ -1,0 +1,5 @@
+---
+'@sanity/visual-editing': patch
+---
+
+fix: prevent a React 19 update loop when Visual Editing overlays are hidden by Suspense

--- a/packages/visual-editing/src/ui/Overlays.test.tsx
+++ b/packages/visual-editing/src/ui/Overlays.test.tsx
@@ -87,8 +87,10 @@ describe('Overlays', () => {
     await act(render)
     expect(container.textContent).toContain('Loading')
 
-    suspender.resume()
-    await act(render)
+    await act(async () => {
+      suspender.resume()
+      render()
+    })
     expect(container.childElementCount).toBeGreaterThan(0)
     expect(container.textContent).not.toContain('Loading')
   })

--- a/packages/visual-editing/src/ui/Overlays.test.tsx
+++ b/packages/visual-editing/src/ui/Overlays.test.tsx
@@ -1,0 +1,83 @@
+import {act, type ReactNode, Suspense} from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {afterAll, afterEach, beforeAll, describe, expect, test} from 'vitest'
+
+import {Overlays} from './Overlays'
+
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean
+}
+const originalActEnvironment = actEnvironment.IS_REACT_ACT_ENVIRONMENT
+
+beforeAll(() => {
+  actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+})
+
+afterAll(() => {
+  actEnvironment.IS_REACT_ACT_ENVIRONMENT = originalActEnvironment
+})
+
+function createSuspender() {
+  let suspended = false
+  let resolve: (() => void) | undefined
+  let promise: Promise<void> | undefined
+
+  return {
+    Component({children}: {children: ReactNode}) {
+      if (suspended) throw promise
+      return children
+    },
+    suspend() {
+      suspended = true
+      promise = new Promise<void>((_resolve) => {
+        resolve = _resolve
+      })
+    },
+    resume() {
+      suspended = false
+      resolve?.()
+    },
+  }
+}
+
+describe('Overlays', () => {
+  const mounted: {container: HTMLElement; root: Root}[] = []
+
+  afterEach(async () => {
+    await act(async () => {
+      for (const {container, root} of mounted) {
+        root.unmount()
+        container.remove()
+      }
+    })
+    mounted.length = 0
+  })
+
+  test('can be hidden and revealed by Suspense', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    mounted.push({container, root})
+    const suspender = createSuspender()
+
+    const render = () =>
+      root.render(
+        <Suspense fallback={<div>Loading</div>}>
+          <suspender.Component>
+            <Overlays inFrame={false} inPopUp={false} />
+          </suspender.Component>
+        </Suspense>,
+      )
+
+    await act(render)
+    expect(container.querySelector('[data-ui="Card"]')).not.toBeNull()
+
+    suspender.suspend()
+    await act(render)
+    expect(container.textContent).toContain('Loading')
+
+    suspender.resume()
+    await act(render)
+    expect(container.querySelector('[data-ui="Card"]')).not.toBeNull()
+  })
+})

--- a/packages/visual-editing/src/ui/Overlays.test.tsx
+++ b/packages/visual-editing/src/ui/Overlays.test.tsx
@@ -8,13 +8,23 @@ const actEnvironment = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean
 }
 const originalActEnvironment = actEnvironment.IS_REACT_ACT_ENVIRONMENT
+const originalFonts = Object.getOwnPropertyDescriptor(document, 'fonts')
 
 beforeAll(() => {
   actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+  Object.defineProperty(document, 'fonts', {
+    configurable: true,
+    value: {ready: Promise.resolve()},
+  })
 })
 
 afterAll(() => {
   actEnvironment.IS_REACT_ACT_ENVIRONMENT = originalActEnvironment
+  if (originalFonts) {
+    Object.defineProperty(document, 'fonts', originalFonts)
+  } else {
+    Reflect.deleteProperty(document, 'fonts')
+  }
 })
 
 function createSuspender() {

--- a/packages/visual-editing/src/ui/Overlays.test.tsx
+++ b/packages/visual-editing/src/ui/Overlays.test.tsx
@@ -1,30 +1,28 @@
 import {act, type ReactNode, Suspense} from 'react'
 import {createRoot, type Root} from 'react-dom/client'
-import {afterAll, afterEach, beforeAll, describe, expect, test} from 'vitest'
+import {afterAll, afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
 
 import {Overlays} from './Overlays'
+
+const controllerRoots = vi.hoisted(() => [] as (HTMLElement | null)[])
+vi.mock('./useController', () => ({
+  useController: (rootElement: HTMLElement | null) => {
+    controllerRoots.push(rootElement)
+    return {current: null}
+  },
+}))
 
 const actEnvironment = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean
 }
 const originalActEnvironment = actEnvironment.IS_REACT_ACT_ENVIRONMENT
-const originalFonts = Object.getOwnPropertyDescriptor(document, 'fonts')
 
 beforeAll(() => {
   actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
-  Object.defineProperty(document, 'fonts', {
-    configurable: true,
-    value: {ready: Promise.resolve()},
-  })
 })
 
 afterAll(() => {
   actEnvironment.IS_REACT_ACT_ENVIRONMENT = originalActEnvironment
-  if (originalFonts) {
-    Object.defineProperty(document, 'fonts', originalFonts)
-  } else {
-    Reflect.deleteProperty(document, 'fonts')
-  }
 })
 
 function createSuspender() {
@@ -63,6 +61,7 @@ describe('Overlays', () => {
       }
     })
     mounted.length = 0
+    controllerRoots.length = 0
   })
 
   test('can be hidden and revealed by Suspense', async () => {
@@ -84,6 +83,8 @@ describe('Overlays', () => {
     await act(render)
     expect(container.childElementCount).toBeGreaterThan(0)
     expect(container.textContent).not.toContain('Loading')
+    expect(controllerRoots.at(-1)).toBeInstanceOf(HTMLElement)
+    controllerRoots.length = 0
 
     suspender.suspend()
     await act(render)
@@ -95,5 +96,6 @@ describe('Overlays', () => {
     })
     expect(container.childElementCount).toBeGreaterThan(0)
     expect(container.textContent).not.toContain('Loading')
+    expect(controllerRoots).not.toContain(null)
   })
 })

--- a/packages/visual-editing/src/ui/Overlays.test.tsx
+++ b/packages/visual-editing/src/ui/Overlays.test.tsx
@@ -80,7 +80,8 @@ describe('Overlays', () => {
       )
 
     await act(render)
-    expect(container.querySelector('[data-ui="Card"]')).not.toBeNull()
+    expect(container.childElementCount).toBeGreaterThan(0)
+    expect(container.textContent).not.toContain('Loading')
 
     suspender.suspend()
     await act(render)
@@ -88,6 +89,7 @@ describe('Overlays', () => {
 
     suspender.resume()
     await act(render)
-    expect(container.querySelector('[data-ui="Card"]')).not.toBeNull()
+    expect(container.childElementCount).toBeGreaterThan(0)
+    expect(container.textContent).not.toContain('Loading')
   })
 })

--- a/packages/visual-editing/src/ui/Overlays.test.tsx
+++ b/packages/visual-editing/src/ui/Overlays.test.tsx
@@ -32,11 +32,13 @@ function createSuspender() {
   let resolve: (() => void) | undefined
   let promise: Promise<void> | undefined
 
+  const Component = ({children}: {children: ReactNode}) => {
+    if (suspended) throw promise
+    return children
+  }
+
   return {
-    Component({children}: {children: ReactNode}) {
-      if (suspended) throw promise
-      return children
-    },
+    Component,
     suspend() {
       suspended = true
       promise = new Promise<void>((_resolve) => {

--- a/packages/visual-editing/src/ui/Overlays.tsx
+++ b/packages/visual-editing/src/ui/Overlays.tsx
@@ -238,6 +238,11 @@ export function Overlays(props: {
     dragGroupRect: null,
   })
   const [rootElement, setRootElement] = useState<HTMLElement | null>(null)
+  const handleRootElementRef = useCallback((element: HTMLElement | null) => {
+    // React 19 detaches refs when Suspense hides a subtree. Updating state in
+    // that detach path can repeatedly hide and reveal the subtree.
+    if (element) setRootElement(element)
+  }, [])
   const [overlayEnabled, setOverlayEnabled] = useState(true)
 
   useEffect(() => {
@@ -464,7 +469,7 @@ export function Overlays(props: {
                   <Root
                     data-fading-out={fadingOut ? '' : undefined}
                     data-overlays={overlaysFlash ? '' : undefined}
-                    ref={setRootElement}
+                    ref={handleRootElementRef}
                     $zIndex={zIndex}
                   >
                     <DocumentReporter documentIds={documentIds} perspective={perspective} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- ignore the overlay root's transient `null` ref while React 19 hides a Suspense subtree
- add a regression test covering an overlay Suspense hide/reveal cycle and root state preservation
- add a patch changeset

## Testing
- `pnpm build`
- `pnpm --filter @sanity/visual-editing test --run` (28 tests, no type errors)
- `pnpm test` (16 workspace tasks)
- `pnpm lint`
- verified the regression fails with the old state-setter ref and passes with the fix

Fixes #3562
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61b27335-39fa-4d76-aa2b-bc05a0b8dac5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61b27335-39fa-4d76-aa2b-bc05a0b8dac5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

