### PR TITLE
Pin release workflow npm to 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,11 @@ jobs:
           check-latest: true
           node-version: lts/*
       - name: Update npm to use trusted publishing (OIDC)
-        run: npm install -g npm@latest
+        # Pin npm 11: npm 12 wraps `info --json` in an array; @changesets/cli 3.0.1's
+        # pnpm parser does not unwrap it (changesets/changesets#2274), so
+        # getUnpublishedPackages crashes on `response.info.versions.includes`.
+        # Trusted publishing only needs npm >= 11.5.1.
+        run: npm install -g npm@11
       - run: pnpm install
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Release on main crashes because `.github/workflows/release.yml` installs `npm@latest`, which is now npm 12. `pnpm info --json` then returns an array-wrapped packument. `@changesets/cli@3.0.1` unwraps that in its npm parser but not in `packages/cli/src/lib/pnpm.ts` (`parseInfoResult`). `getUnpublishedPackages` then does `response.info.versions.includes(...)` on undefined.

Failing run: https://github.com/sanity-io/visual-editing/actions/runs/33517457076/job/99887973291

Upstream is still `@changesets/cli@3.0.1` (changesets/changesets#2274). Trusted publishing only needs npm >= 11.5.1, so this pins the install to `npm@11`.

No changeset: workflow-only, CI does not require one.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e628025-e3a1-4423-956a-cc368a39015e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e628025-e3a1-4423-956a-cc368a39015e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

