### PR TITLE
feat(visual-editing-standalone)!: require importing the stylesheet, exported as ./styles.css

### DIFF
--- a/.changeset/standalone-require-styles-css.md
+++ b/.changeset/standalone-require-styles-css.md
@@ -1,0 +1,24 @@
+---
+'@sanity/visual-editing-standalone': major
+---
+
+feat!: require importing the stylesheet, now exported as `./styles.css`
+
+The published JS no longer references the overlays' static stylesheet at all. Both automatic wirings shipped so far broke native ESM consumers: the relative `import './style.css'` of 1.1.0 and the self-referential `import '@sanity/visual-editing-standalone/style.css'` of 1.2.0 were each externalized by esm.sh's build to a `style.css.mjs` URL that redirects to the raw `text/css` file, which browsers refuse to run as a module — 1.2.0 crashed on the entry itself, taking `createDataAttribute` down with it.
+
+Instead, import the stylesheet explicitly, once, wherever Visual Editing is enabled. With a bundler:
+
+```ts
+import '@sanity/visual-editing-standalone/styles.css'
+```
+
+Or, when loading from esm.sh, with a `<link>` tag:
+
+```html
+<link rel="stylesheet" href="https://esm.sh/@sanity/visual-editing-standalone@2/styles.css" />
+```
+
+Breaking changes:
+
+- The stylesheet export is renamed from `./style.css` to `./styles.css`, matching the `@sanity/ui@4` subpath it repackages, and is now a plain export (the Node no-op shim behind the former conditional export is gone — nothing imports the stylesheet at runtime anymore).
+- The stylesheet is no longer loaded automatically. Skipping it does not break the overlays, but the loading-spinner animation, screen-reader-only hiding, and label ellipsis rules go missing.

--- a/packages/visual-editing-standalone/README.md
+++ b/packages/visual-editing-standalone/README.md
@@ -14,15 +14,12 @@ styled-components, and Sanity UI—is compiled into package-internal ESM chunks.
 Installing it adds no production or peer dependencies, and the exact bundled
 versions are listed in the `inlinedDependencies` field of `package.json`.
 
-The overlays' static stylesheet ships as a conditional `./style.css` export —
-the same pattern `@sanity/ui` publishes — and the entry imports it
-self-referentially. Bundlers resolve the `browser`/`style` conditions to the
-stylesheet and load it automatically, like any CSS import. Node and other
-runtimes that cannot load `.css` files resolve the `node`/`default` conditions
-to a no-op JS shim instead of crashing, which also makes the import harmless
-during server-side module evaluation. Native ESM environments such as esm.sh
-resolve the shim too — add the stylesheet with a `<link>` tag as shown in
-[Load from esm.sh](#load-from-esmsh).
+The overlays' static stylesheet ships as the `./styles.css` export — named
+after the `@sanity/ui@4` subpath it repackages — and must be imported
+explicitly, as shown in [Import the stylesheet](#import-the-stylesheet). The
+published JS never references the stylesheet itself, so the package loads in
+every ESM runtime — bundlers, Node, esm.sh, import maps — without CSS-handling
+support.
 
 ## When to use this package
 
@@ -47,11 +44,26 @@ npm install @sanity/visual-editing-standalone
 
 No React packages need to be installed alongside it.
 
+## Import the stylesheet
+
+Import the overlays' static styles once, wherever Visual Editing is enabled:
+
+```ts
+import '@sanity/visual-editing-standalone/styles.css'
+```
+
+Bundlers handle the import like any other stylesheet. Without a bundler, add a
+`<link>` tag instead, as in the [esm.sh example](#load-from-esmsh) below.
+
+Skipping the stylesheet does not break the overlays, but the loading-spinner
+animation, screen-reader-only hiding, and label ellipsis rules go missing.
+
 ## Enable Visual Editing
 
 Only load Visual Editing in the browser while draft or preview mode is active:
 
 ```ts
+import '@sanity/visual-editing-standalone/styles.css'
 import {enableVisualEditing} from '@sanity/visual-editing-standalone'
 
 const disableVisualEditing = enableVisualEditing({
@@ -78,9 +90,8 @@ disableVisualEditing()
 
 The overlay renderer stays in a separate lazy chunk that only loads when
 `enableVisualEditing()` is called. Applications that only import
-`createDataAttribute` never load it, and any bundler can tree-shake the unused
-`enableVisualEditing` export away entirely — the entry's stylesheet import is
-the package's only side effect (declared in `sideEffects`).
+`createDataAttribute` never load it, and since the JS is side-effect free any
+bundler can tree-shake the unused `enableVisualEditing` export away entirely.
 
 The standalone options are framework-neutral. React-based custom overlay
 components and plugins remain available from `@sanity/visual-editing`.
@@ -103,17 +114,16 @@ const dataSanity = createDataAttribute({
 
 ## Load from esm.sh
 
-The package can be loaded directly as a browser module. esm.sh resolves the
-entry's stylesheet import to the no-op shim, so include the stylesheet itself
+The package can be loaded directly as a browser module — add the stylesheet
 with a `<link>` tag:
 
 ```html
-<link rel="stylesheet" href="https://esm.sh/@sanity/visual-editing-standalone@1/dist/style.css" />
+<link rel="stylesheet" href="https://esm.sh/@sanity/visual-editing-standalone@2/styles.css" />
 <script type="module">
   import {
     createDataAttribute,
     enableVisualEditing,
-  } from 'https://esm.sh/@sanity/visual-editing-standalone@1'
+  } from 'https://esm.sh/@sanity/visual-editing-standalone@2'
 
   document.querySelector('h1').dataset.sanity = createDataAttribute({
     baseUrl: 'https://example.sanity.studio',
@@ -125,14 +135,6 @@ with a `<link>` tag:
   enableVisualEditing()
 </script>
 ```
-
-Without the `<link>` the overlays still function, but the few static rules —
-the loading-spinner animation, screen-reader-only hiding, and label ellipsis —
-are missing.
-
-When serving the package yourself (import maps, no bundler), map the
-`@sanity/visual-editing-standalone/style.css` specifier to the shim at
-`dist/style-css.js` and add the same `<link>` to `dist/style.css`.
 
 Pin an exact package version in production when deterministic CDN output is
 required.

--- a/packages/visual-editing-standalone/package.json
+++ b/packages/visual-editing-standalone/package.json
@@ -31,13 +31,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./style.css": {
-      "types": "./dist/style-css.d.ts",
-      "browser": "./dist/style.css",
-      "style": "./dist/style.css",
-      "node": "./dist/style-css.js",
-      "default": "./dist/style-css.js"
-    },
+    "./styles.css": "./dist/styles.css",
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -105,13 +99,7 @@
   "publishConfig": {
     "exports": {
       ".": "./dist/index.js",
-      "./style.css": {
-        "types": "./dist/style-css.d.ts",
-        "browser": "./dist/style.css",
-        "style": "./dist/style.css",
-        "node": "./dist/style-css.js",
-        "default": "./dist/style-css.js"
-      },
+      "./styles.css": "./dist/styles.css",
       "./package.json": "./package.json"
     }
   }

--- a/packages/visual-editing-standalone/src/dist.test.ts
+++ b/packages/visual-editing-standalone/src/dist.test.ts
@@ -8,72 +8,49 @@ import pkg from '../package.json'
 
 /**
  * These tests assert the shape of the built package (`turbo.json` orders `build` before
- * `test`): the published dist is the entire product of this package, and 1.1.0 shipped a
- * regression no source-level test could catch — a relative `import './style.css'` statement
- * in the lazy overlay chunk, which crashes every native ESM consumer (esm.sh rewrites it to a
- * `.css.mjs` URL that redirects to the raw `text/css` file, which browsers refuse to run as a
- * module).
+ * `test`): the published dist is the entire product of this package, and both stylesheet
+ * wirings that shipped before broke native ESM consumers in ways no source-level test could
+ * catch. The relative `import './style.css'` of 1.1.0 and the self-referential
+ * `import '<pkg>/style.css'` of 1.2.0 were each externalized by esm.sh's build to a
+ * `style.css.mjs` URL that redirects to the raw `text/css` file, which browsers refuse to
+ * run as a module. The contract since 2.0.0: the published JS never references the
+ * stylesheet — consumers import the `./styles.css` export themselves.
  */
 const distDir = fileURLToPath(new URL('../dist', import.meta.url))
 
-/** Matches relative stylesheet imports (static or dynamic), in minified output too. */
-const relativeCssImport = /(?:\bimport\b|\bfrom\b)\s*\(?\s*['"]\.\.?\/[^'"]*\.css['"]/
-
-/**
- * The self-referential import `cssNodeCompatPlugin` prepends to the entry: resolved through
- * the conditional `./style.css` export, so every runtime gets a loadable module (stylesheet
- * for bundlers, the no-op shim for Node and esm.sh).
- */
-const selfReferentialCssImport = /import\s*['"]@sanity\/visual-editing-standalone\/style\.css['"]/
-
-/** The conditional CSS export pattern (`exports.nodeCompat`), like `@sanity/ui` publishes. */
-const conditionalCssExport = {
-  types: './dist/style-css.d.ts',
-  browser: './dist/style.css',
-  style: './dist/style.css',
-  node: './dist/style-css.js',
-  default: './dist/style-css.js',
-}
+/** Matches any stylesheet import (static or dynamic, relative or bare), minified too. */
+const cssImport = /(?:\bimport\b|\bfrom\b)\s*\(?\s*['"][^'"]*\.css['"]/
 
 function readDistChunks(): {fileName: string; code: string}[] {
   expect(existsSync(distDir), 'dist/ is missing — run `pnpm build` first').toBe(true)
   return readdirSync(distDir)
-    .filter((fileName) => fileName.endsWith('.js') && !fileName.endsWith('style-css.js'))
+    .filter((fileName) => fileName.endsWith('.js'))
     .map((fileName) => ({fileName, code: readFileSync(join(distDir, fileName), 'utf8')}))
 }
 
-test('ships no relative stylesheet imports in the dist JS', () => {
-  for (const {fileName, code} of readDistChunks()) {
-    expect(
-      relativeCssImport.test(code),
-      `${fileName} must not import a stylesheet by relative path`,
-    ).toBe(false)
+test('ships no stylesheet imports in the dist JS', () => {
+  const chunks = readDistChunks()
+  expect(chunks.length).toBeGreaterThan(0)
+  for (const {fileName, code} of chunks) {
+    expect(cssImport.test(code), `${fileName} must not import a stylesheet`).toBe(false)
   }
 })
 
-test('imports the stylesheet self-referentially from the entry only', () => {
-  const chunks = readDistChunks()
-  const entry = chunks.find(({fileName}) => fileName === 'index.js')
-  const importers = chunks.filter(({code}) => selfReferentialCssImport.test(code))
+test('emits the stylesheet behind the plain ./styles.css export', () => {
+  const styleSheet = join(distDir, 'styles.css')
+  expect(existsSync(styleSheet), 'dist/styles.css must exist').toBe(true)
+  expect(readFileSync(styleSheet, 'utf8')).toContain('{')
 
-  expect(entry, 'dist/index.js must exist').toBeDefined()
-  expect(
-    selfReferentialCssImport.test(entry?.code ?? ''),
-    'the entry must import the stylesheet through the conditional ./style.css export',
-  ).toBe(true)
-  expect(
-    importers.map(({fileName}) => fileName),
-    'only the entry carries the stylesheet import',
-  ).toEqual(['index.js'])
+  expect(pkg.exports['./styles.css']).toBe('./dist/styles.css')
+  expect(pkg.publishConfig.exports['./styles.css']).toBe('./dist/styles.css')
 })
 
-test('emits the stylesheet, its no-op shim, and the conditional export', () => {
-  const styleSheet = join(distDir, 'style.css')
-  expect(existsSync(styleSheet), 'dist/style.css must exist').toBe(true)
-  expect(readFileSync(styleSheet, 'utf8')).toContain('{')
-  expect(existsSync(join(distDir, 'style-css.js')), 'dist/style-css.js must exist').toBe(true)
-  expect(existsSync(join(distDir, 'style-css.d.ts')), 'dist/style-css.d.ts must exist').toBe(true)
+test('ships neither the removed ./style.css export nor its Node shim', () => {
+  expect(pkg.exports).not.toHaveProperty('./style.css')
+  expect(pkg.publishConfig.exports).not.toHaveProperty('./style.css')
 
-  expect(pkg.exports['./style.css']).toEqual(conditionalCssExport)
-  expect(pkg.publishConfig.exports['./style.css']).toEqual(conditionalCssExport)
+  const files = readdirSync(distDir)
+  expect(files).not.toContain('style.css')
+  expect(files).not.toContain('style-css.js')
+  expect(files).not.toContain('style-css.d.ts')
 })

--- a/packages/visual-editing-standalone/src/index.test.ts
+++ b/packages/visual-editing-standalone/src/index.test.ts
@@ -10,14 +10,14 @@ test('exposes only the standalone runtime API', () => {
 })
 
 test('exposes only the root entry point plus its stylesheet, and no runtime dependencies', () => {
-  // `@sanity/ui@4` ships static styles as a stylesheet, extracted into a package-internal
-  // `./style.css` conditional export that the entry imports self-referentially — see the
-  // `css` option in `tsdown.config.ts` and the shape assertions in `dist.test.ts`.
-  expect(Object.keys(pkg.exports).sort()).toEqual(['.', './package.json', './style.css'])
+  // `@sanity/ui@4` ships static styles as a stylesheet, extracted into the `./styles.css`
+  // export that consumers must import themselves — see the `css` option in
+  // `tsdown.config.ts` and the shape assertions in `dist.test.ts`.
+  expect(Object.keys(pkg.exports).sort()).toEqual(['.', './package.json', './styles.css'])
   expect(Object.keys(pkg.publishConfig.exports).sort()).toEqual([
     '.',
     './package.json',
-    './style.css',
+    './styles.css',
   ])
   expect(pkg).not.toHaveProperty('dependencies')
   expect(pkg).not.toHaveProperty('peerDependencies')

--- a/packages/visual-editing-standalone/tsdown.config.ts
+++ b/packages/visual-editing-standalone/tsdown.config.ts
@@ -35,29 +35,25 @@ export default mergeConfig(
       onlyImport: [],
     },
     // `@sanity/ui@4` ships its static styles as `@sanity/ui/styles.css`, which the bundled
-    // `@sanity/visual-editing` overlays import. Extract it into `dist/style.css` behind the
-    // conditional `./style.css` export (`exports.nodeCompat` with a no-op JS shim for
-    // runtimes that cannot load `.css` files), and prepend the self-referential
-    // `import "@sanity/visual-editing-standalone/style.css"` to the entry (`inject`) — the
-    // same conditional-export pattern `@sanity/ui` itself publishes. This keeps every
-    // consumer working without an external `@sanity/ui` dependency:
+    // `@sanity/visual-editing` overlays import. Extract it into `dist/styles.css` behind a
+    // plain `./styles.css` export — named after the `@sanity/ui` subpath it repackages —
+    // that consumers load themselves: with a bundler
+    // (`import '@sanity/visual-editing-standalone/styles.css'`) or a `<link>` tag, as
+    // documented in the README.
     //
-    // - bundlers resolve the `browser`/`style` conditions to the stylesheet and load it
-    //   automatically, like any CSS import;
-    // - Node (SSR module evaluation) resolves the `node`/`default` conditions to the shim
-    //   instead of crashing on a `.css` file;
-    // - esm.sh externalizes the import into a URL that resolves to the shim as well
-    //   (verified: `esm.sh/@sanity/ui@4.0.2/styles.css?target=es2022` 301s to the
-    //   `styles-css.js` shim), so native ESM consumers never execute `text/css` — they add
-    //   the stylesheet with a `<link>` tag as documented in the README.
-    //
-    // Passing `css` here (rather than through `mergeConfig` below) is load-bearing: only the
-    // `defineConfig` option wires up `cssNodeCompatPlugin`. The raw `@tsdown/css` `inject`
-    // emits a relative `import './style.css'` statement instead, which crashes every native
-    // ESM consumer as soon as the lazy overlay chunk loads — esm.sh rewrites it to a
-    // `.css.mjs` URL that redirects to the raw `text/css` file, which browsers refuse to run
-    // as a module (the 1.1.0 regression).
+    // The published JS must never reference the stylesheet, which is why `inject` stays off.
+    // Both spellings of an injected import break native ESM consumers on esm.sh as soon as
+    // the importing chunk loads: the relative `import './style.css'` of 1.1.0 and the
+    // self-referential `import '<pkg>/style.css'` of 1.2.0 (`exports.nodeCompat`) are each
+    // externalized by esm.sh's build to a `style.css.mjs` URL that redirects to the raw
+    // `text/css` file, which browsers refuse to run as a module. 1.2.0 was the worse of the
+    // two — the import sat in the entry, so even `import {createDataAttribute}` crashed.
+    // And since nothing references the stylesheet anymore, the export needs no Node shim
+    // (`exports.nodeCompat`) either — a plain string export is enough.
     css: {
+      exports: true,
+      fileName: 'styles.css',
+      inject: false,
       minify: true,
     },
   }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Both automatic stylesheet wirings shipped so far break native ESM consumers on esm.sh, because esm.sh's build externalizes any stylesheet import in the JS — relative or self-referential — to a `style.css.mjs` URL that 301-redirects to the raw `text/css` file, which browsers refuse to execute as a module:

- **1.1.0** (relative `import './style.css'` in the lazy overlay chunk): `enableVisualEditing()` crashed when the chunk loaded.
- **1.2.0** (`exports.nodeCompat` + self-referential `import '@sanity/visual-editing-standalone/style.css'`, from [#3618](https://github.com/sanity-io/visual-editing/pull/3618)): worse — esm.sh rewrites the entry's self-referential import to `./style.css.mjs` (verified: the published `1.2.0/es2022/visual-editing-standalone.mjs` contains it, and `1.2.0/es2022/style.css.mjs` 301s to raw CSS), so the **entry itself** crashes, taking `createDataAttribute` down with it. The shim resolution that works for dependency imports (`@sanity/visual-editing` → `@sanity/ui/styles.css` resolves to the `styles-css.js` shim) does not apply to esm.sh's self-referential rewrite path.

## Fix (breaking)

The published JS no longer references the stylesheet at all — there is nothing left for esm.sh (or any runtime) to mishandle. Consumers import the styles explicitly, once:

```ts
import '@sanity/visual-editing-standalone/styles.css'
```

or, from esm.sh:

```html
<link rel="stylesheet" href="https://esm.sh/@sanity/visual-editing-standalone@2/styles.css" />
```

(The plain-string CSS export subpath on esm.sh 301s to the raw stylesheet served as `text/css` — verified against the published 1.1.0 — which is exactly right for a `<link>` and only wrong for a module import, which no longer exists.)

Breaking changes:

- `./style.css` → **`./styles.css`** (matching the `@sanity/ui@4` subpath it repackages), now a plain export — the conditional export and its Node no-op shim are gone since nothing imports the stylesheet at runtime.
- The stylesheet is no longer loaded automatically. Skipping it doesn't break the overlays; the loading-spinner animation, screen-reader-only hiding, and label ellipsis rules go missing.

Implementation is just the `css` option: `{exports: true, fileName: 'styles.css', inject: false, minify: true}` — no inject, no nodeCompat, no custom plugins. The README documents the required import and the simpler esm.sh snippet.

## Verification

- Dist regression tests updated: **zero** stylesheet imports anywhere in the dist JS, `dist/styles.css` emitted behind the plain export, no `style.css`/`style-css.js`/`style-css.d.ts` remnants.
- Browser-tested over plain static native ESM (no bundler, no import map): with the `<link>` → overlays mount, lazy chunk loads, static styles apply; without the `<link>` → no module errors of any kind, overlays mount, styles absent as documented.
- `pnpm build` (publint clean), `pnpm test`, `pnpm lint` pass; knip has no standalone-related findings.

Supersedes the approach from [#3618](https://github.com/sanity-io/visual-editing/pull/3618) (shipped in 1.2.0). Add the `trigger: preview` label to publish a pkg.pr.new snapshot for a real end-to-end check via `esm.sh/pr/…` before release.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5a962b4-1083-46b2-b1bd-62038ead150a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5a962b4-1083-46b2-b1bd-62038ead150a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

