### PR TITLE
docs(visual-editing-standalone): make README easier to scan

### DIFF
--- a/packages/visual-editing-standalone/README.md
+++ b/packages/visual-editing-standalone/README.md
@@ -16,7 +16,10 @@ applications.
 npm install @sanity/visual-editing-standalone
 ```
 
-You do not need to install React.
+> [!TIP]
+> Does your application use React? Use
+> [`@sanity/visual-editing`](../visual-editing/README.md) instead. It also
+> supports custom overlay components and plugins.
 
 ### 2. Enable Visual Editing
 
@@ -84,11 +87,3 @@ const dataSanity = createDataAttribute({
   path: 'mainImage',
 }).toString()
 ```
-
-## React applications
-
-Use [`@sanity/visual-editing`](../visual-editing/README.md) instead. This
-standalone package includes its own copy of React.
-
-Use `@sanity/visual-editing` also if you need custom overlay components or
-plugins.

--- a/packages/visual-editing-standalone/README.md
+++ b/packages/visual-editing-standalone/README.md
@@ -1,76 +1,47 @@
 # `@sanity/visual-editing-standalone`
 
-Use this package to add Sanity Visual Editing to applications that do not use
-React.
+Add Sanity Visual Editing to Vue, Nuxt, Svelte, Astro, or plain JavaScript
+applications.
 
-The package has one JavaScript entry point:
+> [!IMPORTANT]
+> Import `@sanity/visual-editing-standalone/styles.css` wherever you enable
+> Visual Editing. The overlays need these styles for accessibility, labels,
+> and loading indicators.
 
-```ts
-import {createDataAttribute, enableVisualEditing} from '@sanity/visual-editing-standalone'
-```
+## Quick start
 
-The package includes all of its runtime code: the internal React renderer,
-React DOM, styled-components, and Sanity UI. The package has no dependencies
-and no peer dependencies. The `inlinedDependencies` field in `package.json`
-shows the version of each included dependency.
+### 1. Install
 
-The package also has one stylesheet, which you must import. See
-[Import the stylesheet](#import-the-stylesheet).
-
-## When to use this package
-
-Use this package with Vue, Nuxt, Svelte, Astro, plain JavaScript, or another
-environment that can load ES modules.
-
-Do not use this package in a React application. The package includes its own
-copy of React, and a React application would then have two copies. In a React
-application, use [`@sanity/visual-editing`](../visual-editing/README.md).
-
-The word "standalone" refers to this distribution of the package. It is not
-related to the `standalone` value from the Visual Editing environment APIs.
-
-## Install the package
-
-```sh
+```bash
 npm install @sanity/visual-editing-standalone
 ```
 
-You do not have to install React.
+You do not need to install React.
 
-## Import the stylesheet
+### 2. Enable Visual Editing
 
-The package does not load its stylesheet automatically. Import the stylesheet
-one time, where you enable Visual Editing:
-
-```ts
-import '@sanity/visual-editing-standalone/styles.css'
-```
-
-A bundler loads this import as a usual stylesheet. If you do not use a
-bundler, add a `<link>` tag. See [Load from esm.sh](#load-from-esmsh).
-
-The overlays operate without the stylesheet, but these defects occur:
-
-- The loading spinner does not rotate.
-- Text for screen readers becomes visible.
-- Long labels do not show an ellipsis.
-
-## Enable Visual Editing
-
-Enable Visual Editing only in the browser, and only while draft or preview
-mode is active:
+Import the stylesheet and call `enableVisualEditing()` in the browser. Do this
+only while draft or preview mode is active.
 
 ```ts
 import '@sanity/visual-editing-standalone/styles.css'
 import {enableVisualEditing} from '@sanity/visual-editing-standalone'
 
+enableVisualEditing()
+```
+
+`enableVisualEditing()` returns a cleanup function. Call it when preview mode
+stops or the page unloads.
+
+## Use a client-side router
+
+Pass a history adapter if your application controls navigation:
+
+```ts
 const disableVisualEditing = enableVisualEditing({
   history: {
     subscribe: (navigate) => {
-      const onPopState = () => {
-        navigate({type: 'pop', url: location.href})
-      }
-
+      const onPopState = () => navigate({type: 'pop', url: location.href})
       addEventListener('popstate', onPopState)
       return () => removeEventListener('popstate', onPopState)
     },
@@ -81,23 +52,27 @@ const disableVisualEditing = enableVisualEditing({
     },
   },
 })
-
-// Call this when preview mode stops or the page unloads.
-disableVisualEditing()
 ```
 
-The overlay renderer is in a different chunk. The package loads that chunk
-only when you call `enableVisualEditing()`. If your application imports only
-`createDataAttribute`, the chunk does not load. A bundler can also remove the
-unused `enableVisualEditing` code.
+## Use esm.sh
 
-The options are the same for all frameworks. If you need custom overlay
-components or plugins, use `@sanity/visual-editing`.
+Add the stylesheet with a `<link>` tag. Then load the JavaScript module.
+
+```html
+<link rel="stylesheet" href="https://esm.sh/@sanity/visual-editing-standalone@2/styles.css" />
+<script type="module">
+  import {enableVisualEditing} from 'https://esm.sh/@sanity/visual-editing-standalone@2'
+
+  enableVisualEditing()
+</script>
+```
+
+Use an exact version in production to keep the CDN output stable.
 
 ## Create data attributes
 
-Use `createDataAttribute` for values that cannot contain stega encoding.
-Examples are images, numbers, and booleans:
+Use `createDataAttribute` for values that cannot contain stega encoding, such
+as images, numbers, and booleans:
 
 ```ts
 import {createDataAttribute} from '@sanity/visual-editing-standalone'
@@ -110,29 +85,10 @@ const dataSanity = createDataAttribute({
 }).toString()
 ```
 
-## Load from esm.sh
+## React applications
 
-You can load the package directly as a browser module. Add the stylesheet with
-a `<link>` tag:
+Use [`@sanity/visual-editing`](../visual-editing/README.md) instead. This
+standalone package includes its own copy of React.
 
-```html
-<link rel="stylesheet" href="https://esm.sh/@sanity/visual-editing-standalone@2/styles.css" />
-<script type="module">
-  import {
-    createDataAttribute,
-    enableVisualEditing,
-  } from 'https://esm.sh/@sanity/visual-editing-standalone@2'
-
-  document.querySelector('h1').dataset.sanity = createDataAttribute({
-    baseUrl: 'https://example.sanity.studio',
-    id: 'post-1',
-    type: 'post',
-    path: 'title',
-  }).toString()
-
-  enableVisualEditing()
-</script>
-```
-
-In production, use an exact package version. Then the CDN output does not
-change.
+Use `@sanity/visual-editing` also if you need custom overlay components or
+plugins.

--- a/packages/visual-editing-standalone/README.md
+++ b/packages/visual-editing-standalone/README.md
@@ -15,6 +15,12 @@ when one is available. A framework integration can also configure preview
 mode, data loading, and live updates.
 
 - **React:** Use [`@sanity/visual-editing`](../visual-editing/README.md).
+- **Next.js App Router:** Use
+  [`next-sanity`](https://www.sanity.io/docs/visual-editing/visual-editing-with-next-js-app-router).
+- **Next.js Pages Router:** Use
+  [`@sanity/visual-editing/next-pages-router`](https://www.sanity.io/docs/visual-editing/visual-editing-with-next-js-pages-router).
+- **Astro:** Use
+  [`@sanity/astro`](https://www.sanity.io/docs/visual-editing/astro-visual-editing).
 - **SvelteKit:** Use
   [`@sanity/sveltekit`](https://www.sanity.io/docs/visual-editing/visual-editing-with-sveltekit).
 - **Nuxt:** Use

--- a/packages/visual-editing-standalone/README.md
+++ b/packages/visual-editing-standalone/README.md
@@ -1,12 +1,27 @@
 # `@sanity/visual-editing-standalone`
 
-Add Sanity Visual Editing to Vue, Nuxt, Svelte, Astro, or plain JavaScript
-applications.
+Add click-to-edit overlays to a non-React application that does not have a
+framework integration.
 
 > [!IMPORTANT]
 > Import `@sanity/visual-editing-standalone/styles.css` wherever you enable
 > Visual Editing. The overlays need these styles for accessibility, labels,
 > and loading indicators.
+
+## Choose the right integration
+
+Use a [framework-specific guide](https://www.sanity.io/docs/visual-editing/introduction-to-visual-editing#framework-quickstarts)
+when one is available. A framework integration can also configure preview
+mode, data loading, and live updates.
+
+- **React:** Use [`@sanity/visual-editing`](../visual-editing/README.md).
+- **SvelteKit:** Use
+  [`@sanity/sveltekit`](https://www.sanity.io/docs/visual-editing/visual-editing-with-sveltekit).
+- **Nuxt:** Use
+  [`@nuxtjs/sanity`](https://www.sanity.io/docs/visual-editing/visual-editing-with-nuxt).
+
+Use this standalone package when your application does not use React and no
+framework integration handles Visual Editing for you.
 
 ## Quick start
 
@@ -15,11 +30,6 @@ applications.
 ```bash
 npm install @sanity/visual-editing-standalone
 ```
-
-> [!TIP]
-> Does your application use React? Use
-> [`@sanity/visual-editing`](../visual-editing/README.md) instead. It also
-> supports custom overlay components and plugins.
 
 ### 2. Enable Visual Editing
 

--- a/packages/visual-editing-standalone/README.md
+++ b/packages/visual-editing-standalone/README.md
@@ -1,66 +1,64 @@
 # `@sanity/visual-editing-standalone`
 
-Self-contained, ESM-only Visual Editing for applications that do not otherwise
-use React.
+Use this package to add Sanity Visual Editing to applications that do not use
+React.
 
-The entire API is a single entry point:
+The package has one JavaScript entry point:
 
 ```ts
 import {createDataAttribute, enableVisualEditing} from '@sanity/visual-editing-standalone'
 ```
 
-All runtime code—including the internal React renderer, React DOM,
-styled-components, and Sanity UI—is compiled into package-internal ESM chunks.
-Installing it adds no production or peer dependencies, and the exact bundled
-versions are listed in the `inlinedDependencies` field of `package.json`.
+The package includes all of its runtime code: the internal React renderer,
+React DOM, styled-components, and Sanity UI. The package has no dependencies
+and no peer dependencies. The `inlinedDependencies` field in `package.json`
+shows the version of each included dependency.
 
-The overlays' static stylesheet ships as the `./styles.css` export — named
-after the `@sanity/ui@4` subpath it repackages — and must be imported
-explicitly, as shown in [Import the stylesheet](#import-the-stylesheet). The
-published JS never references the stylesheet itself, so the package loads in
-every ESM runtime — bundlers, Node, esm.sh, import maps — without CSS-handling
-support.
+The package also has one stylesheet, which you must import. See
+[Import the stylesheet](#import-the-stylesheet).
 
 ## When to use this package
 
-Use this package with Vue, Nuxt, Svelte, Astro, vanilla JavaScript, or another
-ESM-native environment where installing and bundling the React dependency graph
-is undesirable.
+Use this package with Vue, Nuxt, Svelte, Astro, plain JavaScript, or another
+environment that can load ES modules.
 
-React applications should use
-[`@sanity/visual-editing`](../visual-editing/README.md) instead. This package
-embeds its own React runtime, so using it in a React application would ship a
-second copy.
+Do not use this package in a React application. The package includes its own
+copy of React, and a React application would then have two copies. In a React
+application, use [`@sanity/visual-editing`](../visual-editing/README.md).
 
-The word "standalone" describes this package's self-contained distribution. It
-is unrelated to the `standalone` value reported by Visual Editing environment
-APIs.
+The word "standalone" refers to this distribution of the package. It is not
+related to the `standalone` value from the Visual Editing environment APIs.
 
-## Install
+## Install the package
 
 ```sh
 npm install @sanity/visual-editing-standalone
 ```
 
-No React packages need to be installed alongside it.
+You do not have to install React.
 
 ## Import the stylesheet
 
-Import the overlays' static styles once, wherever Visual Editing is enabled:
+The package does not load its stylesheet automatically. Import the stylesheet
+one time, where you enable Visual Editing:
 
 ```ts
 import '@sanity/visual-editing-standalone/styles.css'
 ```
 
-Bundlers handle the import like any other stylesheet. Without a bundler, add a
-`<link>` tag instead, as in the [esm.sh example](#load-from-esmsh) below.
+A bundler loads this import as a usual stylesheet. If you do not use a
+bundler, add a `<link>` tag. See [Load from esm.sh](#load-from-esmsh).
 
-Skipping the stylesheet does not break the overlays, but the loading-spinner
-animation, screen-reader-only hiding, and label ellipsis rules go missing.
+The overlays operate without the stylesheet, but these defects occur:
+
+- The loading spinner does not rotate.
+- Text for screen readers becomes visible.
+- Long labels do not show an ellipsis.
 
 ## Enable Visual Editing
 
-Only load Visual Editing in the browser while draft or preview mode is active:
+Enable Visual Editing only in the browser, and only while draft or preview
+mode is active:
 
 ```ts
 import '@sanity/visual-editing-standalone/styles.css'
@@ -84,22 +82,22 @@ const disableVisualEditing = enableVisualEditing({
   },
 })
 
-// Call this when preview mode is disabled or the page is torn down.
+// Call this when preview mode stops or the page unloads.
 disableVisualEditing()
 ```
 
-The overlay renderer stays in a separate lazy chunk that only loads when
-`enableVisualEditing()` is called. Applications that only import
-`createDataAttribute` never load it, and since the JS is side-effect free any
-bundler can tree-shake the unused `enableVisualEditing` export away entirely.
+The overlay renderer is in a different chunk. The package loads that chunk
+only when you call `enableVisualEditing()`. If your application imports only
+`createDataAttribute`, the chunk does not load. A bundler can also remove the
+unused `enableVisualEditing` code.
 
-The standalone options are framework-neutral. React-based custom overlay
-components and plugins remain available from `@sanity/visual-editing`.
+The options are the same for all frameworks. If you need custom overlay
+components or plugins, use `@sanity/visual-editing`.
 
 ## Create data attributes
 
-Use `createDataAttribute` for values that cannot carry stega encoding, such as
-images, numbers, and booleans:
+Use `createDataAttribute` for values that cannot contain stega encoding.
+Examples are images, numbers, and booleans:
 
 ```ts
 import {createDataAttribute} from '@sanity/visual-editing-standalone'
@@ -114,8 +112,8 @@ const dataSanity = createDataAttribute({
 
 ## Load from esm.sh
 
-The package can be loaded directly as a browser module — add the stylesheet
-with a `<link>` tag:
+You can load the package directly as a browser module. Add the stylesheet with
+a `<link>` tag:
 
 ```html
 <link rel="stylesheet" href="https://esm.sh/@sanity/visual-editing-standalone@2/styles.css" />
@@ -136,5 +134,5 @@ with a `<link>` tag:
 </script>
 ```
 
-Pin an exact package version in production when deterministic CDN output is
-required.
+In production, use an exact package version. Then the CDN output does not
+change.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reworks the standalone README for fast scanning and lower cognitive load:

- leads with a clear package-selection decision: use a framework integration first when one exists;
- lists the recommended paths for React, Next.js App Router (`next-sanity`), Next.js Pages Router (`@sanity/visual-editing/next-pages-router`), Astro (`@sanity/astro`), SvelteKit (`@sanity/sveltekit`), and Nuxt (`@nuxtjs/sanity`), with links to their current Visual Editing guides;
- positions this standalone package as the fallback for non-React applications without a batteries-included Visual Editing integration;
- follows with a two-step quick start (install, enable);
- keeps the required stylesheet in one compact `IMPORTANT` callout and in the copyable quick-start snippet;
- moves router setup, esm.sh usage, and data attributes into short task-based sections;
- removes repeated package, dependency, stylesheet, and implementation explanations;
- simplifies the esm.sh example to the minimum working setup.

The required stylesheet import, cleanup behavior, router adapter, `createDataAttribute`, and exact `@2` esm.sh URLs remain documented.

Docs-only follow-up to [#3627](https://github.com/sanity-io/visual-editing/pull/3627); no changeset.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5a962b4-1083-46b2-b1bd-62038ead150a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5a962b4-1083-46b2-b1bd-62038ead150a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

