### PR TITLE
fix(visual-editing-standalone): type the styles.css export

### DIFF
--- a/.changeset/standalone-styles-css-types.md
+++ b/.changeset/standalone-styles-css-types.md
@@ -1,0 +1,5 @@
+---
+'@sanity/visual-editing-standalone': patch
+---
+
+Ship TypeScript types for the `./styles.css` export so consumers can `import '@sanity/visual-editing-standalone/styles.css'` without a local `declare module`. The runtime export stays the stylesheet (`default` still points at `dist/styles.css`) so esm.sh `<link>` tags keep resolving to `text/css`.

--- a/packages/visual-editing-standalone/package.json
+++ b/packages/visual-editing-standalone/package.json
@@ -31,7 +31,10 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./styles.css": "./dist/styles.css",
+    "./styles.css": {
+      "types": "./dist/styles.css.d.ts",
+      "default": "./dist/styles.css"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -99,7 +102,10 @@
   "publishConfig": {
     "exports": {
       ".": "./dist/index.js",
-      "./styles.css": "./dist/styles.css",
+      "./styles.css": {
+        "types": "./dist/styles.css.d.ts",
+        "default": "./dist/styles.css"
+      },
       "./package.json": "./package.json"
     }
   }

--- a/packages/visual-editing-standalone/src/dist.test.ts
+++ b/packages/visual-editing-standalone/src/dist.test.ts
@@ -14,7 +14,7 @@ import pkg from '../package.json'
  * `import '<pkg>/style.css'` of 1.2.0 were each externalized by esm.sh's build to a
  * `style.css.mjs` URL that redirects to the raw `text/css` file, which browsers refuse to
  * run as a module. The contract since 2.0.0: the published JS never references the
- * stylesheet — consumers import the `./styles.css` export themselves.
+ * stylesheet — consumers import the typed `./styles.css` export themselves.
  */
 const distDir = fileURLToPath(new URL('../dist', import.meta.url))
 
@@ -36,16 +36,27 @@ test('ships no stylesheet imports in the dist JS', () => {
   }
 })
 
-test('emits the stylesheet behind the plain ./styles.css export', () => {
+test('emits the stylesheet behind a typed ./styles.css export', () => {
   const styleSheet = join(distDir, 'styles.css')
   expect(existsSync(styleSheet), 'dist/styles.css must exist').toBe(true)
   expect(readFileSync(styleSheet, 'utf8')).toContain('{')
 
-  expect(pkg.exports['./styles.css']).toBe('./dist/styles.css')
-  expect(pkg.publishConfig.exports['./styles.css']).toBe('./dist/styles.css')
+  const types = join(distDir, 'styles.css.d.ts')
+  expect(existsSync(types), 'dist/styles.css.d.ts must exist').toBe(true)
+  expect(readFileSync(types, 'utf8')).toContain('export {}')
+
+  // `default` stays the stylesheet so esm.sh `<link href="…/styles.css">` 301s to
+  // `text/css`. `types` is what makes `import '<pkg>/styles.css'` type-check under
+  // TypeScript 6 `noUncheckedSideEffectImports` without a consumer `declare module`.
+  const stylesCssExport = {
+    types: './dist/styles.css.d.ts',
+    default: './dist/styles.css',
+  }
+  expect(pkg.exports['./styles.css']).toEqual(stylesCssExport)
+  expect(pkg.publishConfig.exports['./styles.css']).toEqual(stylesCssExport)
 })
 
-test('ships neither the removed ./style.css export nor its Node shim', () => {
+test('ships neither the removed ./style.css export nor a Node CSS shim', () => {
   expect(pkg.exports).not.toHaveProperty('./style.css')
   expect(pkg.publishConfig.exports).not.toHaveProperty('./style.css')
 
@@ -53,4 +64,6 @@ test('ships neither the removed ./style.css export nor its Node shim', () => {
   expect(files).not.toContain('style.css')
   expect(files).not.toContain('style-css.js')
   expect(files).not.toContain('style-css.d.ts')
+  expect(files).not.toContain('styles-css.js')
+  expect(files).not.toContain('styles-css.d.ts')
 })

--- a/packages/visual-editing-standalone/src/index.test.ts
+++ b/packages/visual-editing-standalone/src/index.test.ts
@@ -10,9 +10,9 @@ test('exposes only the standalone runtime API', () => {
 })
 
 test('exposes only the root entry point plus its stylesheet, and no runtime dependencies', () => {
-  // `@sanity/ui@4` ships static styles as a stylesheet, extracted into the `./styles.css`
-  // export that consumers must import themselves — see the `css` option in
-  // `tsdown.config.ts` and the shape assertions in `dist.test.ts`.
+  // `@sanity/ui@4` ships static styles as a stylesheet, extracted into the typed
+  // `./styles.css` export that consumers must import themselves — see the `css`
+  // option in `tsdown.config.ts` and the shape assertions in `dist.test.ts`.
   expect(Object.keys(pkg.exports).sort()).toEqual(['.', './package.json', './styles.css'])
   expect(Object.keys(pkg.publishConfig.exports).sort()).toEqual([
     '.',
@@ -37,6 +37,10 @@ test('preserves the source package implementations and types', () => {
   expectTypeOf<
     NonNullable<Parameters<typeof standalone.enableVisualEditing>[0]>['onVariantChange']
   >().toEqualTypeOf<((variant: string | undefined) => void) | undefined>()
+})
+
+test('types the stylesheet as a side-effect module', () => {
+  expectTypeOf<typeof import('@sanity/visual-editing-standalone/styles.css')>().toEqualTypeOf<{}>()
 })
 
 test('creates data attributes through the standalone entry point', () => {

--- a/packages/visual-editing-standalone/src/styles.css.d.ts
+++ b/packages/visual-editing-standalone/src/styles.css.d.ts
@@ -1,0 +1,3 @@
+// Type declarations for the `./styles.css` side-effect import.
+// oxlint-disable-next-line unicorn/require-module-specifiers -- empty module for a CSS side-effect import
+export {}

--- a/packages/visual-editing-standalone/tsdown.config.ts
+++ b/packages/visual-editing-standalone/tsdown.config.ts
@@ -128,22 +128,9 @@ export default mergeConfig(
         'styled',
       ],
     },
-    plugins: [
-      {
-        name: 'css-export-types',
-        generateBundle(_outputOptions, bundle) {
-          const hasStylesheet = Object.values(bundle).some(
-            (file) => file.type === 'asset' && file.fileName === 'styles.css',
-          )
-          if (!hasStylesheet) return
-          this.emitFile({
-            type: 'asset',
-            fileName: 'styles.css.d.ts',
-            source: '// Type declarations for the `./styles.css` side-effect import.\nexport {}\n',
-          })
-        },
-      },
-    ],
+    // Copied into dist after the Rolldown pass and before publint. generateBundle is too
+    // early: the CSS asset is not in the bundle yet when this config's plugins run.
+    copy: ['src/styles.css.d.ts'],
     exports: {
       customExports(exports) {
         return insertStylesCssExport(exports)

--- a/packages/visual-editing-standalone/tsdown.config.ts
+++ b/packages/visual-editing-standalone/tsdown.config.ts
@@ -1,6 +1,38 @@
 import {defineConfig} from '@sanity/tsdown-config'
 import {mergeConfig, type UserConfig} from 'tsdown'
 
+/**
+ * `./styles.css` stays a CSS file at runtime (`default` → the stylesheet) so esm.sh
+ * `<link rel="stylesheet" href="…/styles.css">` still 301s to `text/css`. A `types`
+ * condition is required on top: TypeScript 6 `noUncheckedSideEffectImports` otherwise
+ * forces every consumer to `declare module '@sanity/visual-editing-standalone/styles.css'`.
+ *
+ * `{nodeCompat: true}` is the wrong tool — it points `default` at a JS shim, and esm.sh
+ * follows `default` (see `@sanity/ui/styles.css` → `styles-css.js`).
+ */
+const stylesCssExport = {
+  types: './dist/styles.css.d.ts',
+  default: './dist/styles.css',
+} as const
+
+/** Place `./styles.css` before `./package.json`, matching tsdown-config's `insertCssExport`. */
+function insertStylesCssExport(exports: Record<string, unknown>): Record<string, unknown> {
+  const next: Record<string, unknown> = {}
+  let inserted = false
+  for (const [key, value] of Object.entries(exports)) {
+    if (key === './styles.css') continue
+    if (key === './package.json' && !inserted) {
+      next['./styles.css'] = stylesCssExport
+      inserted = true
+    }
+    next[key] = value
+  }
+  if (!inserted) {
+    next['./styles.css'] = stylesCssExport
+  }
+  return next
+}
+
 export default mergeConfig(
   await defineConfig({
     tsconfig: 'tsconfig.dist.json',
@@ -36,8 +68,8 @@ export default mergeConfig(
     },
     // `@sanity/ui@4` ships its static styles as `@sanity/ui/styles.css`, which the bundled
     // `@sanity/visual-editing` overlays import. Extract it into `dist/styles.css` behind a
-    // plain `./styles.css` export — named after the `@sanity/ui` subpath it repackages —
-    // that consumers load themselves: with a bundler
+    // `./styles.css` export — named after the `@sanity/ui` subpath it repackages — that
+    // consumers load themselves: with a bundler
     // (`import '@sanity/visual-editing-standalone/styles.css'`) or a `<link>` tag, as
     // documented in the README.
     //
@@ -48,10 +80,13 @@ export default mergeConfig(
     // externalized by esm.sh's build to a `style.css.mjs` URL that redirects to the raw
     // `text/css` file, which browsers refuse to run as a module. 1.2.0 was the worse of the
     // two — the import sat in the entry, so even `import {createDataAttribute}` crashed.
-    // And since nothing references the stylesheet anymore, the export needs no Node shim
-    // (`exports.nodeCompat`) either — a plain string export is enough.
+    //
+    // `css.exports` stays off so we can declare the subpath ourselves: `types` → a
+    // side-effect `.d.ts`, `default` → the stylesheet. A plain string export has no types
+    // (Nuxt then needs `declare module`), and `exports.nodeCompat` would point `default`
+    // at a JS shim, which esm.sh serves for `<link>` tags.
     css: {
-      exports: true,
+      exports: false,
       fileName: 'styles.css',
       inject: false,
       minify: true,
@@ -92,6 +127,27 @@ export default mergeConfig(
         'memo',
         'styled',
       ],
+    },
+    plugins: [
+      {
+        name: 'css-export-types',
+        generateBundle(_outputOptions, bundle) {
+          const hasStylesheet = Object.values(bundle).some(
+            (file) => file.type === 'asset' && file.fileName === 'styles.css',
+          )
+          if (!hasStylesheet) return
+          this.emitFile({
+            type: 'asset',
+            fileName: 'styles.css.d.ts',
+            source: '// Type declarations for the `./styles.css` side-effect import.\nexport {}\n',
+          })
+        },
+      },
+    ],
+    exports: {
+      customExports(exports) {
+        return insertStylesCssExport(exports)
+      },
     },
     // Unlike a typical library, consumers download this package's bundled dependencies.
     // `true` enables the full Oxc pass — equivalent to `{compress, mangle, codegen: true}`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Consumers such as [`nuxt-modules/sanity#1530`](https://github.com/nuxt-modules/sanity/pull/1530) had to add:

```ts
declare module '@sanity/visual-editing-standalone/styles.css'
```

TypeScript 6 enables `noUncheckedSideEffectImports` by default (and `@sanity/tsconfig/strictest` turns it on), so `import '@sanity/visual-editing-standalone/styles.css'` fails unless the package ships types for that subpath.

## Change

Publish `./styles.css` as:

```json
{
  "types": "./dist/styles.css.d.ts",
  "default": "./dist/styles.css"
}
```

- `types` is a side-effect declaration (`export {}`), so consumers no longer need a local `declare module`.
- `default` stays the stylesheet. A Node shim (`exports.nodeCompat`) would make esm.sh serve JS for `<link rel="stylesheet" href="https://esm.sh/@sanity/visual-editing-standalone@2/styles.css">` — the same thing that happens today with `@sanity/ui/styles.css`.

The declaration is copied into `dist` after the Rolldown pass (and before publint). Emitting it from `generateBundle` is too early: the CSS asset is not in the bundle yet.

## Test plan

- [x] Package tests (`dist` contract + `typeof import('@sanity/visual-editing-standalone/styles.css')`)
- [x] `pnpm --filter @sanity/visual-editing-standalone build` (publint clean)
- [ ] Confirm the Nuxt module can drop `declare module '@sanity/visual-editing-standalone/styles.css'`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed2253cf-f52f-44ab-8708-5997e2093280?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed2253cf-f52f-44ab-8708-5997e2093280&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

