### PR TITLE
fix(visual-editing): keep styled-components peer on ^6.1

### DIFF
--- a/.changeset/styled-components-peer-6-1.md
+++ b/.changeset/styled-components-peer-6-1.md
@@ -1,0 +1,5 @@
+---
+'@sanity/visual-editing': patch
+---
+
+Restore the `styled-components` peer range to `^6.1` so consumers on 6.1.x stay compatible. The catalog/dev dependency remains on 6.5.x.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -52,6 +52,12 @@
       "rangeStrategy": "bump"
     },
     {
+      "description": "Keep styled-components peer range on ^6.1 for consumer compatibility",
+      "matchDepNames": ["styled-components"],
+      "matchDepTypes": ["peerDependencies"],
+      "rangeStrategy": "widen"
+    },
+    {
       "matchPackageNames": ["eslint-plugin-react-hooks"],
       "description": "Disable until 5.2 is out",
       "enabled": false

--- a/packages/visual-editing/package.json
+++ b/packages/visual-editing/package.json
@@ -168,7 +168,7 @@
     "react": "^19.2",
     "react-dom": "^19.2",
     "react-router": ">= 7",
-    "styled-components": "^6.5.2",
+    "styled-components": "^6.1",
     "svelte": ">= 4"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restores the published `styled-components` peer range on `@sanity/visual-editing` to `^6.1`. Renovate’s `rangeStrategy: bump` had narrowed it to `^6.5.2` (via #3616), which breaks consumers still on 6.1.x even though 6.5.x already satisfies `^6.1`.

The catalog/dev dependency stays on `^6.5.2`. A Renovate package rule now uses `widen` for the `styled-components` peer so this does not get bumped again.

## Changes
- `packages/visual-editing/package.json`: peer `styled-components` `^6.5.2` → `^6.1`
- `.github/renovate.json`: `rangeStrategy: "widen"` for `styled-components` peerDependencies
- changeset: patch for `@sanity/visual-editing`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27137fe8-6b74-4a97-b728-94eb7ba7d6da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27137fe8-6b74-4a97-b728-94eb7ba7d6da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

