### PR TITLE
Keep visual editing overlay labels on-screen with CSS anchor positioning

### DIFF
--- a/.changeset/overlay-css-anchor-labels.md
+++ b/.changeset/overlay-css-anchor-labels.md
@@ -1,0 +1,8 @@
+---
+'@sanity/visual-editing': patch
+'@sanity/visual-editing-standalone': patch
+---
+
+Keep visual editing overlay labels on-screen while the preview scrolls by positioning them with CSS anchor positioning when the browser supports it.
+
+Browsers without `anchor-name` / `position-try-fallbacks` keep the previous IntersectionObserver flip above/below the overlay.

--- a/packages/visual-editing/src/ui/ElementOverlay.test.tsx
+++ b/packages/visual-editing/src/ui/ElementOverlay.test.tsx
@@ -1,0 +1,175 @@
+import {studioTheme, ThemeProvider} from '@sanity/ui'
+import {act, type ReactNode} from 'react'
+import {createRoot, type Root} from 'react-dom/client'
+import {afterAll, afterEach, beforeAll, describe, expect, test, vi} from 'vitest'
+
+import type {SanityNode} from '../types'
+import {ElementOverlay} from './ElementOverlay'
+import {
+  PreviewSnapshotsContext,
+  type PreviewSnapshotsContextValue,
+} from './preview/PreviewSnapshotsContext'
+import {SchemaContext, type SchemaContextValue} from './schema/SchemaContext'
+
+const {supportsCssAnchorPositioningMock} = vi.hoisted(() => ({
+  supportsCssAnchorPositioningMock: vi.fn(() => false),
+}))
+
+vi.mock('./cssAnchorPositioning', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./cssAnchorPositioning')>()
+  return {
+    ...actual,
+    supportsCssAnchorPositioning: supportsCssAnchorPositioningMock,
+  }
+})
+
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean
+}
+const originalActEnvironment = actEnvironment.IS_REACT_ACT_ENVIRONMENT
+
+beforeAll(() => {
+  actEnvironment.IS_REACT_ACT_ENVIRONMENT = true
+})
+
+afterAll(() => {
+  actEnvironment.IS_REACT_ACT_ENVIRONMENT = originalActEnvironment
+})
+
+const schemaValue: SchemaContextValue = {
+  getField: () => ({field: undefined, parent: undefined}),
+  getType: () => undefined,
+}
+
+const node: SanityNode = {
+  id: 'doc',
+  baseUrl: '/studio',
+  path: 'title',
+  type: 'page',
+}
+
+const emptyPreviewSnapshots: PreviewSnapshotsContextValue = []
+
+function Wrapper({children}: {children: ReactNode}) {
+  return (
+    <ThemeProvider
+      // oxlint-disable-next-line typescript/no-deprecated
+      theme={studioTheme}
+      scheme="light"
+    >
+      <SchemaContext.Provider value={schemaValue}>
+        <PreviewSnapshotsContext.Provider value={emptyPreviewSnapshots}>
+          {children}
+        </PreviewSnapshotsContext.Provider>
+      </SchemaContext.Provider>
+    </ThemeProvider>
+  )
+}
+
+describe('ElementOverlay', () => {
+  const mounted: {container: HTMLElement; root: Root}[] = []
+  const observers: {observe: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn>}[] = []
+  let ioCallback: IntersectionObserverCallback | undefined
+
+  beforeAll(() => {
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        observe = vi.fn()
+        disconnect = vi.fn()
+        unobserve = vi.fn()
+        constructor(callback: IntersectionObserverCallback) {
+          ioCallback = callback
+          observers.push(this)
+        }
+      },
+    )
+  })
+
+  afterAll(() => {
+    vi.unstubAllGlobals()
+  })
+
+  afterEach(async () => {
+    await act(async () => {
+      for (const {container, root} of mounted) {
+        root.unmount()
+        container.remove()
+      }
+    })
+    mounted.length = 0
+    observers.length = 0
+    ioCallback = undefined
+    supportsCssAnchorPositioningMock.mockReturnValue(false)
+  })
+
+  async function renderOverlay(hovered = true) {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    mounted.push({container, root})
+
+    await act(async () => {
+      root.render(
+        <Wrapper>
+          <ElementOverlay
+            inFrame={false}
+            id="overlay-1"
+            draggable={false}
+            element={document.createElement('div')}
+            focused={false}
+            hovered={hovered}
+            isDragging={false}
+            node={node}
+            rect={{x: 10, y: 20, w: 100, h: 50}}
+            showActions={false}
+            wasMaybeCollapsed={false}
+            enableScrollIntoView={false}
+            targets={[]}
+            elementType="element"
+          />
+        </Wrapper>,
+      )
+    })
+
+    return container
+  }
+
+  test('positions the overlay box with top/left so fixed labels can use the viewport', async () => {
+    const container = await renderOverlay(false)
+    const overlay = container.querySelector('[data-ui="Card"]') as HTMLElement | null
+    expect(overlay).toBeTruthy()
+    expect(overlay?.style.top).toBe('20px')
+    expect(overlay?.style.left).toBe('10px')
+    expect(overlay?.style.width).toBe('100px')
+    expect(overlay?.style.height).toBe('50px')
+    expect(overlay?.style.transform).toBe('')
+  })
+
+  test('falls back to IntersectionObserver flipping when CSS anchor positioning is unavailable', async () => {
+    const container = await renderOverlay(true)
+    expect(observers).toHaveLength(1)
+    expect(observers[0]?.observe).toHaveBeenCalled()
+
+    await act(async () => {
+      ioCallback?.(
+        [
+          {
+            boundingClientRect: {top: -8} as DOMRectReadOnly,
+          } as IntersectionObserverEntry,
+        ],
+        observers[0] as unknown as IntersectionObserver,
+      )
+    })
+
+    const overlay = container.querySelector('[data-hovered]') as HTMLElement | null
+    expect(overlay?.hasAttribute('data-flipped')).toBe(true)
+  })
+
+  test('skips the IntersectionObserver fallback when CSS anchor positioning is supported', async () => {
+    supportsCssAnchorPositioningMock.mockReturnValue(true)
+    const container = await renderOverlay(true)
+    expect(observers).toHaveLength(0)
+    expect(container.querySelector('[data-hovered]')?.hasAttribute('data-flipped')).toBe(false)
+  })
+})

--- a/packages/visual-editing/src/ui/ElementOverlay.tsx
+++ b/packages/visual-editing/src/ui/ElementOverlay.tsx
@@ -24,7 +24,7 @@ import {
   type ReactElement,
 } from 'react'
 import scrollIntoView from 'scroll-into-view-if-needed'
-import {styled} from 'styled-components'
+import {css, styled} from 'styled-components'
 import {v4 as uuid} from 'uuid'
 
 import {PointerEvents} from '../overlay-components/components/PointerEvents'
@@ -44,6 +44,7 @@ import type {
   VisualEditingNode,
 } from '../types'
 import {getLinkHref} from '../util/getLinkHref'
+import {CSS_ANCHOR_POSITIONING_SUPPORTS, supportsCssAnchorPositioning} from './cssAnchorPositioning'
 import {PopoverBackground} from './PopoverPortal'
 import {usePreviewSnapshots} from './preview/usePreviewSnapshots'
 import {useSchema} from './schema/useSchema'
@@ -83,14 +84,35 @@ export interface ElementOverlayProps {
   onMenuOpenChange: (open: boolean) => void
 }
 
+/**
+ * Shared CSS-anchor chrome: `position: fixed` so overflow fallbacks are
+ * measured against the preview iframe/viewport, not this overlay box.
+ * Requires no `transform`/`will-change: transform` on ancestors (those would
+ * make `fixed` descendants use the overlay as their containing block).
+ */
+const overlayChromeAnchorPositioning = (insets: ReturnType<typeof css>) => css`
+  @supports ${CSS_ANCHOR_POSITIONING_SUPPORTS} {
+    position: fixed;
+    position-anchor: --sanity-ve-overlay;
+    inset: auto;
+    ${insets}
+    position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;
+    position-try: flip-block, flip-inline, flip-block flip-inline;
+  }
+`
+
 const Root = styled(Card)`
   background-color: var(--overlay-bg);
   border-radius: 3px;
   pointer-events: none;
   position: absolute;
-  will-change: transform;
+  overflow: visible;
   box-shadow: var(--overlay-box-shadow);
   transition: none;
+
+  /* Scoped so each overlay's labels bind to this box, not the last overlay on the page. */
+  anchor-name: --sanity-ve-overlay;
+  anchor-scope: --sanity-ve-overlay;
 
   --overlay-bg: transparent;
   --overlay-box-shadow: inset 0 0 0 1px transparent;
@@ -143,6 +165,11 @@ const Actions = styled(Flex)`
     bottom: auto;
     top: 100%;
   }
+
+  ${overlayChromeAnchorPositioning(css`
+    bottom: anchor(top);
+    right: anchor(right);
+  `)}
 `
 
 const HUD = styled(Flex)`
@@ -163,6 +190,11 @@ const HUD = styled(Flex)`
   [data-flipped] & {
     top: calc(100% + 2rem);
   }
+
+  ${overlayChromeAnchorPositioning(css`
+    top: anchor(bottom);
+    left: anchor(left);
+  `)}
 `
 
 const MenuWrapper = styled(Flex)`
@@ -188,6 +220,11 @@ const Tab = styled(Flex)`
     bottom: auto;
     top: 100%;
   }
+
+  ${overlayChromeAnchorPositioning(css`
+    bottom: anchor(top);
+    left: anchor(left);
+  `)}
 `
 
 const ActionOpen = styled(Card)`
@@ -487,7 +524,8 @@ export const ElementOverlay = memo(function ElementOverlay(
     () => ({
       width: `${rect.w}px`,
       height: `${rect.h}px`,
-      transform: `translate(${rect.x}px, ${rect.y}px)`,
+      top: `${rect.y}px`,
+      left: `${rect.x}px`,
     }),
     [rect],
   )
@@ -526,7 +564,13 @@ export const ElementOverlay = memo(function ElementOverlay(
 
   const [isNearTop, setIsNearTop] = useState(false)
   useEffect(() => {
-    if (!ref.current || !hovered) return undefined
+    // CSS anchor positioning flips chrome against the viewport as the preview
+    // scrolls; the IntersectionObserver heuristic is only a fallback.
+    if (supportsCssAnchorPositioning()) return undefined
+    if (!ref.current || !hovered) {
+      setIsNearTop(false)
+      return undefined
+    }
 
     const io = new IntersectionObserver(
       ([intersection]) => {
@@ -536,7 +580,7 @@ export const ElementOverlay = memo(function ElementOverlay(
     )
     io.observe(ref.current)
     return () => io.disconnect()
-  }, [hovered, isNearTop])
+  }, [hovered])
 
   const [activeExclusivePlugin, setActiveExclusivePlugin] = useState<{
     plugin: OverlayPluginExclusiveDefinition

--- a/packages/visual-editing/src/ui/__tests__/cssAnchorPositioning.test.ts
+++ b/packages/visual-editing/src/ui/__tests__/cssAnchorPositioning.test.ts
@@ -1,0 +1,24 @@
+import {describe, expect, test} from 'vitest'
+
+import {
+  CSS_ANCHOR_POSITIONING_SUPPORTS,
+  supportsCssAnchorPositioning,
+} from '../cssAnchorPositioning'
+
+describe('supportsCssAnchorPositioning', () => {
+  test('is true only when CSS.supports reports anchors and try-fallbacks', () => {
+    expect(supportsCssAnchorPositioning(() => true)).toBe(true)
+    expect(supportsCssAnchorPositioning(() => false)).toBe(false)
+  })
+
+  test('asks CSS.supports with the same query the overlay chrome @supports rule uses', () => {
+    const supportsFn = (conditionText: string) => {
+      expect(conditionText).toBe(CSS_ANCHOR_POSITIONING_SUPPORTS)
+      return true
+    }
+
+    expect(supportsCssAnchorPositioning(supportsFn)).toBe(true)
+    expect(CSS_ANCHOR_POSITIONING_SUPPORTS).toContain('anchor-name: --sanity-ve-overlay')
+    expect(CSS_ANCHOR_POSITIONING_SUPPORTS).toContain('position-try-fallbacks: flip-block')
+  })
+})

--- a/packages/visual-editing/src/ui/cssAnchorPositioning.ts
+++ b/packages/visual-editing/src/ui/cssAnchorPositioning.ts
@@ -1,0 +1,21 @@
+/**
+ * Feature-detection query for CSS anchor positioning plus overflow fallbacks.
+ *
+ * Overlay chrome (title labels, "Open in Studio", HUD) uses this as progressive
+ * enhancement: browsers that match keep labels on-screen while the preview
+ * iframe scrolls, without the IntersectionObserver flip heuristic.
+ *
+ * Both conditions are required. `anchor-name` alone would tether labels but
+ * would not flip them away from the viewport edge.
+ */
+export const CSS_ANCHOR_POSITIONING_SUPPORTS =
+  '(anchor-name: --sanity-ve-overlay) and (position-try-fallbacks: flip-block)'
+
+/** @internal */
+export function supportsCssAnchorPositioning(
+  supportsFn: ((conditionText: string) => boolean) | undefined = globalThis.CSS?.supports?.bind(
+    globalThis.CSS,
+  ),
+): boolean {
+  return supportsFn?.(CSS_ANCHOR_POSITIONING_SUPPORTS) === true
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Overlay title labels, “Open in Studio”, and HUD chips sit outside the highlighted box (`bottom: 100%` / `top: 100%`). While the preview iframe scrolls, those labels often leave the visible viewport.

The previous fix only flipped chrome when an IntersectionObserver saw the overlay’s **top** go above the viewport (`boundingClientRect.top < 0`). That misses the common case where the overlay is still fully on-screen (for example a navbar at `y = 0`) but the label above it is not, and it does not handle left/right overflow.

## What

Progressive enhancement with [CSS anchor positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Anchor_positioning/Using):

- Each overlay box is an `anchor-name` / `anchor-scope` so labels bind to **that** overlay, not the last one on the page.
- Labels, “Open in Studio”, and HUD use `position: fixed` + `anchor()` insets + `position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline` inside `@supports (anchor-name: --sanity-ve-overlay) and (position-try-fallbacks: flip-block)`.
- `position: fixed` is required so overflow fallbacks are measured against the **preview iframe/viewport**, not the overlay box itself.
- The overlay box is placed with `top`/`left` instead of `transform`, and `will-change: transform` is removed. A transformed ancestor would make `position: fixed` descendants use the overlay as their containing block, which would defeat flipping.

Browsers without those CSS features keep the existing IntersectionObserver above/below flip.

## How to verify

1. `pnpm storybook:visual-editing` (or `pnpm storybook` in `packages/visual-editing`).
2. Open the Overlays → Marketing Page story.
3. Hover encoded fields near the top, then scroll so the highlight reaches the top and sides of the preview — the label should stay on-screen (flip below / to the other inline side) in Chromium and Safari that implement CSS anchor positioning.
4. In a browser without `position-try-fallbacks`, labels should still flip below when the overlay top crosses the viewport, as before.

Unit tests cover feature detection, `top`/`left` placement, the IntersectionObserver fallback, and skipping that observer when CSS anchors are supported.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de7d013f-c1a6-4660-945f-0c2bd49babda?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de7d013f-c1a6-4660-945f-0c2bd49babda&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

