### PR TITLE
fix(deps): widen allowed `@sanity/client` peer dep

### DIFF
--- a/.changeset/yummy-poets-yawn.md
+++ b/.changeset/yummy-poets-yawn.md
@@ -1,0 +1,8 @@
+---
+"@sanity/preview-url-secret": patch
+"@sanity/visual-editing-csm": patch
+"@sanity/visual-editing-types": patch
+"@sanity/visual-editing": patch
+---
+
+fix(deps): widen allowed `@sanity/client` peer dep

--- a/packages/preview-url-secret/package.json
+++ b/packages/preview-url-secret/package.json
@@ -90,7 +90,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@sanity/client": "^7.26.2"
+    "@sanity/client": "^7.26.2 || ^8.0.0"
   },
   "browserslist": "extends @sanity/browserslist-config",
   "engines": {

--- a/packages/visual-editing-csm/package.json
+++ b/packages/visual-editing-csm/package.json
@@ -55,7 +55,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@sanity/client": "^7.26.2"
+    "@sanity/client": "^7.26.2 || ^8.0.0"
   },
   "browserslist": "extends @sanity/browserslist-config",
   "engines": {

--- a/packages/visual-editing-types/package.json
+++ b/packages/visual-editing-types/package.json
@@ -50,7 +50,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@sanity/client": "^7.26.2",
+    "@sanity/client": "^7.26.2 || ^8.0.0",
     "@sanity/types": "*"
   },
   "peerDependenciesMeta": {

--- a/packages/visual-editing/package.json
+++ b/packages/visual-editing/package.json
@@ -163,7 +163,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@sanity/client": "^7.26.2",
+    "@sanity/client": "^7.26.2 || ^8.0.0",
     "@sveltejs/kit": ">= 2",
     "next": ">=16.0.0-0",
     "react": "^19.2",


### PR DESCRIPTION
Widens the peer dependency range to allow `@sanity/client@8`. Ideally we'd upgrade node baseline to v22.12 and used client v8 but I don't have time at the moment.