### PR TITLE
feat(loaders): accept any @sanity/client version via SanityClientLike

### DIFF
--- a/.changeset/loose-clients-decoupled.md
+++ b/.changeset/loose-clients-decoupled.md
@@ -1,0 +1,46 @@
+---
+'@sanity/visual-editing-types': minor
+'@sanity/core-loader': minor
+'@sanity/react-loader': minor
+'@sanity/svelte-loader': minor
+'@sanity/visual-editing': minor
+---
+
+feat: accept any `@sanity/client` version in the loaders via `SanityClientLike`
+
+Options that took a client used to be typed as `SanityClient | SanityStegaClient`. `SanityClient`
+declares a `#private` field, which makes it nominal rather than structural, so a client only
+satisfied it when it came from the exact same copy of `@sanity/client`. Passing a client from a
+different major failed to typecheck, and so did a duplicate install of the same version:
+
+```
+Type 'SanityClient' is not assignable to type 'SanityClient | SanityStegaClient'.
+  Property '#private' in type 'SanityClient' refers to a different member that cannot be
+  accessed from within type 'SanityClient'.
+```
+
+These options now take `SanityClientLike`, a structural interface covering only what the loaders
+use: `config()`, `withConfig()` and `fetch()`. Any client satisfies it, from any version, including
+the ones from `@sanity/client/stega`, `@sanity/preview-kit/client` and `next-sanity`.
+
+This affects `createQueryStore({client})`, `setServerClient()`, `enableLiveMode({client})`,
+`useLiveMode({client})`, `handlePreview({client})` and `handleLoadQuery({client})`. All of them
+accept strictly more than before, so no changes are needed.
+
+For SvelteKit, `event.locals.client` still gives you the full `SanityClient` API. If your app
+resolves a different copy of `@sanity/client` than these packages do, name your own client type in
+`app.d.ts` to avoid a mismatch:
+
+```ts
+import type {SanityClient} from '@sanity/client'
+import type {LoaderLocals} from '@sanity/svelte-loader'
+
+declare global {
+  namespace App {
+    interface Locals extends LoaderLocals<SanityClient> {}
+  }
+}
+```
+
+The one narrowing is `unstable__serverClient.instance`, which is now `SanityClientLike`. It is
+marked `@internal` and prefixed `unstable__`.

--- a/.changeset/typecheck-not-inert.md
+++ b/.changeset/typecheck-not-inert.md
@@ -1,0 +1,11 @@
+---
+'@sanity/core-loader': patch
+'@sanity/svelte-loader': patch
+---
+
+fix: run vitest's typecheck against a tsconfig that actually checks the test files
+
+`typecheck.tsconfig` pointed at `tsconfig.build.json` in both packages. In `core-loader` that config
+sets `noCheck`, and in `svelte-loader` it only includes `src`, so type assertions in `test` were
+outside the program. Either way every assertion silently passed. Type errors in `src` are still
+covered by `pkg build --strict --check`.

--- a/packages/core-loader/package.json
+++ b/packages/core-loader/package.json
@@ -73,11 +73,14 @@
     "@sanity/client": "^7.26.2",
     "@sanity/comlink": "^4.0.3",
     "@sanity/presentation-comlink": "^2.2.3",
-    "@sanity/visual-editing-csm": "workspace:^"
+    "@sanity/visual-editing-csm": "workspace:^",
+    "@sanity/visual-editing-types": "workspace:^"
   },
   "devDependencies": {
     "@repo/package.config": "workspace:*",
+    "@sanity/client-v8": "npm:@sanity/client@^8.0.0",
     "@sanity/pkg-utils": "catalog:",
+    "@sanity/preview-url-secret": "workspace:^",
     "@sanity/tsconfig": "catalog:",
     "async-cache-dedupe": "2.2.0",
     "happy-dom": "^18.0.1",

--- a/packages/core-loader/src/index.ts
+++ b/packages/core-loader/src/index.ts
@@ -1,10 +1,10 @@
-import type {ClientPerspective, ContentSourceMap, QueryParams, SanityClient} from '@sanity/client'
+import type {ClientPerspective, ContentSourceMap, QueryParams} from '@sanity/client'
 import {createCache, type Cache} from 'async-cache-dedupe'
 import {atom, map, onMount, startTask, type MapStore} from 'nanostores'
 
 import {runtime} from './env'
 import {defineEnableLiveMode} from './live-mode'
-import type {EnableLiveMode, Fetcher, QueryStoreState} from './types'
+import type {EnableLiveMode, Fetcher, QueryStoreState, SanityClientLike} from './types'
 
 export type {MapStore}
 
@@ -15,14 +15,12 @@ export type {WritableAtom} from 'nanostores'
 export interface CreateQueryStoreOptions {
   /**
    * The Sanity client to use for fetching data, or `false` if `ssr: true` and it's set with `setServerClient` later
-   * You may use any client that is an `instanceof SanityClient` or `instanceof SanityStegaClient`.
    * @example `import {createClient} from '@sanity/client'`
    * @example `import {createClient} from '@sanity/client/stega'`
    * @example `import {createClient} from '@sanity/preview-kit/client'`
    * @example `import {createClient} from 'next-sanity'`
    */
-  // oxlint-disable-next-line typescript/no-deprecated
-  client: SanityClient | import('@sanity/client/stega').SanityStegaClient | false
+  client: SanityClientLike | false
   /**
    * If you want all data fetching to be done server-side in production, set this to `true` and `client: false`.
    * Then, in your server entry file, you can set the Sanity client with `setServerClient`.
@@ -51,8 +49,7 @@ export interface QueryStore {
    * When `ssr: true` you call this in your server entry point that imports the result of `createQueryStore` instance.
    * It's required to call it before any data fetching is done.
    */
-  // oxlint-disable-next-line typescript/no-deprecated
-  setServerClient: (client: SanityClient | import('@sanity/client/stega').SanityStegaClient) => void
+  setServerClient: (client: SanityClientLike) => void
   enableLiveMode: EnableLiveMode
   /** @internal */
   unstable__cache: {
@@ -68,7 +65,7 @@ export interface QueryStore {
     /**
      * Only set if `ssr: true` and `setServerClient` has been called.
      */
-    instance: SanityClient | undefined
+    instance: SanityClientLike | undefined
     /**
      * Will be `true` if the client given to `setServerClient` has a token configured.
      */
@@ -76,7 +73,7 @@ export interface QueryStore {
   }
 }
 
-function cloneClientWithConfig(newClient: SanityClient): SanityClient {
+function cloneClientWithConfig(newClient: SanityClientLike): SanityClientLike {
   return newClient.withConfig({
     allowReconfigure: false,
   })
@@ -96,9 +93,9 @@ export const createQueryStore = (options: CreateQueryStoreOptions): QueryStore =
   if (!ssr && !options.client) {
     throw new TypeError(`\`client\` is required`)
   }
-  let client = ssr ? undefined : cloneClientWithConfig(options.client as SanityClient)
+  let client = ssr || !options.client ? undefined : cloneClientWithConfig(options.client)
 
-  function createDefaultCache(client: SanityClient | undefined) {
+  function createDefaultCache(client: SanityClientLike | undefined) {
     return createCache().define('fetch', async (key: string) => {
       if (!client) {
         throw new Error(
@@ -232,7 +229,7 @@ export const createQueryStore = (options: CreateQueryStoreOptions): QueryStore =
     if (!ssr) {
       throw new Error('`setServerClient` can only be called when `ssr: true`')
     }
-    unstable__serverClient.instance = client = cloneClientWithConfig(newClient as SanityClient)
+    unstable__serverClient.instance = client = cloneClientWithConfig(newClient)
     unstable__serverClient.canPreviewDrafts = !!client.config().token
     $fetcher.set(createDefaultFetcher())
   }

--- a/packages/core-loader/src/live-mode/enableLiveMode.ts
+++ b/packages/core-loader/src/live-mode/enableLiveMode.ts
@@ -4,7 +4,6 @@ import {
   type ContentSourceMap,
   type ContentSourceMapDocuments,
   type QueryParams,
-  type SanityClient,
 } from '@sanity/client'
 import {stegaEncodeSourceMap} from '@sanity/client/stega'
 import {createNode, createNodeMachine} from '@sanity/comlink'
@@ -28,9 +27,7 @@ const LISTEN_HEARTBEAT_INTERVAL = 20_000
 export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
   const {client, setFetcher, onConnect, onDisconnect, onPerspective, onVariant} = options
   if (!client) {
-    throw new Error(
-      `Expected \`client\` to be an instance of SanityClient: ${JSON.stringify(client)}`,
-    )
+    throw new Error(`Expected \`client\` to be a Sanity client: ${JSON.stringify(client)}`)
   }
   const {projectId, dataset, perspective} = client.config()
 
@@ -91,15 +88,11 @@ export function enableLiveMode(options: LazyEnableLiveModeOptions): () => void {
       if (
         data.result !== undefined &&
         data.resultSourceMap !== undefined &&
-        (client as SanityClient).config().stega.enabled
+        client.config().stega.enabled
       ) {
         cache.set(cacheKey, {
           ...data,
-          result: stegaEncodeSourceMap(
-            data.result,
-            data.resultSourceMap,
-            (client as SanityClient).config().stega,
-          ),
+          result: stegaEncodeSourceMap(data.result, data.resultSourceMap, client.config().stega),
         })
       } else {
         cache.set(cacheKey, data)

--- a/packages/core-loader/src/types.ts
+++ b/packages/core-loader/src/types.ts
@@ -1,7 +1,13 @@
-import type {ClientPerspective, ContentSourceMap, QueryParams, SanityClient} from '@sanity/client'
+import type {ClientPerspective, ContentSourceMap, QueryParams} from '@sanity/client'
+import type {SanityClientLike} from '@sanity/visual-editing-types'
 import type {MapStore} from 'nanostores'
 
 export type {ContentSourceMap, MapStore, QueryParams}
+export type {
+  SanityClientLike,
+  SanityClientLikeConfig,
+  SanityClientLikeQueryOptions,
+} from '@sanity/visual-editing-types'
 
 /** @public */
 export interface QueryStoreState<QueryResponseResult, QueryResponseError> {
@@ -33,15 +39,13 @@ export interface EnableLiveModeOptions {
    */
   allowStudioOrigin?: 'same-origin' | `https://${string}` | `http://${string}` | string
   /**
-   * You may use any client that is an `instanceof SanityClient` or `instanceof SanityStegaClient`.
    * Required when `ssr: true`, optional otherwise.
    * @example `import {createClient} from '@sanity/client'`
    * @example `import {createClient} from '@sanity/client/stega'`
    * @example `import {createClient} from '@sanity/preview-kit/client'`
    * @example `import {createClient} from 'next-sanity'`
    */
-  // oxlint-disable-next-line typescript/no-deprecated
-  client?: SanityClient | import('@sanity/client/stega').SanityStegaClient
+  client?: SanityClientLike
   /**
    * Fires when a connection is established to a parent Studio window.
    */

--- a/packages/core-loader/test/SanityClientLike.test-d.ts
+++ b/packages/core-loader/test/SanityClientLike.test-d.ts
@@ -1,0 +1,47 @@
+import {createClient, type SanityClient} from '@sanity/client'
+// `@sanity/client-v8` is an alias for the next major of `@sanity/client`, installed alongside the
+// version this package depends on. Without a second copy in the tree these assertions are vacuous,
+// since a single copy of the client is always compatible with itself.
+import {createClient as createClientV8} from '@sanity/client-v8'
+import {createClient as createStegaClientV8} from '@sanity/client-v8/stega'
+import {createClient as createStegaClient} from '@sanity/client/stega'
+import type {SanityClientLike as PreviewUrlSecretSanityClientLike} from '@sanity/preview-url-secret'
+import {describe, expectTypeOf, test} from 'vitest'
+
+import type {SanityClientLike} from '../src'
+
+const config = {projectId: 'pv8n7t0d', dataset: 'production'}
+
+describe('SanityClientLike', () => {
+  test('is satisfied by clients from the version we depend on', () => {
+    expectTypeOf(createClient(config)).toExtend<SanityClientLike>()
+    // The stega factory is deprecated in favour of `stega` on the main client, but the option this
+    // replaces named `SanityStegaClient` explicitly, so keep covering it.
+    // oxlint-disable-next-line typescript/no-deprecated
+    expectTypeOf(createStegaClient(config)).toExtend<SanityClientLike>()
+  })
+
+  test('is satisfied by clients from a different major', () => {
+    expectTypeOf(createClientV8(config)).toExtend<SanityClientLike>()
+    // oxlint-disable-next-line typescript/no-deprecated
+    expectTypeOf(createStegaClientV8(config)).toExtend<SanityClientLike>()
+  })
+
+  test('is not the nominal `SanityClient` in disguise', () => {
+    // `SanityClient` declares a `#private` field, so requiring it is what breaks duplicate
+    // installs and cross-major usage. If this ever starts passing, the interface has been
+    // narrowed back to the class and the decoupling is gone.
+    expectTypeOf<SanityClientLike>().not.toExtend<SanityClient>()
+  })
+
+  test('rejects things that are not clients', () => {
+    expectTypeOf<Record<string, never>>().not.toExtend<SanityClientLike>()
+    expectTypeOf<{fetch: typeof globalThis.fetch}>().not.toExtend<SanityClientLike>()
+  })
+
+  test('is accepted by `validatePreviewUrl` from @sanity/preview-url-secret', () => {
+    // `handlePreview` passes a client typed as this straight to `validatePreviewUrl`, which
+    // declares its own narrower `SanityClientLike`. Keep the two compatible so it needs no cast.
+    expectTypeOf<SanityClientLike>().toExtend<PreviewUrlSecretSanityClientLike>()
+  })
+})

--- a/packages/core-loader/vitest.config.ts
+++ b/packages/core-loader/vitest.config.ts
@@ -4,7 +4,9 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     typecheck: {
-      tsconfig: 'tsconfig.build.json',
+      // Not `tsconfig.build.json`: it sets `noCheck`, which silently makes every type assertion
+      // pass. Type errors in `src` are caught by `pkg build --strict --check` instead.
+      tsconfig: 'tsconfig.json',
     },
   },
 })

--- a/packages/react-loader/package.json
+++ b/packages/react-loader/package.json
@@ -118,6 +118,8 @@
     "node": ">=18"
   },
   "inlinedDependencies": {
+    "@sanity/media-library-types": "1.6.0",
+    "@sanity/types": "6.9.2",
     "fast-deep-equal": "3.1.3"
   }
 }

--- a/packages/react-loader/src/defineStudioUrlStore.ts
+++ b/packages/react-loader/src/defineStudioUrlStore.ts
@@ -1,4 +1,3 @@
-import type {SanityClient} from '@sanity/client'
 import type {CreateQueryStoreOptions} from '@sanity/core-loader'
 
 type StudioUrlLike =
@@ -13,7 +12,7 @@ export function defineStudioUrlStore(client: CreateQueryStoreOptions['client']):
   setStudioUrl: (nextStudioUrl: StudioUrlLike) => void
 } {
   let studioUrl: StudioUrlLike =
-    typeof client === 'object' ? (client as SanityClient)?.config().stega.studioUrl : undefined
+    typeof client === 'object' ? client?.config().stega.studioUrl : undefined
   const serverSnapshot = studioUrl
   const subscribers = new Set<() => void>()
   return {

--- a/packages/react-loader/src/defineUseLiveMode.ts
+++ b/packages/react-loader/src/defineUseLiveMode.ts
@@ -1,4 +1,3 @@
-import type {SanityClient} from '@sanity/client'
 import type {QueryStore} from '@sanity/core-loader'
 import {useEffect} from 'react'
 
@@ -40,9 +39,7 @@ export function defineUseLiveMode({
     }, [allowStudioOrigin, client, onConnect, onDisconnect, onPerspective, onVariant])
     useEffect(() => {
       setStudioUrl(
-        (studioUrl ?? typeof client === 'object')
-          ? (client as SanityClient)?.config().stega.studioUrl
-          : undefined,
+        (studioUrl ?? typeof client === 'object') ? client?.config().stega.studioUrl : undefined,
       )
     }, [studioUrl, client])
   }

--- a/packages/svelte-loader/src/LiveMode.svelte
+++ b/packages/svelte-loader/src/LiveMode.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import type {SanityClient} from '@sanity/client'
+  import type {SanityClientLike} from '@sanity/core-loader'
   import {onMount} from 'svelte'
   import {useLiveMode} from './createQueryStore'
 
-  export let client: SanityClient
+  export let client: SanityClientLike
 
   onMount(() => useLiveMode({client}))
 </script>

--- a/packages/svelte-loader/src/defineStudioUrlStore.ts
+++ b/packages/svelte-loader/src/defineStudioUrlStore.ts
@@ -1,4 +1,3 @@
-import type {SanityClient} from '@sanity/client'
 import type {ResolveStudioUrl, StudioUrl} from '@sanity/client/csm'
 import type {CreateQueryStoreOptions} from '@sanity/core-loader'
 import {writable, type Writable} from 'svelte/store'
@@ -9,6 +8,6 @@ export function defineStudioUrlStore(
   client: CreateQueryStoreOptions['client'],
 ): Writable<StudioUrlLike> {
   return writable<StudioUrlLike>(
-    typeof client === 'object' ? (client as SanityClient)?.config().stega.studioUrl : undefined,
+    typeof client === 'object' ? client?.config().stega.studioUrl : undefined,
   )
 }

--- a/packages/svelte-loader/src/defineUseLiveMode.ts
+++ b/packages/svelte-loader/src/defineUseLiveMode.ts
@@ -1,4 +1,3 @@
-import type {SanityClient} from '@sanity/client'
 import type {QueryStore} from '@sanity/core-loader'
 
 import {defineStudioUrlStore} from './defineStudioUrlStore'
@@ -24,10 +23,7 @@ export function defineUseLiveMode({
     }
 
     studioUrlStore.set(
-      studioUrl ??
-        (typeof client === 'object'
-          ? (client as SanityClient)?.config().stega.studioUrl
-          : undefined),
+      studioUrl ?? (typeof client === 'object' ? client?.config().stega.studioUrl : undefined),
     )
 
     return enableLiveMode({

--- a/packages/svelte-loader/src/global.d.ts
+++ b/packages/svelte-loader/src/global.d.ts
@@ -1,7 +1,12 @@
+import {SanityClientLike} from '@sanity/core-loader'
+
 import {LoaderLocals} from './types'
 
 declare global {
   namespace App {
-    interface Locals extends LoaderLocals {}
+    // Parameterised with the structural type rather than taking the `SanityClient` default: this
+    // declaration is only for building this package, where the client may come from
+    // `unstable__serverClient`. Consumers get the default, keeping the full client API.
+    interface Locals extends LoaderLocals<SanityClientLike> {}
   }
 }

--- a/packages/svelte-loader/src/hooks.ts
+++ b/packages/svelte-loader/src/hooks.ts
@@ -1,4 +1,4 @@
-import type {SanityClient} from '@sanity/client'
+import type {SanityClientLike} from '@sanity/core-loader'
 import {handlePreview} from '@sanity/visual-editing/svelte'
 import {type Handle} from '@sveltejs/kit'
 import {sequence} from '@sveltejs/kit/hooks'
@@ -15,7 +15,7 @@ export const handleLoadQuery =
     loadQuery,
   }: {
     loadQuery?: HandleOptions['loadQuery']
-    client?: SanityClient
+    client?: SanityClientLike
   }): Handle =>
   async ({event, resolve}) => {
     const client = _client || event.locals.client

--- a/packages/svelte-loader/src/types.ts
+++ b/packages/svelte-loader/src/types.ts
@@ -10,6 +10,7 @@ import {
   createQueryStore as createCoreQueryStore,
   type EnableLiveModeOptions,
   type QueryStoreState,
+  type SanityClientLike,
 } from '@sanity/core-loader'
 import type {EncodeDataAttributeFunction} from '@sanity/core-loader/encode-data-attribute'
 import type {HandlePreviewOptions, VisualEditingLocals} from '@sanity/visual-editing/svelte'
@@ -178,10 +179,7 @@ export interface QueryStore {
     // ): QueryStoreState<QueryResponseResult, QueryResponseError>
   }
   useLiveMode: UseLiveMode
-  unstable__serverClient: {
-    instance: SanityClient | undefined
-    canPreviewDrafts?: boolean | undefined
-  }
+  unstable__serverClient: ReturnType<typeof createCoreQueryStore>['unstable__serverClient']
 }
 
 /** @public */
@@ -195,7 +193,12 @@ export interface HandleOptions {
   loadQuery?: LoadQuery
 }
 
-/** @public */
-export interface LoaderLocals extends VisualEditingLocals {
+/**
+ * See {@link VisualEditingLocals} for when to pass `TClient` explicitly.
+ * @public
+ */
+export interface LoaderLocals<
+  TClient extends SanityClientLike = SanityClient,
+> extends VisualEditingLocals<TClient> {
   loadQuery: LoadQuery
 }

--- a/packages/svelte-loader/test/locals.test-d.ts
+++ b/packages/svelte-loader/test/locals.test-d.ts
@@ -1,0 +1,28 @@
+import type {SanityClient} from '@sanity/client'
+import type {SanityClientLike} from '@sanity/core-loader'
+import {describe, expectTypeOf, test} from 'vitest'
+
+import type {LoaderLocals} from '../src/types'
+
+describe('LoaderLocals', () => {
+  test('keeps the full client API by default', () => {
+    // `handlePreview` only needs `SanityClientLike`, but narrowing `locals.client` to it would take
+    // `listen`, `getDocument` and the rest away from everyone already reading it.
+    expectTypeOf<LoaderLocals['client']>().toEqualTypeOf<SanityClient>()
+    expectTypeOf<LoaderLocals['client']['listen']>().toBeFunction()
+  })
+
+  test('can be parameterised for apps that resolve their own copy of the client', () => {
+    interface OtherCopyOfSanityClient extends SanityClientLike {
+      listen(query: string): {subscribe(): void}
+    }
+    expectTypeOf<
+      LoaderLocals<OtherCopyOfSanityClient>['client']
+    >().toEqualTypeOf<OtherCopyOfSanityClient>()
+  })
+
+  test('only accepts client types that cover what `handlePreview` uses', () => {
+    // @ts-expect-error `{}` does not satisfy the `SanityClientLike` constraint
+    expectTypeOf<LoaderLocals<Record<string, never>>>().toBeObject()
+  })
+})

--- a/packages/svelte-loader/vitest.config.ts
+++ b/packages/svelte-loader/vitest.config.ts
@@ -3,7 +3,9 @@ import {defineConfig} from 'vitest/config'
 export default defineConfig({
   test: {
     typecheck: {
-      tsconfig: 'tsconfig.build.json',
+      // Not `tsconfig.build.json`: it only includes `src`, so files under `test` are outside the
+      // program and every type assertion in them silently passes.
+      tsconfig: 'tsconfig.json',
     },
   },
 })

--- a/packages/visual-editing-types/src/index.ts
+++ b/packages/visual-editing-types/src/index.ts
@@ -1,9 +1,86 @@
+import type {
+  ClientPerspective,
+  ContentSourceMap,
+  QueryParams,
+  ResponseQueryOptions,
+} from '@sanity/client'
 import type {StudioPathLike} from '@sanity/client/csm'
+import type {InitializedStegaConfig, StegaConfig} from '@sanity/client/stega'
 import type {ArrayOptions, InsertMenuOptions, PreviewValue} from '@sanity/types'
 
 export type {InsertMenuOptions}
 
 export type {Path} from '@sanity/client/csm'
+
+/**
+ * The subset of `@sanity/client` configuration that loaders reconfigure clients with.
+ * @public
+ */
+export interface SanityClientLikeConfig {
+  allowReconfigure?: boolean
+  apiVersion?: string
+  perspective?: ClientPerspective
+  resultSourceMap?: boolean | 'withKeyArraySelector'
+  stega?: StegaConfig | boolean
+  useCdn?: boolean
+}
+
+/**
+ * The subset of `@sanity/client` query options that loaders pass to `fetch`.
+ * @public
+ */
+export type SanityClientLikeQueryOptions = Pick<
+  ResponseQueryOptions,
+  | 'cache'
+  | 'headers'
+  | 'next'
+  | 'perspective'
+  | 'resultSourceMap'
+  | 'stega'
+  | 'tag'
+  | 'useCdn'
+  | 'variant'
+>
+
+/**
+ * A structural subset of `SanityClient` describing only what loaders need: reading the
+ * configuration, cloning with a new configuration, and running queries.
+ *
+ * Prefer this over `SanityClient` in public options. `SanityClient` declares a `#private`
+ * field, which makes it nominal rather than structural, so a client is only assignable to it
+ * if it comes from the exact same copy of `@sanity/client`. Any duplicate install fails to
+ * typecheck, even at the same version, and so does passing a client from a different major.
+ *
+ * Satisfied by clients from `@sanity/client`, `@sanity/client/stega`,
+ * `@sanity/preview-kit/client` and `next-sanity`, across versions.
+ * @public
+ */
+export interface SanityClientLike {
+  config(): {
+    dataset?: string
+    perspective?: ClientPerspective
+    projectId?: string
+    stega: InitializedStegaConfig
+    token?: string
+    useCdn: boolean
+  }
+  withConfig(config: SanityClientLikeConfig): SanityClientLike
+  /**
+   * `R` defaults to `any` to match `SanityClient['fetch']`, where the same default lets callers
+   * pass the result straight into a generic position. Defaulting to `unknown` instead would be
+   * stricter than the client it stands in for, and callers cannot always name the type.
+   */
+  fetch<R = any>(
+    query: string,
+    params?: QueryParams,
+    options?: SanityClientLikeQueryOptions & {filterResponse?: true},
+  ): Promise<R>
+  fetch<R = any>(
+    query: string,
+    params: QueryParams,
+    options: SanityClientLikeQueryOptions & {filterResponse: false},
+  ): Promise<{result: R; resultSourceMap?: ContentSourceMap}>
+}
 
 /**
  * Data resolved from a Sanity node

--- a/packages/visual-editing/package.json
+++ b/packages/visual-editing/package.json
@@ -114,6 +114,7 @@
     "@sanity/types": "catalog:",
     "@sanity/ui": "catalog:",
     "@sanity/visual-editing-csm": "workspace:^",
+    "@sanity/visual-editing-types": "workspace:^",
     "@vercel/stega": "^1.1.0",
     "dequal": "^2.0.3",
     "lodash-es": "^4.18.1",

--- a/packages/visual-editing/svelte/global.d.ts
+++ b/packages/visual-editing/svelte/global.d.ts
@@ -1,7 +1,12 @@
+import {SanityClientLike} from '@sanity/visual-editing-types'
+
 import {VisualEditingLocals} from './types'
 
 declare global {
   namespace App {
-    interface Locals extends VisualEditingLocals {}
+    // Parameterised with the structural type rather than taking the `SanityClient` default: this
+    // declaration is only for building this package, where all we know about the client is what
+    // `handlePreview` was handed. Consumers get the default, keeping the full client API.
+    interface Locals extends VisualEditingLocals<SanityClientLike> {}
   }
 }

--- a/packages/visual-editing/svelte/types.ts
+++ b/packages/visual-editing/svelte/types.ts
@@ -1,5 +1,6 @@
 import type {SanityClient} from '@sanity/client'
 import type {HistoryRefresh, VisualEditingOptions} from '@sanity/visual-editing'
+import type {SanityClientLike} from '@sanity/visual-editing-types'
 
 /** @public */
 export interface VisualEditingProps extends Omit<VisualEditingOptions, 'history' | 'refresh'> {
@@ -16,9 +17,10 @@ export interface VisualEditingProps extends Omit<VisualEditingOptions, 'history'
 /** @public */
 export interface HandlePreviewOptions {
   /**
-   * The Sanity client instance for fetching data and listening to mutations
+   * The Sanity client instance to use for validating the preview URL, and to put on
+   * `event.locals.client` with the preview perspective applied
    */
-  client: SanityClient
+  client: SanityClientLike
   preview?: {
     /**
      * The preview secret to use for verifying preview access
@@ -46,8 +48,24 @@ export interface HandlePreviewOptions {
   }
 }
 
-/** @public */
-export interface VisualEditingLocals {
-  client: SanityClient
+/**
+ * `handlePreview` accepts any client shaped like `SanityClientLike`, but puts whichever one it was
+ * given on `event.locals.client`. The type parameter defaults to `SanityClient` so the full client
+ * API stays available. If your app resolves a different copy of `@sanity/client` than this package
+ * does, pass your own client type to avoid a mismatch:
+ * @example
+ * ```ts
+ * import type {SanityClient} from '@sanity/client'
+ *
+ * declare global {
+ *   namespace App {
+ *     interface Locals extends VisualEditingLocals<SanityClient> {}
+ *   }
+ * }
+ * ```
+ * @public
+ */
+export interface VisualEditingLocals<TClient extends SanityClientLike = SanityClient> {
+  client: TClient
   preview: boolean
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -538,13 +538,22 @@ importers:
       '@sanity/visual-editing-csm':
         specifier: workspace:*
         version: link:../visual-editing-csm
+      '@sanity/visual-editing-types':
+        specifier: workspace:^
+        version: link:../visual-editing-types
     devDependencies:
       '@repo/package.config':
         specifier: workspace:*
         version: link:../@repo/package.config
+      '@sanity/client-v8':
+        specifier: npm:@sanity/client@^8.0.0
+        version: '@sanity/client@8.0.0(vitest@3.2.7(@types/node@24.13.3)(happy-dom@18.0.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.3.0))(lightningcss@1.33.0)(tsx@4.23.12)(yaml@2.9.0))'
       '@sanity/pkg-utils':
         specifier: 'catalog:'
         version: 12.1.2(@tsdown/css@0.22.14)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.24.2)(typescript@6.0.3)(unrun@0.3.1)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@sanity/preview-url-secret':
+        specifier: workspace:*
+        version: link:../preview-url-secret
       '@sanity/tsconfig':
         specifier: 'catalog:'
         version: 2.2.1
@@ -695,6 +704,9 @@ importers:
       '@sanity/visual-editing-csm':
         specifier: workspace:*
         version: link:../visual-editing-csm
+      '@sanity/visual-editing-types':
+        specifier: workspace:^
+        version: link:../visual-editing-types
       '@vercel/stega':
         specifier: ^1.1.0
         version: 1.1.0
@@ -3968,6 +3980,10 @@ packages:
     resolution: {integrity: sha512-iEkGiHbrxCnT/A30A6pH+vX4otP3lLp935Vwuv0/YrnETxrKCn6PnsZU+TfTm6ZEZ9kZGs8wKP5yBLmZw5S6OQ==}
     engines: {node: '>=20'}
 
+  '@sanity/client@8.0.0':
+    resolution: {integrity: sha512-PL2zaAkTz8fL93cEFNsmLFmaFl0/xyslnA3pdYXegdP9v1A+GRwXV3delEPaNmRn520CCDAnCrB7Bz3D//uyQQ==}
+    engines: {node: '>=22.12.0'}
+
   '@sanity/codegen@7.0.3':
     resolution: {integrity: sha512-t3Svo28RWX7OOvj4DkNX0fSWpzt+94pslKwvkKhSs4Lw24Ta1hYkE1a+OgwUjKBbw2Za54V7NpMwNlXjPEr2Fw==}
     engines: {node: '>=20.19 <22 || >=22.12'}
@@ -6314,6 +6330,10 @@ packages:
     resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
     engines: {node: '>=18.0.0'}
 
+  eventsource-parser@4.0.0:
+    resolution: {integrity: sha512-aIpvYxbqTx4KYWw73KpCt1Rh22tEAJ144F1qR76CT3Ex+LNMEPKf5HFrK5Yz9fMP1EVT0GrfA35VZvWQhMPuSQ==}
+    engines: {node: '>=22.12'}
+
   eventsource@2.0.2:
     resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
     engines: {node: '>=12.0.0'}
@@ -6321,6 +6341,10 @@ packages:
   eventsource@4.1.1:
     resolution: {integrity: sha512-D6bTRWh6KahHTK/m4WnjPQyEinNPf9eFLEZSEoj7d6fTibspnAVYfzHvirL7u/aoX5d9YYfIkBVAhmigUELk9w==}
     engines: {node: '>=20.0.0'}
+
+  eventsource@5.0.0:
+    resolution: {integrity: sha512-iNd5IgeR56Om1Aje0ACZTd5oRQ+u5i6RfRkKdIuhlykeH3o+f0vIiiT0i9t1SXABfTnsfxVPadAB2T4cLS32Sw==}
+    engines: {node: '>=22.12.0'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -6543,6 +6567,15 @@ packages:
   get-it@8.8.3:
     resolution: {integrity: sha512-IfkbWqOGO2kd2Ccgiz/NIzk3bcwjtVqBm3RNa3j/veHg2q7c1DgS3EXrCrvIWH0jbNTbhkdblnxBP7Dm8CiH+A==}
     engines: {node: '>=14.0.0'}
+
+  get-it@9.4.1:
+    resolution: {integrity: sha512-WEYs8b65nMYdYvbi0AwlyfRWrnkto1xLG1YqxFGKrU4yb7Vd06ryIS5XAFrBgRnYwsoszsZEsUGimQMQE7ztVA==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      vitest: '>=2.0.0'
+    peerDependenciesMeta:
+      vitest:
+        optional: true
 
   get-json@1.1.0:
     resolution: {integrity: sha512-IjoEwpXyyEsRtwBSZ0SYA6By6oVBnakpftFHAAkSSlLYRZ1NPGFS/r+6fSgbk7t6njfEuYVMbD1pe4ex6vgLcw==}
@@ -13003,6 +13036,16 @@ snapshots:
       nanoid: 3.3.18
       rxjs: 7.8.2
 
+  '@sanity/client@8.0.0(vitest@3.2.7(@types/node@24.13.3)(happy-dom@18.0.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.3.0))(lightningcss@1.33.0)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      eventsource: 5.0.0
+      get-it: 9.4.1(vitest@3.2.7(@types/node@24.13.3)(happy-dom@18.0.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.3.0))(lightningcss@1.33.0)(tsx@4.23.12)(yaml@2.9.0))
+      nanoid: 6.0.1
+      obug: 2.1.4
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - vitest
+
   '@sanity/codegen@7.0.3(@oclif/core@4.13.3)(@sanity/cli-core@2.8.1(@noble/hashes@2.3.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.2)(yaml@2.9.0))(oxfmt@0.63.0(svelte@5.56.9(@typescript-eslint/types@8.67.0)))(react@19.2.8)':
     dependencies:
       '@babel/core': 7.29.7
@@ -16079,11 +16122,17 @@ snapshots:
 
   eventsource-parser@3.1.1: {}
 
+  eventsource-parser@4.0.0: {}
+
   eventsource@2.0.2: {}
 
   eventsource@4.1.1:
     dependencies:
       eventsource-parser: 3.1.1
+
+  eventsource@5.0.0:
+    dependencies:
+      eventsource-parser: 4.0.0
 
   execa@5.1.1:
     dependencies:
@@ -16332,6 +16381,12 @@ snapshots:
       is-retry-allowed: 2.2.0
       through2: 4.0.2
       tunnel-agent: 0.6.0
+
+  get-it@9.4.1(vitest@3.2.7(@types/node@24.13.3)(happy-dom@18.0.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.3.0))(lightningcss@1.33.0)(tsx@4.23.12)(yaml@2.9.0)):
+    dependencies:
+      undici: 7.29.0
+    optionalDependencies:
+      vitest: 3.2.7(@types/node@24.13.3)(happy-dom@18.0.1)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.3.0))(lightningcss@1.33.0)(tsx@4.23.12)(yaml@2.9.0)
 
   get-json@1.1.0:
     dependencies:


### PR DESCRIPTION
## The problem

Loader options that take a client were typed as `SanityClient | SanityStegaClient`. That breaks when the app resolves a different `@sanity/client` than the loaders do:

```
error TS2322: Type 'SanityClient' is not assignable to type 'SanityClient | SanityStegaClient'.
  Property '#private' in type 'SanityClient' refers to a different member
  that cannot be accessed from within type 'SanityClient'.
```

The cause is not the v7 to v8 changes. `SanityClient` declares a `#private` field, which makes it **nominal** rather than structural, so a client only satisfies it when it comes from the exact same copy of the package. A duplicate install of the *same* version fails too. The v7/v8 config diffs (`requester` moving into `InitializedClientConfig`, `resolveFetch` replacing `_requestHandler`) are just extra fuel.

The methods the loaders actually use are unchanged: `fetch`, `config` and `withConfig` are byte-identical between v7.26.2 and v8.0.0, which is why one interface can serve both.

## The change

`SanityClientLike` in `@sanity/visual-editing-types`, covering only what the loaders need, re-exported from `@sanity/core-loader` so the react and svelte loaders pick it up through their existing `export type * from`:

```ts
export interface SanityClientLike {
  config(): {
    dataset?: string
    perspective?: ClientPerspective
    projectId?: string
    stega: InitializedStegaConfig
    token?: string
    useCdn: boolean
  }
  withConfig(config: SanityClientLikeConfig): SanityClientLike
  fetch<R = any>(query: string, params?: QueryParams, options?: /* filtered */): Promise<R>
  fetch<R = any>(query: string, params: QueryParams, options: /* unfiltered */): Promise<{result: R; resultSourceMap?: ContentSourceMap}>
}
```

Notes on the shape:

- Query options are `Pick<ResponseQueryOptions, ...>` rather than hand-written fields, so they track the real client instead of drifting from it.
- `config().stega` stays `InitializedStegaConfig`, which is what lets `enableLiveMode` pass it straight into `stegaEncodeSourceMap`. Safe because `StegaConfig` is structurally identical across majors and carries no private brand.
- Both `fetch` overloads are needed: the loaders use `filterResponse: false`, and `preview-url-secret`'s `validatePreviewUrl` uses the plain form.
- `R` defaults to `any` to match `SanityClient['fetch']`. Defaulting to `unknown` is stricter than the client it stands in for and breaks callers who cannot name the type.

It lives in `visual-editing-types` because that is the only existing package reachable from both sides: `core-loader` and `visual-editing` already pull it in transitively via `visual-editing-csm`.

Eight `as SanityClient` casts became unnecessary and are gone.

## Not a breaking change

Every option accepts strictly more than before: `createQueryStore({client})`, `setServerClient()`, `enableLiveMode({client})`, `useLiveMode({client})`, `handlePreview({client})`, `handleLoadQuery({client})`.

For SvelteKit, `event.locals.client` keeps the full `SanityClient` API:

```ts
export interface VisualEditingLocals<TClient extends SanityClientLike = SanityClient> {
  client: TClient
  preview: boolean
}
```

The default keeps `.listen()`, `.getDocument()` and the rest available to everyone already reading it. Our own `global.d.ts` stubs parameterise it with `SanityClientLike`, which is what lets `handlePreview` assign internally without a cast. Apps that resolve their own copy of `@sanity/client` name it explicitly in `app.d.ts`:

```ts
declare global {
  namespace App {
    interface Locals extends LoaderLocals<SanityClient> {}
  }
}
```

The one narrowing is `unstable__serverClient.instance`, now `SanityClientLike`. Leaving it as the nominal class would have recreated the bug in a different spot, since it holds a client the caller handed us. It is marked `@internal` and prefixed `unstable__`.

## Tests

`packages/core-loader/test/SanityClientLike.test-d.ts` installs `@sanity/client@8` under an alias as a devDep so the cross-major case is genuinely reproduced. Without a second copy in the tree the assertions would be vacuous, since one copy is always compatible with itself. It covers:

- clients from both majors, plain and stega, satisfy the interface
- the interface is accepted by `validatePreviewUrl`, which `handlePreview` calls
- the interface has not been quietly narrowed back to the nominal class
- non-clients are still rejected

`packages/svelte-loader/test/locals.test-d.ts` covers the locals default and the escape hatch.

## Also in here: the typecheck was inert

`typecheck.tsconfig` pointed at `tsconfig.build.json` in both packages. In `core-loader` that sets `noCheck`; in `svelte-loader` it only includes `src`, so files under `test` were outside the program. Either way every type assertion silently passed, including the new ones. Confirmed by asserting `expectTypeOf<string>().toEqualTypeOf<number>()` and watching it pass. Both now point at `tsconfig.json`, and each was verified to fail on a deliberate bad assertion before being trusted.

That flushed out a real bug in this PR: with no default on `R`, it fell back to `unknown` and broke the internal cache typing in `core-loader/src/index.ts`. Hence the `= any` above.

**Still inert, not fixed here:** `react-loader`'s existing `test/createQueryStore/universal.test-d.ts` and all of `visual-editing`'s tests, for the same two reasons. Turning them on risks surfacing a pile of unrelated pre-existing errors, so it is left for a follow-up, but they currently guard nothing.

## Out of scope

- `visual-editing/src/optimistic/*` keeps `SanityClient`. It uses `transaction`, `mutate` and `listen` and wants the real thing.
- `preview-url-secret`'s own narrower `SanityClientLike` is untouched. Its need is genuinely smaller, and widening it would break anyone passing a hand-rolled object. A type test locks the one-way compatibility instead.
- `packages/visual-editing-standalone/package.json` has a one-line `@sanity/ui` 4.0.1 to 4.0.2 change that the build regenerated. Drift from the recent `@sanity/ui` bump, unrelated to this work. Happy to drop it.
- Noticed but not changed: `defineUseLiveMode` in both loaders does `(studioUrl ?? typeof client === 'object') ? client?.config().stega.studioUrl : undefined`, which ignores an explicitly passed `studioUrl` whenever it is truthy. Looks like it was meant to be `studioUrl ?? (typeof client === 'object' ? ... : undefined)`. Only the cast was removed.
