### PR TITLE
feat(visual-editing-standalone): add onVariantChange

### DIFF
--- a/.changeset/standalone-on-variant-change.md
+++ b/.changeset/standalone-on-variant-change.md
@@ -1,0 +1,5 @@
+---
+'@sanity/visual-editing-standalone': minor
+---
+
+Add `onVariantChange` to `enableVisualEditing` options, matching `@sanity/visual-editing`, so non-React apps can persist the Studio editing variant for server-side fetches.

--- a/packages/visual-editing-standalone/src/enableVisualEditing.ts
+++ b/packages/visual-editing-standalone/src/enableVisualEditing.ts
@@ -34,6 +34,12 @@ export interface VisualEditingOptions {
    */
   onPerspectiveChange?: (perspective: ClientPerspective) => void
   /**
+   * Fires when the editing variant changes in the Studio, with the bare variant id,
+   * or undefined when the variant is cleared. Allows persisting the change to a
+   * session cookie so server-side fetches can apply it.
+   */
+  onVariantChange?: (variant: string | undefined) => void
+  /**
    * Reports stega payloads found in places where they always cause bugs or bloat.
    */
   onSuspiciousStega?: (reports: SuspiciousStegaReport[]) => void

--- a/packages/visual-editing-standalone/src/index.test.ts
+++ b/packages/visual-editing-standalone/src/index.test.ts
@@ -33,6 +33,9 @@ test('preserves the source package implementations and types', () => {
   expectTypeOf<ReturnType<typeof standalone.enableVisualEditing>>().toEqualTypeOf<
     ReturnType<typeof enableVisualEditingSource>
   >()
+  expectTypeOf<
+    NonNullable<Parameters<typeof standalone.enableVisualEditing>[0]>['onVariantChange']
+  >().toEqualTypeOf<((variant: string | undefined) => void) | undefined>()
 })
 
 test('creates data attributes through the standalone entry point', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`@sanity/visual-editing` already accepts `onVariantChange` (added in #3500) so apps can persist the Studio editing variant for server-side fetches. The standalone package redefines `VisualEditingOptions` without React-only `components`/`plugins`, and that copy was missing the callback.

`enableVisualEditing()` already forwards its options object to the source implementation, so this is a type-level addition: standalone consumers can now pass `onVariantChange` the same way they pass `onPerspectiveChange`.

## Changes

- Add `onVariantChange?: (variant: string | undefined) => void` to standalone `VisualEditingOptions`
- Assert the option’s type in the standalone package tests
- Minor changeset for `@sanity/visual-editing-standalone`

## Test plan

- [x] `pnpm turbo run test --filter=@sanity/visual-editing-standalone` (4 tests passed, no type errors)
- [x] Lint the changed files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0063b6b1-fc3a-422b-be99-2fedc2a75604?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0063b6b1-fc3a-422b-be99-2fedc2a75604&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

