### PR TITLE
fix(visual-editing-csm): recover node data when stega href search params are unusable

### DIFF
--- a/.changeset/decode-edit-intent-fallback.md
+++ b/.changeset/decode-edit-intent-fallback.md
@@ -1,0 +1,5 @@
+---
+"@sanity/visual-editing-csm": patch
+---
+
+`decodeSanityNodeData` now recovers document metadata from the `/intent/edit/` segment of stega hrefs when the URL search params are unusable, e.g. when the configured `studioUrl` contains a query string or uses hash routing. Previously such hrefs decoded into a legacy node without an `id`, leaving the Presentation documents panel empty and making overlay clicks do nothing ([sanity-io/sanity#14454](https://github.com/sanity-io/sanity/issues/14454))

--- a/packages/visual-editing-csm/src/decodeSanityNodeData.test.ts
+++ b/packages/visual-editing-csm/src/decodeSanityNodeData.test.ts
@@ -1,4 +1,5 @@
-import {describe, expect, test} from 'vitest'
+import {createEditUrl} from '@sanity/client/csm'
+import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {decodeSanityString, decodeSanityNodeData} from './decodeSanityNodeData'
 
@@ -62,5 +63,105 @@ describe('decodeSanityNodeData', () => {
     ],
   ])('%j => %j', (input, output) => {
     expect(decodeSanityNodeData(input)).toEqual(output)
+  })
+})
+
+describe('decodeSanityNodeData with hrefs where the URL search params are unusable', () => {
+  const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  afterEach(() => {
+    consoleErrorSpy.mockClear()
+  })
+
+  test('recovers when the studio baseUrl contains a query string', () => {
+    // The `?` in the baseUrl swallows the `baseUrl` search param of the edit
+    // intent url, e.g. `https://example.com/studio?variant=abc/intent/edit/...`
+    const baseUrl = 'https://example.com/studio?variant=abc'
+    const href = createEditUrl({
+      baseUrl,
+      workspace: 'staging',
+      tool: 'presentation',
+      id: 'drafts.abc123',
+      type: 'guildVideo',
+      path: 'sections[_key=="xyz"].title',
+    })
+
+    expect(decodeSanityNodeData({origin: 'sanity.io', href})).toEqual({
+      baseUrl,
+      workspace: 'staging',
+      tool: 'presentation',
+      id: 'abc123',
+      type: 'guildVideo',
+      path: 'sections[_key=="xyz"].title',
+      perspective: 'drafts',
+    })
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  test('recovers when the studio baseUrl contains a query string and a hash', () => {
+    const baseUrl = 'https://example.com/studio?variant=abc#'
+    const href = createEditUrl({baseUrl, id: 'abc123', type: 'guildVideo', path: 'title'})
+
+    expect(decodeSanityNodeData({origin: 'sanity.io', href})).toEqual({
+      baseUrl,
+      id: 'abc123',
+      type: 'guildVideo',
+      path: 'title',
+      perspective: 'published',
+    })
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  test('recovers when the studio baseUrl uses hash routing', () => {
+    // The edit intent url ends up entirely inside the URL hash, e.g.
+    // `/studio#/intent/edit/...`, leaving the URL search params empty
+    const baseUrl = '/studio#'
+    const href = createEditUrl({baseUrl, id: 'drafts.abc123', type: 'guildVideo', path: 'title'})
+
+    expect(decodeSanityNodeData({origin: 'sanity.io', href})).toEqual({
+      baseUrl,
+      id: 'abc123',
+      type: 'guildVideo',
+      path: 'title',
+      perspective: 'drafts',
+    })
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  test.each([
+    [
+      `/studio/intent/edit/mode=presentation;id=abc123;type=guildVideo;path=${encodeURIComponent('sections[_key=="xyz"].title')};tool=presentation`,
+      {
+        baseUrl: '/studio',
+        id: 'abc123',
+        type: 'guildVideo',
+        path: 'sections[_key=="xyz"].title',
+        tool: 'presentation',
+        perspective: 'drafts',
+      },
+    ],
+    [
+      '/intent/edit/mode=presentation;id=abc123;type=guildVideo;path=title',
+      {
+        baseUrl: '/',
+        id: 'abc123',
+        type: 'guildVideo',
+        path: 'title',
+        perspective: 'drafts',
+      },
+    ],
+  ])('recovers from the router params when the search segment is absent (%s)', (href, output) => {
+    expect(decodeSanityNodeData({origin: 'sanity.io', href})).toEqual(output)
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  test('keeps legacy behaviour for hrefs without an edit intent', () => {
+    const node = {origin: 'sanity.io', href: '/some/page'}
+    expect(decodeSanityNodeData(node)).toEqual(node)
+  })
+
+  test('keeps legacy behaviour and logs when recovery fails', () => {
+    const node = {origin: 'sanity.io', href: '/some/page?foo=bar'}
+    expect(decodeSanityNodeData(node)).toEqual(node)
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to parse sanity node', expect.anything())
   })
 })

--- a/packages/visual-editing-csm/src/decodeSanityNodeData.ts
+++ b/packages/visual-editing-csm/src/decodeSanityNodeData.ts
@@ -65,6 +65,48 @@ export function decodeSanityString(str: string): SanityNode | undefined {
   return data
 }
 
+const EDIT_INTENT_MARKER = '/intent/edit/'
+
+/**
+ * Recovers sanity node data from the edit intent segment of an href, i.e.
+ * `/intent/edit/<router params>?<search params>`. `new URL(href)` cannot be
+ * trusted to locate the search params of the edit intent: if the studio
+ * baseUrl itself contains a query string or a hash, the edit intent search
+ * params end up inside another search param or inside the URL hash. The raw
+ * href still contains the intact edit intent, so parse it from the string
+ * instead.
+ */
+function decodeEditIntentSegment(href: string): SanityNode | undefined {
+  const markerIndex = href.indexOf(EDIT_INTENT_MARKER)
+  if (markerIndex === -1) return undefined
+  try {
+    const segment = href.slice(markerIndex + EDIT_INTENT_MARKER.length)
+    const searchIndex = segment.indexOf('?')
+    const routerParams = searchIndex === -1 ? segment : segment.slice(0, searchIndex)
+    const data: Record<string, string> = {}
+    for (const routerParam of routerParams.split(';')) {
+      const separatorIndex = routerParam.indexOf('=')
+      if (separatorIndex === -1) continue
+      const key = routerParam.slice(0, separatorIndex)
+      if (key === 'id' || key === 'type' || key === 'path' || key === 'tool') {
+        data[key] = decodeURIComponent(routerParam.slice(separatorIndex + 1))
+      }
+    }
+    if (searchIndex !== -1) {
+      // Search params take precedence: unlike the router params they also
+      // carry `baseUrl`, `workspace`, `perspective`, `projectId` and `dataset`
+      Object.assign(data, Object.fromEntries(new URLSearchParams(segment.slice(searchIndex + 1))))
+    }
+    // Everything before the edit intent is the studio baseUrl, possibly
+    // followed by a workspace name
+    data['baseUrl'] ??= href.slice(0, markerIndex) || '/'
+    const sanityNode = safeParse(sanityNodeSchema, data)
+    return sanityNode.success ? sanityNode.output : undefined
+  } catch {
+    return undefined
+  }
+}
+
 /**
  * Transforms stringified JSON into sanity node data
  * @param str - JSON sanity data
@@ -78,16 +120,21 @@ function decodeSanityObject(
   }
   const sanityLegacyNode = safeParse(sanityLegacyNodeSchema, data)
   if (sanityLegacyNode.success) {
+    const {href} = sanityLegacyNode.output
     try {
       const url = new URL(
-        sanityLegacyNode.output.href,
+        href,
         typeof document === 'undefined' ? 'https://example.com' : location.origin,
       )
       if (url.searchParams.size > 0) {
         return parse(sanityNodeSchema, Object.fromEntries(url.searchParams.entries()))
       }
-      return sanityLegacyNode.output
+      return decodeEditIntentSegment(href) ?? sanityLegacyNode.output
     } catch (err) {
+      const recoveredSanityNode = decodeEditIntentSegment(href)
+      if (recoveredSanityNode) {
+        return recoveredSanityNode
+      }
       console.error('Failed to parse sanity node', err)
       return sanityLegacyNode.output
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the visual-editing side of [sanity-io/sanity#14454](https://github.com/sanity-io/sanity/issues/14454) (empty Presentation documents panel plus dead overlay clicks for some documents while sibling types on the same page work).

### Root cause

`createEditUrl` in `@sanity/client` joins the studio `baseUrl` and the edit intent as plain strings, so a `studioUrl` containing a query string (e.g. `https://example.com/studio?variant=abc`) produces a stega href whose first `?` does not belong to the edit intent:

```
https://example.com/studio?variant=abc/intent/edit/mode=presentation;id=abc123;type=guildVideo;path=title?baseUrl=…&id=abc123&type=guildVideo&path=title
```

`decodeSanityNodeData` parses that href with `new URL()`, which attributes everything after the first `?` to the URL search. The always-first `baseUrl` search param gets swallowed into the studioUrl's own first param (with hash routing, e.g. `/studio#`, the entire edit intent lands in the URL hash instead), valibot parsing fails, and the decoder falls back to a legacy `{origin, href}` node without an `id`. Overlays still render, but:

- `orderSanityNodesByPosition` drops id-less nodes from the `visual-editing/documents` message, so the Presentation documents panel is empty, and
- Presentation ignores `visual-editing/focus` payloads without an `id`, so clicking the overlay does nothing.

The only diagnostic is a `console.error('Failed to parse sanity node')` in the preview iframe.

### Fix

The raw href still contains the intact edit intent, so when the URL search params are unusable, `decodeSanityNodeData` now locates `/intent/edit/` in the string and parses the segment's own search params, falling back to the router params (`id`, `type`, `path`, `tool`) and deriving `baseUrl` from the href prefix when the search segment is absent. Hrefs without an edit intent keep the current legacy behaviour, and the `console.error` diagnostic remains when recovery fails.

The first commit adds the failing tests, the second makes them pass. Hrefs in the tests are generated with `createEditUrl` so they stay faithful to the producer.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a40bab4f-0388-4b07-aae3-e46e154660be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a40bab4f-0388-4b07-aae3-e46e154660be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

